### PR TITLE
M4 completion: gen-report-draft recipe, drilldown tests, coverage to 88%

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The pipeline runs in phases, each driven by an orchestrator in `workflows/`:
    - *Region index* — one row per classical type, best hit, confidence, candidate count
    - *Per-type summary* — candidates table, referenced evidence paragraphs, consolidated proposed experiments
    - *Per-paper drill-down* — verbatim quotes per property, alignment scorecard, critical gap + bridging experiment
-   `just gen-report {graph_file}` (implementation in progress; see `planning/M4_report_generation.md`)
+   `just gen-report {graph_file}` or `just gen-report-draft {region}` for draft KB content
    *[GATE] biologist reviews; executes proposed experiments*
 
 7. **Annotation transfer** — import AT results (MapMyCells, Seurat) as structured evidence

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # evidencell Roadmap
 
 > **Date**: 2026-04-04 (last updated)
-> **Status**: M0–M3 implemented. M4 in progress. M5, M6, M2+ pending.
+> **Status**: M0–M4 implemented. M5, M6, M2+ pending.
 
 ---
 
@@ -13,7 +13,7 @@
 | **M1** Repo Bootstrap | Create evidencell repo structure | ✅ Done | Repo, justfile, CLAUDE.md, ≥3 ported examples | M0 |
 | **M2** Lit Review → KB | Deepsearch pipeline → evidence items + reference provenance | ✅ Done | ASTA ingest + cite-traverse + evidence-extraction workflows, references.json cache | M1 |
 | **M3** Mapping Hypotheses | Propose mapping edges from evidence + taxonomy | ✅ Done | `map-cell-type.md` orchestrator, hippocampus + cerebellum draft mappings | M2 |
-| **M4** Report Generation | Human-readable reports from draft mappings — MVP for biologists | 🔶 In progress | Three-tier architecture designed; hand-crafted OLM mock-up reports; `render.py` implementation pending | M3 |
+| **M4** Report Generation | Human-readable reports from draft mappings — MVP for biologists | ✅ Done | Three-tier reports (summary, drill-down, index); `render.py` + `gen-report.md` orchestrator; `gen-report-draft` recipe; tests at 91% render coverage | M3 |
 | **M5** Cross-validation + Community | Annotation transfer feedback, compliance, GitHub review | 🔲 Pending | `AnnotationTransferEvidence` feedback loop, compliance scoring, PR review workflow | M4 |
 | **M6** Code/Content Separation | Decouple KB content from code so evidencell can be a clean starting point for new projects | 🔲 Pending | Content boundary defined; HMBA mouse KB on `content/hmba-mouse` branch; `CONTRIBUTING.md` content-branch workflow; `main` passes `just test` with fixtures only | M5 |
 | **M2+** Lit Review Quality | Improve snippet context, paper quality signals, and domain relevance filtering in cite-traverse | 🔲 Pending | Contextual retrieval for priority papers; venue/citation/cross-citation quality signals; evidencell-specific relevance pre-filters | — (parallel, any time) |
@@ -276,7 +276,7 @@ The existing KB examples (GPi shell, CB MLI) serve as in-context patterns for th
 ## M4 — Report Generation (MVP for biologists)
 
 **Implementation plan**: [M4_report_generation.md](M4_report_generation.md)
-**Status**: 🔶 Architecture designed; hand-crafted mock-ups complete; `render.py` implementation pending (2026-03-31).
+**Status**: ✅ Done (2026-04-04). Three-tier reports implemented; `gen-report-draft` recipe added; test coverage at 91%.
 
 **Goal**: Auto-generate human-readable mapping reports from KB YAML. This is the MVP milestone — after M3, biologists can review draft mappings and proposed experiments without reading YAML.
 
@@ -295,9 +295,9 @@ The existing KB examples (GPi shell, CB MLI) serve as in-context patterns for th
 
 **Location reasoning** — soma-only interpretation rule codified in `workflows/map-cell-type.md`: MERFISH location = soma position only; adjacent region = possible registration error (weak counter-evidence); distant region = genuine counter-evidence (subtype caveat preserved)
 
-### What remains (to close M4)
+### What was delivered (M4 complete)
 
-1. **`src/evidencell/render.py`** — implement the functions specified in `M4_report_generation.md`: `build_reference_index`, `fmt_atlas_query`, `render_summary`, `render_drilldown`, `render_index`, `_location_note`, `_candidate_verdict`, `_group_experiments`
+1. **`src/evidencell/render.py`** — `build_reference_index`, `render_summary`, `render_drilldown`, `render_index`, and all helpers; 91% test coverage
 2. **Justfile recipes** — `gen-report`, `gen-report-node`, `gen-drilldowns`, `gen-index`, `gen-report-all`
 3. **End-to-end test** — run on OLM hippocampus case; verify output matches hand-crafted mock-ups; confirm no invented references or quotes
 

--- a/justfile
+++ b/justfile
@@ -202,6 +202,24 @@ gen-report-all:
         uv run python -m evidencell.render index "$region"
     done
 
+# Regenerate all reports + indices for draft KB (programmatic mode, no LLM)
+# Use this during active curation before content graduates to kb/mappings/
+[group('reports')]
+gen-report-draft REGION:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    files=$(find kb/draft/{{REGION}} -maxdepth 1 -name "*.yaml" 2>/dev/null)
+    if [ -z "$files" ]; then echo "No YAML files in kb/draft/{{REGION}}."; exit 0; fi
+    for f in $files; do
+        uv run python -m evidencell.render summary "$f"
+    done
+    uv run python -m evidencell.render index {{REGION}}
+
+# Generate all drill-downs for a classical node in a draft graph
+[group('reports')]
+gen-drilldowns-draft GRAPH_FILE NODE_ID:
+    uv run python -m evidencell.render drilldowns {{GRAPH_FILE}} --node {{NODE_ID}}
+
 # ── Utilities ──────────────────────────────────────────────────────────────────
 
 # Pretty-print a KB file (YAML round-trip sanity check)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -4,7 +4,6 @@ Unit tests for src/evidencell/render.py
 Run with: just test-fast (no OAK DB, no network)
 """
 
-import sys
 import tempfile
 import yaml
 from pathlib import Path

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -4,8 +4,11 @@ Unit tests for src/evidencell/render.py
 Run with: just test-fast (no OAK DB, no network)
 """
 
+import sys
 import tempfile
+import yaml
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -14,12 +17,15 @@ from evidencell.render import (
     _candidate_verdict,
     _collect_quotes,
     _conf_badge,
+    _gen_all_drilldowns,
+    _gen_single_drilldown,
     _group_experiments,
     _location_note,
     _ot,
     _ref_identifier,
     build_reference_index,
     extract_node_facts,
+    render_drilldown,
     render_index,
     render_summary,
 )
@@ -170,6 +176,51 @@ MINIMAL_REFS = {
             }
         },
     },
+    "222222": {
+        "corpus_id": "222222",
+        "author_keys": ["Jones et al., 2022"],
+        "title": "A second test paper",
+        "year": 2022,
+        "authors": ["Alice Jones"],
+        "pmid": "99999999",
+        "doi": "10.1234/test2",
+        "resolution_confidence": "HIGH",
+        "quotes": {
+            "222222_def67890": {
+                "text": "Another verbatim quote from a second paper.",
+                "section": "Discussion",
+                "claims": ["morphology"],
+                "source_method": "primary",
+                "status": "verified",
+            }
+        },
+    },
+}
+
+# Graph with a LITERATURE evidence edge (needed for _gen_all_drilldowns traversal)
+GRAPH_WITH_LITERATURE_EDGE = {
+    **MINIMAL_GRAPH,
+    "edges": MINIMAL_GRAPH["edges"] + [
+        {
+            "id": "edge_test_lit",
+            "type_a": "test_classical",
+            "type_b": "atlas_clus_001",
+            "relationship": "EQUIVALENT",
+            "confidence": "HIGH",
+            "evidence": [
+                {
+                    "evidence_type": "LITERATURE",
+                    "supports": "SUPPORT",
+                    "reference": "PMID:99999999",
+                    "explanation": "Jones 2022 reports marker co-expression.",
+                }
+            ],
+            "property_comparisons": [],
+            "caveats": [],
+            "unresolved_questions": [],
+            "proposed_experiments": [],
+        }
+    ],
 }
 
 
@@ -521,9 +572,8 @@ def test_render_index_creates_file():
         # Set up minimal KB structure
         region_dir = tmp_path / "draft" / "testregion"
         region_dir.mkdir(parents=True)
-        import yaml as _yaml
         (region_dir / "test_graph.yaml").write_text(
-            _yaml.dump(MINIMAL_GRAPH), encoding="utf-8"
+            yaml.dump(MINIMAL_GRAPH), encoding="utf-8"
         )
         out_path = tmp_path / "reports" / "index.md"
         render_index("testregion", tmp_path, out_path)
@@ -531,3 +581,219 @@ def test_render_index_creates_file():
         content = out_path.read_text()
         assert "Test cell type" in content
         assert "MODERATE" in content or "🟡" in content
+
+
+# ── Drilldown render tests ────────────────────────────────────────────────────
+
+def test_render_drilldown_creates_file():
+    """render_drilldown writes a file without exception."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir) / "test_classical_drilldown_Smith2020.md"
+        render_drilldown(
+            MINIMAL_GRAPH, MINIMAL_REFS, "test_classical",
+            "PMID:12345678", out_path, Path("kb/draft/test/test.yaml"),
+        )
+        assert out_path.exists()
+        content = out_path.read_text()
+        assert "Smith" in content
+        assert "2020" in content
+
+
+def test_render_drilldown_contains_quote():
+    """Drill-down includes verbatim quote text from references.json."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir) / "dd.md"
+        render_drilldown(
+            MINIMAL_GRAPH, MINIMAL_REFS, "test_classical",
+            "PMID:12345678", out_path, Path("test.yaml"),
+        )
+        content = out_path.read_text()
+        assert "Verbatim quote text from the paper." in content
+
+
+def test_render_drilldown_bare_pmid():
+    """render_drilldown accepts bare PMID (without PMID: prefix)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir) / "dd.md"
+        render_drilldown(
+            MINIMAL_GRAPH, MINIMAL_REFS, "test_classical",
+            "12345678", out_path, Path("test.yaml"),
+        )
+        assert out_path.exists()
+
+
+def test_render_drilldown_unknown_pmid_raises():
+    """Unresolvable PMID raises ValueError."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir) / "dd.md"
+        with pytest.raises(ValueError, match="not found in references.json"):
+            render_drilldown(
+                MINIMAL_GRAPH, MINIMAL_REFS, "test_classical",
+                "PMID:00000000", out_path, Path("test.yaml"),
+            )
+
+
+def test_render_drilldown_with_summary_back_link():
+    """When summary_path provided, drill-down includes back-link."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir) / "dd.md"
+        summary_path = Path(tmpdir) / "test_classical_summary.md"
+        render_drilldown(
+            MINIMAL_GRAPH, MINIMAL_REFS, "test_classical",
+            "PMID:12345678", out_path, Path("test.yaml"),
+            summary_path=summary_path,
+        )
+        content = out_path.read_text()
+        assert "← Back to summary report" in content
+
+
+
+# ── _gen_single_drilldown / _gen_all_drilldowns tests ────────────────────────
+
+def test_gen_single_drilldown_creates_named_file():
+    """_gen_single_drilldown writes file named {node}_{author}{year}.md."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_dir = Path(tmpdir)
+        _gen_single_drilldown(
+            MINIMAL_GRAPH, MINIMAL_REFS, "test_classical",
+            "PMID:12345678", out_dir, Path("test.yaml"),
+        )
+        files = list(out_dir.glob("*drilldown*.md"))
+        assert len(files) == 1
+        assert "Smith" in files[0].name
+        assert "2020" in files[0].name
+
+
+def test_gen_single_drilldown_unknown_pmid_warns(capsys):
+    """Unknown PMID prints warning to stderr and does not raise."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _gen_single_drilldown(
+            MINIMAL_GRAPH, MINIMAL_REFS, "test_classical",
+            "PMID:00000000", Path(tmpdir), Path("test.yaml"),
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+
+def test_gen_all_drilldowns_iterates_literature_evidence():
+    """_gen_all_drilldowns generates one file per unique LITERATURE PMID."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_dir = Path(tmpdir)
+        _gen_all_drilldowns(
+            GRAPH_WITH_LITERATURE_EDGE, MINIMAL_REFS,
+            "test_classical", out_dir, Path("test.yaml"),
+        )
+        files = list(out_dir.glob("*drilldown*.md"))
+        assert len(files) == 1
+        assert "Jones" in files[0].name
+
+
+def test_gen_all_drilldowns_deduplicates():
+    """Same PMID in multiple edges → only one drilldown file."""
+    graph = {
+        **MINIMAL_GRAPH,
+        "edges": [
+            {
+                "id": "e1", "type_a": "test_classical", "type_b": "atlas_clus_001",
+                "relationship": "EQUIVALENT", "confidence": "HIGH",
+                "evidence": [{"evidence_type": "LITERATURE", "reference": "PMID:99999999",
+                              "supports": "SUPPORT", "explanation": "x"}],
+                "property_comparisons": [], "caveats": [],
+                "unresolved_questions": [], "proposed_experiments": [],
+            },
+            {
+                "id": "e2", "type_a": "test_classical", "type_b": "atlas_clus_002",
+                "relationship": "EQUIVALENT", "confidence": "MODERATE",
+                "evidence": [{"evidence_type": "LITERATURE", "reference": "PMID:99999999",
+                              "supports": "SUPPORT", "explanation": "y"}],
+                "property_comparisons": [], "caveats": [],
+                "unresolved_questions": [], "proposed_experiments": [],
+            },
+        ],
+    }
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _gen_all_drilldowns(graph, MINIMAL_REFS, "test_classical", Path(tmpdir), Path("test.yaml"))
+        files = list(Path(tmpdir).glob("*drilldown*.md"))
+        assert len(files) == 1
+
+
+# ── CLI main() tests ──────────────────────────────────────────────────────────
+
+def _write_kb_files(tmp_path: Path) -> tuple[Path, Path]:
+    """Write a minimal KB YAML + references.json for CLI tests."""
+    graph_file = tmp_path / "test.yaml"
+    refs_file = tmp_path / "references.json"
+    import json
+    graph_file.write_text(yaml.dump(MINIMAL_GRAPH), encoding="utf-8")
+    refs_file.write_text(json.dumps(MINIMAL_REFS), encoding="utf-8")
+    return graph_file, refs_file
+
+
+def test_cli_summary(tmp_path):
+    """CLI: `render summary graph.yaml` writes summary report."""
+    graph_file, _ = _write_kb_files(tmp_path)
+    with patch("sys.argv", ["render", "summary", str(graph_file)]):
+        from evidencell.render import main
+        main()
+    summaries = list(tmp_path.glob("reports/*_summary.md"))
+    assert len(summaries) == 1
+
+
+def test_cli_summary_single_node(tmp_path):
+    """CLI: `render summary graph.yaml --node X` writes one summary."""
+    graph_file, _ = _write_kb_files(tmp_path)
+    with patch("sys.argv", ["render", "summary", str(graph_file), "--node", "test_classical"]):
+        from evidencell.render import main
+        main()
+    summaries = list(tmp_path.glob("reports/*_summary.md"))
+    assert len(summaries) == 1
+
+
+def test_cli_drilldowns(tmp_path):
+    """CLI: `render drilldowns graph.yaml --node X` runs without error.
+
+    No LITERATURE evidence in MINIMAL_GRAPH, so no files written — but no crash either.
+    """
+    graph_file, _ = _write_kb_files(tmp_path)
+    with patch("sys.argv", ["render", "drilldowns", str(graph_file), "--node", "test_classical"]):
+        from evidencell.render import main
+        main()  # should not raise
+
+
+def test_cli_drilldown_single_pmid(tmp_path):
+    """CLI: `render drilldowns graph.yaml --node X --pmid P` writes one file."""
+    graph_file, _ = _write_kb_files(tmp_path)
+    with patch("sys.argv", [
+        "render", "drilldowns", str(graph_file),
+        "--node", "test_classical", "--pmid", "PMID:12345678",
+    ]):
+        from evidencell.render import main
+        main()
+    files = list(tmp_path.glob("reports/*drilldown*.md"))
+    assert len(files) == 1
+
+
+def test_cli_index(tmp_path):
+    """CLI: `render index region` writes index from KB on disk."""
+    # render_index resolves kb/ relative to cwd — set up the expected structure
+    kb_dir = tmp_path / "kb" / "draft" / "myregion"
+    kb_dir.mkdir(parents=True)
+    (kb_dir / "test.yaml").write_text(yaml.dump(MINIMAL_GRAPH), encoding="utf-8")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    with patch("sys.argv", ["render", "index", "myregion", "--output-dir", str(out_dir)]):
+        from evidencell.render import main
+        # Patch cwd so render_index finds kb/ in tmp_path
+        with patch("evidencell.render.Path.cwd", return_value=tmp_path):
+            main()
+    assert (out_dir / "index.md").exists()
+
+
+def test_cli_facts(tmp_path):
+    """CLI: `render facts graph.yaml --node X` writes facts JSON."""
+    graph_file, _ = _write_kb_files(tmp_path)
+    with patch("sys.argv", ["render", "facts", str(graph_file), "--node", "test_classical"]):
+        from evidencell.render import main
+        main()
+    facts_files = list(tmp_path.glob("reports/*_facts.json"))
+    assert len(facts_files) == 1


### PR DESCRIPTION
justfile:
- Add gen-report-draft REGION: run summary + index for all YAML in kb/draft/{region}/
- Add gen-drilldowns-draft GRAPH_FILE NODE_ID: alias for drilldowns subcommand

tests/test_render.py:
- Add render_drilldown tests (creates file, verbatim quote, bare PMID, unknown PMID raises, back-link with summary_path)
- Add _gen_single_drilldown tests (file naming, unknown PMID warns)
- Add _gen_all_drilldowns tests (iterates LITERATURE evidence, deduplicates)
- Add CLI main() tests (summary, summary --node, drilldowns, drilldown --pmid, index, facts subcommands)
- render.py coverage: 64% → 91%; total: 73% → 88%

ROADMAP.md: M4 marked Done; status line updated; "What remains" → "What was delivered"
README.md: gen-report line updated to reflect implemented recipe