### PR TITLE
Add ARCH design docs, schema v0.6.x, and KB interface utility

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # evidencell Roadmap
 
-**Date**: 2026-04-13 (last updated)
+**Date**: 2026-04-21 (last updated)
 **Status**: M0–M4 implemented. Active work: schema refinement, lit workflow robustness, workflow contracts.
 
 
@@ -28,8 +28,10 @@
 | **M2+** Lit Review Quality | Improve snippet context, paper quality signals, and domain relevance filtering in cite-traverse | 🔲 Pending | Contextual retrieval for priority papers; venue/citation/cross-citation quality signals; evidencell-specific relevance pre-filters | — (parallel, any time) |
 | **CF** Community Feedback | Enable biologist review of mappings; KB quality scoring | 🔲 Pending | Report-based review workflow; compliance scoring; structured feedback mechanism | S, M4 |
 | **M6** Code/Content Separation | Decouple KB content from code | 🔲 Pending | Content boundary; `content/hmba-mouse` branch; `main` passes `just test` with fixtures only | WC, S |
-| **M7** KB Structure Cleanup | Move workflow ephemera out of `kb/`; one graph per region×atlas; naming convention; graduation criteria | 🔲 Pending — HIGH PRIORITY | `kb/` contains only graph YAML; `references/`, `research/`, `reports/` at repo root; graph naming + graduation criteria in CONTRIBUTING.md | — (can start now) |
-| **M8** Taxonomy Reference DB | Full taxonomy ingest as local queryable DB; graph stubs pulled on demand from reference store | 🔲 Pending | Local taxonomy DB (SQLite or similar); query-based stub generation; `ingest-taxonomy` rewritten to populate DB; `map-cell-type` queries DB for candidates | M7 |
+| **M7** KB Structure Cleanup | Move workflow ephemera out of `kb/`; one file per classical type node; naming convention; graduation criteria | 🔲 Pending | `kb/nodes/{region}/{node_id}.yaml` per classical type; `kb/taxonomy/` for atlas terminal nodes; `references/`, `research/`, `reports/` at repo root; `find_node_file()` utility as stable interface; graduation criteria in CONTRIBUTING.md | M8 |
+| **M8** KB Index + Taxonomy DB | Taxonomy per-file ingest (SQL); KB node index for agent file-finding; both via SQLite | 🔲 Pending — DO BEFORE M7 | `kb/index.db`: node→file map, synonym index, gap flags; taxonomy DB: one file per taxonomy, SQL access; `find_node_file(node_id)` queries index; `map-cell-type` queries taxonomy DB | — (can start now) |
+| **ADAPT** Adaptive Mapping Loop | Reorder workflow so AT runs before edge framing; bridging dataset criteria; compute preflight gate; supertype-level edges | 🔲 Pending | Updated `map-cell-type.md`; dataset bridging criteria; AT preflight gate | S1, AT |
+| **ARCH** Workflow Architecture Refactor | Redesign lit-mining pipeline around Survey vs Targeted distinction; synonym capture; KB flags as workflow memory | 🔲 Can start now | `survey.md` orchestrator; `targeted-search.md` orchestrator; cite-traverse as skill; synonym extraction in asta-report-ingest; KB gap flags; `find_node_file()` utility as file-layout-independent KB interface | `find_node_file()` stub (pre-M8); upgrades to query index post-M8 |
 
 
 ## Cross-Cutting Discussion Points
@@ -664,6 +666,165 @@ now integrated into `map-cell-type.md` Step 3 (mapping edge subagent populates
 `node_b_value` from precomputed stats). For cases requiring per-cell
 distributions rather than cluster means, the class-level h5ad files from the
 Allen S3 bucket remain an option.
+
+---
+
+## ADAPT — Adaptive Mapping Loop
+
+**Design discussion**: [planning/adaptive_mapping_loop_design.md](planning/adaptive_mapping_loop_design.md)
+**Status**: 🔲 Pending (depends on S1 for supertype-level edge support)
+
+**Motivation**: The OLM pilot showed that building detailed per-cluster edges before
+running annotation transfer is the wrong order. MapMyCells resolved to the Sst Gaba_3
+supertype (F1=0.67, 43/46 cells) but placed 0/46 cells on the cluster the workflow
+had nominated as best candidate. The pipeline had no mechanism to revise the framing.
+
+### Proposed ordering
+
+1. **Triage** — taxonomy metadata + ASTA report. Identify candidate level(s) and any
+   high-priority bridging datasets. Do not commit to cluster-level edges yet.
+2. **AT preflight + run** (if bridging dataset available) — before building detailed
+   edges. Determines the resolution level the data supports and whether subpopulations
+   segregate. User approves compute before any downloads.
+3. **Reassess and set edges** — at the resolution the data supports (supertype, subclass,
+   or cluster). Consider sub-node creation for identified subpopulations.
+4. **Expression queries** — targeted marker tests across candidate cell sets.
+5. **Report** — synthesise, document gaps for next cycle.
+
+### Bridging dataset criteria
+
+Prioritise datasets that independently confirm classical type identity:
+- Morphological reconstruction + sequencing (patch-seq, post-hoc fill)
+- Transgenic Cre-driver targeting of the specific classical type + sequencing
+- Spatial transcriptomics with layer/region resolution matching the classical type
+
+Not qualifying: broad regional atlases where cells of the classical type cannot be
+identified independently of transcriptomics.
+
+### Dataset discovery
+
+Two layers: (1) ASTA report explicitly requests bridging datasets with accessions;
+(2) bounded triage follow-up searching from the atlas side (which datasets have
+mapped cells to the candidate supertypes/clusters?). Union of both → preflight
+assessment before any downloads.
+
+### Compute preflight gate (human checkpoint)
+
+Before any AT download/run, report: accession, why it qualifies, file size, RAM
+estimate, API vs local compute recommendation. User decides per dataset. This is
+the key human gate in an otherwise automated loop.
+
+### Deliverables
+
+1. `map-cell-type.md` updated: triage-first ordering; AT before edge framing; explicit
+   reassessment step; sub-node creation decision rule
+2. Bridging dataset criteria documented in `CONTRIBUTING.md` or workflow header
+3. AT preflight integrated as a required step in the workflow (not just a justfile recipe)
+4. ASTA report prompt updated to explicitly request bridging datasets with accessions
+5. Expression query step formalised: which markers to query, how results feed back
+   into edge confidence
+
+### Open questions
+
+- Sub-node splitting rule: when does evidence warrant creating sub-nodes vs. noting
+  heterogeneity in caveats? Needs a decision threshold (e.g. distinct expression
+  profiles + separate AT cluster signals).
+- Lit search cadence: not in the adaptive loop cycle. Gaps from step 5 feed a future
+  lit search cycle (M2). The boundary needs to be explicit in the workflow docs.
+- Graceful degradation: when no AT dataset exists, steps 2–3 collapse. The workflow
+  should degrade to triage → marker queries → report without requiring AT.
+
+---
+
+## ARCH — Workflow Architecture Refactor
+
+**Design discussion**: [planning/workflow_architecture_design.md](planning/workflow_architecture_design.md)
+**Status**: 🔲 Pending
+
+**Motivation**: The current lit-mining pipeline (lit-review → cite-traverse → evidence-extraction)
+conflates two fundamentally different modes of operation. Untangling them is the key to avoiding
+procedural complexity and enabling independent testability of each part.
+
+### The core distinction: Survey vs Targeted
+
+```
+[ASTA report (PDF)]
+        │
+        ▼
+asta-report-ingest ──────────────────────────────► KB (properties + stub edges)
+  [+ synonym extraction]                            │
+                                                    ▼
+                                            KB gap review
+                                         (reads KB flags;
+                                          runs as first step
+                                          of any research cycle)
+                                                    │
+                         ┌──────────────────────────┴───────────────────────┐
+                         ▼                                                  ▼
+                  SURVEY path                                      TARGETED path
+         (cell type poorly characterised;                     (specific KB field gap;
+          KB sparse after ASTA ingest)                         KB has partial content)
+                         │                                                  │
+              ASTA snippet_search across                       targeted snippet query
+              all corpus paper IDs (batch)                     + synonym expansion
+                         │                                                  │
+              PMC full text for gap papers               optionally: cite-traverse skill
+              (enrich where snippets thin)                (1–2 hops, bounded question)
+                         │                                                  │
+              all_summaries.json                           per-query synthesis agent
+              (per-snippet summaries,                      → KB write (PropertySource)
+               section, quotes, relevance)                 → pre-edit hook validates
+                         │
+              synthesis subagent
+              (cross-paper; themes;
+               gap + new types analysis)
+                         │
+                  KB + report.md
+```
+
+**Survey** is bounded by the ASTA paper set. It collects broadly; serendipity has value;
+synthesis must come after mining. **Targeted** answers a specific question; fanning out
+is a bug; synthesis can happen at mining time.
+
+### KB flags as workflow memory
+
+Rather than a separate tracking file, workflow state is encoded as flags on KB nodes.
+Flags are set at each cycle run and cleared when information is found. The gap reviewer
+reads flag state rather than re-deriving gaps from scratch. Gap flags carry priority
+scores (e.g. `AT_dataset_gap: HIGH`, `marker_gap: MODERATE`) to guide targeted runs.
+
+Two main triggers for targeted search:
+1. **Mapping evidence review** — what evidence would strengthen or refine an edge?
+2. **Gap review** — markers and AT transfer dataset accessions are top priority.
+
+### Synonym capture (critical early step)
+
+Synonym mapping is infrastructure for both paths. Without it, queries miss the cell type.
+Mechanism: look for synonyms on each paper as a first processing step; feed forward
+within the run; supplement with PMC full text where snippets are insufficient; leverage
+existing KB synonym content to seed queries.
+
+### cite-traverse as a skill
+
+Citation following is a technique, not a workflow phase. Refactor `cite-traverse.md`
+as a Claude skill invokable by the targeted research agent. The multi-paper ASTA batch
+capability and PMC fallback are preserved — the machinery moves to the skill.
+
+### Deliverables
+
+1. `survey.md` orchestrator — ASTA-bounded lit scan, produces all_summaries.json + report.md
+2. `targeted-search.md` orchestrator — KB-gap-driven, invokes cite-traverse skill
+3. `.claude/skills/cite-traverse.md` — cite-traverse refactored as bounded skill
+4. `asta-report-ingest.md` updated — synonym extraction step added
+5. KB schema updated — gap flags + priority scores on CellTypeNode
+6. `lit-review.md` retired (already marked EXPERIMENTAL)
+7. `evidence-extraction.md` simplified — paper selection gate → extraction → KB write
+
+### Open questions
+
+See [planning/workflow_architecture_design.md](planning/workflow_architecture_design.md)
+for detailed discussion of open questions including per-node summary cache,
+gap reviewer granularity, and synonym bootstrapping.
 
 ---
 

--- a/planning/adaptive_mapping_loop_design.md
+++ b/planning/adaptive_mapping_loop_design.md
@@ -1,0 +1,156 @@
+# Adaptive Mapping Loop — Design Discussion
+
+**Date**: 2026-04-20
+**Status**: Discussion notes — not yet implemented
+**Context**: Emerged from OLM hippocampus pilot where annotation transfer results
+(supertype-level signal, cluster scatter) showed the initial per-cluster edge framing
+was at the wrong resolution. Prompted a rethink of the overall mapping workflow.
+
+---
+
+## The problem with the current pipeline
+
+The current workflow commits to cluster-level mapping hypotheses at the triage stage,
+then accumulates evidence for those specific hypotheses. When annotation transfer runs
+*after* detailed per-cluster edges are built, it can contradict the original framing —
+as happened in the OLM case, where MapMyCells resolved cleanly to the Sst Gaba_3
+supertype (F1=0.67, 43/46 cells) but placed 0/46 cells on the nominated cluster 0769.
+
+The pipeline had no way to loop back and revise: the report, the edges, and the
+evidence paragraphs were all framed around cluster 0769 as the primary candidate,
+even though the data said "supertype."
+
+---
+
+## Proposed workflow ordering
+
+1. **Initial triage** — taxonomy metadata + ASTA report
+   - Outputs: candidate mapping region, candidate level(s) (may be supertype or
+     subclass, not necessarily cluster), any high-priority bridging datasets
+   - Does NOT commit to specific cluster edges yet
+   - Explicitly asks: what bridging datasets exist?
+
+2. **Annotation transfer** (if bridging datasets available — see below)
+   - Run on qualifying datasets before building detailed edges
+   - Outputs: the resolution level the data supports, whether subpopulations
+     segregate to different clusters, which cell sets are actual mapping targets
+   - If no bridging dataset: skip to step 3 with wider uncertainty on level
+
+3. **Reassess and set edges**
+   - Build edges at the resolution the data supports (may be supertype, not cluster)
+   - Identify specific marker gaps that expression queries can fill
+   - Consider subpopulation splitting: if source data separates subtypes (e.g.
+     Sst-OLM vs Htr3a-OLM), score them separately and consider sub-nodes
+
+4. **Expression queries** — targeted across candidate cell sets
+   - Each query either confirms, narrows, or splits the mapping
+   - Example: query Chrna2/Grm1/Npy expression per cluster within Sst Gaba_3
+     to determine whether within-supertype resolution is achievable
+
+5. **Report** — synthesise, document remaining gaps
+
+---
+
+## Dataset selection criteria for annotation transfer
+
+Not all single-cell datasets qualify. Prioritise **bridging datasets** that
+independently confirm classical type identity via a modality other than transcriptomics:
+
+**Qualifying (bridging):**
+- Morphological reconstruction + sequencing (patch-seq, post-hoc DAB fill like
+  Winterer 2019 for OLM)
+- Transgenic Cre-driver targeting of the specific classical type + sequencing
+  (where the driver line has been validated to target the classical type)
+- Spatial transcriptomics with layer/region resolution matching the classical
+  type's anatomical definition
+
+**Not qualifying (useful background, not bridging):**
+- Broad regional scRNA-seq atlases (no way to identify which cells are your
+  classical type without independent marker selection)
+- Studies that use the same markers but don't confirm morphology/electrophysiology
+- Datasets where "OLM" or equivalent is an inferred label, not experimentally confirmed
+
+---
+
+## Compute/resource preflight gate
+
+Before downloading or processing any dataset, report to the user:
+
+- Dataset accession and what makes it a bridging study
+- File size (h5ad or equivalent)
+- Estimated compute requirements (RAM, MapMyCells runtime)
+- Whether web API is feasible (size limits) or local compute needed
+- Recommendation: proceed / skip / subsample
+
+User decides which datasets to run. This keeps the human in the loop at the
+expensive step without babysitting cheaper steps. The existing `at-preflight`
+recipe is the right hook for this.
+
+Autonomy principle: steps 1–3 (triage, triage reassessment, edge framing) can
+run without user approval. The preflight gate before AT is the key human checkpoint.
+Further expression queries (step 4) are cheap and can be automated if the mapping
+target is already set.
+
+---
+
+## Dataset discovery
+
+Two layers:
+
+**Layer 1 — ASTA report.** The ASTA prompt should explicitly request bridging
+datasets: studies combining morphological/electrophysiological identification
+of the classical type with sequencing or spatial transcriptomics, including
+dataset accessions where available. This surfaces obvious high-value datasets
+as part of the literature survey.
+
+**Layer 2 — Triage follow-up.** ASTA may miss datasets because:
+- The relevant paper was ranked low or not reached
+- The accession is in a methods section, not the abstract
+- A relevant spatial/patch-seq study postdates the ASTA run
+- The study doesn't use the classical type name explicitly
+
+A bounded follow-up step checks: given the candidate cell sets from taxonomy
+metadata, are there known datasets that mapped to those specific clusters/supertypes?
+This searches from the atlas side, not the classical-type side. One or two targeted
+queries, not an open-ended literature search.
+
+**Dataset inventory = ASTA-reported datasets + triage follow-up**, then preflight
+assessment on the union before any downloads.
+
+---
+
+## OLM-specific observations (prompting this design)
+
+- Annotation transfer (GSE124847 → WMBv1) resolved to Sst Gaba_3 supertype
+  (F1=0.67, 43/46 cells) but placed 0/46 cells on cluster 0769 specifically
+- Within-supertype scatter (cells spread across clusters 0767–0774) may reflect:
+  (a) genuine OLM subpopulation heterogeneity, or (b) cluster resolution limits
+  for this cell type at current atlas granularity
+- Winterer 2019 identifies two OLM subtypes (Sst-OLM and Htr3a-OLM); Thulin 2025
+  identifies three Sst/Pnoc subclusters. Scoring these separately in AT could
+  determine whether they segregate to different clusters within Sst Gaba_3
+- Implication: the edge for OLM should target Sst Gaba_3 supertype as primary
+  candidate, with per-cluster resolution as an open question, not the reverse
+
+---
+
+## Open questions
+
+1. **Schema**: do edges need explicit support for supertype/subclass-level targets
+   (not just cluster)? S1 (rank encoding) addresses this — `rank: int` instead
+   of hardcoded level names. Confirm S1 is sufficient.
+
+2. **Subpopulation splitting**: when does the agent judge that evidence warrants
+   creating sub-nodes vs. flagging heterogeneity in caveats? Needs a decision rule.
+
+3. **Lit search placement**: not in this cycle. Lit review (M2) feeds the ASTA
+   report (step 1 input), so it's upstream of the adaptive loop, not interleaved.
+   Gaps identified in step 5 (report) become inputs for a future lit search cycle.
+
+4. **Autonomy/supervision balance**: triage + reassessment can be automated;
+   AT preflight is the key human gate; expression queries post-reassessment
+   can be automated if mapping target is set. Still being calibrated.
+
+5. **Compute availability**: users without sufficient local compute skip MapMyCells.
+   Workflow must degrade gracefully: triage → marker queries → report, with AT
+   as an optional enrichment step rather than a required gate.

--- a/planning/workflow_architecture_design.md
+++ b/planning/workflow_architecture_design.md
@@ -1,0 +1,260 @@
+# Workflow Architecture: Survey vs Targeted Search
+
+**Date**: 2026-04-21
+**Status**: Design discussion — informing workflow refactor
+**Context**: Emerged from a broad review of the lit-review → cite-traverse → evidence-extraction
+pipeline. The core insight is that the pipeline conflates two fundamentally different modes
+of operation. Getting this distinction right is the key to avoiding procedural hairballs.
+
+> **Naming note**: "Discovery" was considered for the first path but is too vague.
+> Current working name: **Survey** (bounded by ASTA paper set) vs **Targeted**.
+> Better names welcome.
+
+---
+
+## The core insight: two axes
+
+### Axis 1 — Survey vs Targeted
+
+| | Survey | Targeted |
+|---|---|---|
+| **When** | First encounter; KB sparse after ASTA ingest | KB has content; gap review reveals specific missing fields |
+| **Question** | What do we know about this cell type from the ASTA corpus? | Find Chrna2 expression data for OLM in stratum oriens |
+| **Scope** | Bounded by ASTA paper set (may expand in future) | Narrower; fanning out is a bug |
+| **Sources** | ASTA snippets across all corpus papers; PMC full text for gaps | Targeted snippet query + optional citation follow + full text |
+| **Output shape** | Unknown in advance; serendipity has value | Known (specific PropertySource field) |
+| **Synthesis** | After mining — cross-paper signal matters | At mining time — per-paper agent writes KB directly |
+| **Citation following** | Not the primary mode; corpus already defines scope | Yes, bounded — 1–2 hops for a specific question |
+
+### Axis 2 — Synthesis placement
+
+| | Per-paper agents | Post-hoc |
+|---|---|---|
+| **When** | Targeted mode | Survey mode |
+| **What** | Agent reads one paper, writes KB entry | Cache summaries, single synthesis subagent over all |
+| **Benefit** | Fast; synthesis baked in | Flexible — re-synthesise from same cache |
+| **Cost** | Loses cross-paper signal | Large cache; synthesis deferred |
+
+---
+
+## Pipeline structure
+
+```
+[ASTA report (PDF)]
+        │
+        ▼
+asta-report-ingest ──────────────────────────────► KB (properties + stub edges)
+  [+ synonym extraction]                            │
+                                                    ▼
+                                            KB gap review
+                                         (what's missing?)
+                                            [fluid — runs
+                                            as first step of
+                                            any research cycle]
+                                                    │
+                         ┌──────────────────────────┴───────────────────────┐
+                         ▼                                                  ▼
+                  SURVEY path                                      TARGETED path
+         (cell type poorly characterised;                     (specific KB field gap;
+          KB sparse after ASTA ingest)                         KB has partial content)
+                         │                                                  │
+              ASTA snippet_search across                       targeted snippet query
+              all corpus paper IDs (batch)                     + synonym expansion
+                         │                                                  │
+              PMC full text for gap papers               optionally: cite-traverse skill
+              (enrich where snippets thin)                (1–2 hops, bounded question)
+                         │                                                  │
+              all_summaries.json                           per-query synthesis agent
+              (per-snippet summaries,                      → KB write (PropertySource)
+               section, quotes, relevance)                 → pre-edit hook validates
+                         │
+              synthesis subagent
+              (cross-paper; themes;
+               gap + new types analysis)
+                         │
+                  KB + report.md
+```
+
+---
+
+## How all_summaries.json is produced
+
+This is the central cache for the survey path and deserves explicit description.
+The current cite-traverse fetch subagent produces it as follows:
+
+1. **ASTA snippet_search** across all corpus paper IDs (can be batched — a single
+   call handles multiple papers). Returns short snippets with section metadata.
+
+2. **Filter** — title-kind snippets and peer-review sections excluded.
+
+3. **Per-snippet summary** — for each retained snippet: section, relevance score,
+   1–3 verbatim quotes, node relevance judgement.
+
+4. **PMC full-text fallback** — for papers that returned 0 snippets ("gap papers"):
+   fetch EuropePMC full text, extract up to 3 relevant passages. This is currently
+   a fallback only, not used to enrich all papers.
+
+5. **Merge** — depth_N_summaries from each traversal depth → all_summaries.json.
+
+**Planned improvement (refactor aim):** Use full text more broadly — not just as
+a fallback for zero-snippet papers, but to enrich thin-snippet papers (e.g. 1 snippet
+from a high-relevance paper) and to extract synonyms and dataset accessions that
+snippets miss. The mechanism for this is not yet specified: options include
+a per-paper enrichment pass triggered by relevance score, or a post-scan full-text
+fetch for papers flagged as high-priority by the synthesis subagent.
+
+**What we must NOT lose in refactoring**: the multi-paper batch capability of
+ASTA snippet_search. A single call can cover the full ASTA corpus — this is the
+efficiency gain of the survey path. Refactoring to cite-traverse-as-skill for
+targeted questions should not reduce this capability; it should coexist with it.
+
+---
+
+## Critical early step: synonym capture
+
+**This is potentially the most important infrastructure to get right early.**
+
+Papers, atlases, and databases use different names for the same cell type. Without
+synonym mapping, both survey and targeted searches fail silently — queries miss the
+cell type because the wrong term is used.
+
+Examples:
+- OLM = oriens-lacunosum moleculare = O-LM cell = OLM interneuron
+- "Sst+" in atlas cluster labels vs "somatostatin-expressing" in papers
+- Historical names vs current names
+- Short abbreviations used in atlas annotation vs full classical names in papers
+
+**Synonym bootstrapping mechanism:**
+Look for synonyms on each paper as a first step when processing it. Use what is
+found in subsequent queries — feed forward within the same mining run. Snippet
+search alone may be insufficient for this (snippets may not include the passage
+where the author defines their abbreviation); PMC full-text fetch is probably
+required for reliable synonym extraction.
+
+Also take advantage of existing KB content: if a node already has synonyms from
+a prior run, inject them into all subsequent queries for that node.
+
+**Split-first principle for extraction agents:**
+The KB is built while being queried — extraction agents cannot always determine whether
+two names refer to the same type or subtly distinct types. Collapsing two names into one
+node is lossy and hard to reverse; keeping them separate and linking is not.
+
+Default agent behavior when uncertain: **create two nodes + a `CANDIDATE_SYNONYM` edge**
+(schema v0.6.2) rather than assuming synonym. This is queryable ("show all unresolved
+CANDIDATE_SYNONYM edges"), does not block KB construction, and defers the decision to
+curation. Merging nodes later (migrate evidence, deprecate one) is straightforward.
+Splitting a merged node (reconstruct which evidence belonged to which type) is not.
+
+Curation resolution: confirm (→ EQUIVALENT + migrate evidence) or reject (→ document
+distinguishing feature in caveats; change relationship to PARTIAL_OVERLAP or UNCERTAIN).
+
+**When to add as synonym vs create new node:**
+- Source paper *explicitly* defines one term as abbreviation of another ("hereafter OLM")
+  → add as `TypeSynonym` on the existing node.
+- Two names appear in different papers with overlapping but not identical characterisations
+  → create two nodes + `CANDIDATE_SYNONYM` edge.
+
+**Schema design (v0.6.1):** `CellTypeNode.synonyms` is a list of `TypeSynonym` objects,
+each with:
+- `term` (required) — the alternate name exactly as used in source
+- `synonym_type` — enum: ABBREVIATION | HISTORICAL | ATLAS_LABEL | CROSS_SPECIES | INFORMAL
+- `sources` — list of `PropertySource` (ref, snippet/quote_key, method, scope)
+
+This mirrors the `AnatomicalLocation` pattern: a wrapper class with the term + evidence list.
+A single synonym can have multiple sources (same term cited in multiple papers).
+
+**Where this fits:** ASTA ingest should extract known synonyms as the first processing
+step. KB gap review should flag nodes with no synonyms. Targeted search agents should
+automatically expand queries with all known synonyms. New synonyms discovered during
+mining → added to node before next search cycle.
+
+---
+
+## KB flags as workflow memory
+
+Rather than a separate tracking file, workflow state is encoded as flags on KB nodes.
+This keeps provenance in the KB and avoids a parallel bookkeeping system.
+
+**How it works:**
+- On each research cycle run, flags are set on the node (e.g. `survey_run: 2026-04-21`,
+  `gaps_flagged: [anatomical_location, defining_markers]`).
+- When information is found and written as PropertySource, the corresponding gap flag
+  is cleared.
+- The KB gap reviewer reads current flags + KB content to decide what to do next.
+- This makes cycles efficient: the reviewer doesn't re-derive gaps from scratch,
+  it reads the flag state.
+
+**Priority tags in KB:** Gap flags can carry priority scores — `AT_dataset_gap: HIGH`
+because AT needs a bridging dataset accession; `marker_gap: MODERATE` because ASTA
+already has partial marker information. The gap reviewer uses these to decide what
+targeted question to run next.
+
+Aim: mapping improvement. Two main triggers for targeted search:
+1. **Mapping evidence review** — what evidence would strengthen or refine an edge?
+2. **Gap review** — what information is most beneficial to future mapping?
+   (markers and AT transfer datasets are top priority)
+
+---
+
+## cite-traverse: from orchestrator to skill
+
+cite-traverse is currently a named orchestrator — implying it should be run as a
+top-level step. But **following citations is a technique, not a workflow phase.**
+
+**Proposed redesign:** cite-traverse becomes a skill (`.claude/skills/cite-traverse.md`)
+invokable by a targeted research agent when it judges that following a specific paper's
+references will yield the answer to a bounded question. The skill:
+- Takes one or more entry-point papers + a specific question
+- Traverses 1–2 citation hops (bounded)
+- Writes depth_N_summaries to output_dir
+- Returns a summary of what was found
+
+**What is preserved:** The multi-paper ASTA batch capability, the snippet filtering
+logic, the PMC fallback — all of this lives in the skill and can be invoked from either
+the survey path or the targeted path. Renaming does not reduce capability.
+
+The broad survey-mode scan (ASTA corpus fan-out) uses the same underlying machinery
+but is framed as "snippet scan of corpus" and lives in the survey orchestrator.
+
+---
+
+## Implications for current workflows
+
+| Workflow | Current status | Proposed change |
+|---|---|---|
+| `lit-review.md` | **EXPERIMENTAL — DO NOT USE** | Retire; fold into survey orchestrator |
+| `cite-traverse.md` | Working but overscoped as orchestrator | Refactor as skill; machinery preserved |
+| `evidence-extraction.md` | Overengineered (5 steps, 3 gates) | Simplify: paper selection gate → extraction → KB write |
+| `asta-report-ingest.md` | Working | Keep; add synonym extraction step |
+| New: `survey.md` | Not yet written | ASTA-bounded lit scan after ingest |
+| New: `targeted-search.md` | Not yet written | KB-gap-driven, invokes cite-traverse skill |
+
+---
+
+## Open questions
+
+1. **Gap reviewer as step vs orchestrator entry**: Fluid makes more sense — in the
+   spirit of iterative improvement. Efficiency maintained via KB flags (see above):
+   the reviewer reads flag state rather than re-deriving gaps from scratch each time.
+
+2. **How many targeted questions per cycle?** Hard to specify in advance. Priority
+   tags in KB (see above) determine what runs. Aim is always improved mappings:
+   primary triggers are mapping evidence review and gap review (markers and AT
+   dataset accessions as top priorities).
+
+3. **When does survey terminate?** Survey is bounded by the ASTA paper set (may be
+   broadened in future — e.g. to include papers from a separate lit search run).
+   After survey, results write to DB / KB, and gap flags + mapping state set
+   priorities for targeted runs. No explicit handoff signal needed — the gap flags
+   carry forward.
+
+4. **Synonym bootstrapping:** Look for synonyms on each paper as first processing
+   step; feed forward to subsequent queries in the same run. Snippet search may be
+   insufficient — PMC full text likely needed for reliable synonym extraction.
+   Mechanism: enrichment pass for high-relevance papers, triggered by relevance score.
+   Also: leverage existing KB synonym content to seed queries.
+
+5. **Per-node running summary cache:** If targeted runs produce summaries for narrow
+   questions, a per-node cache of all collected summaries (across runs) avoids
+   re-fetching. Unclear whether this is worth the complexity vs just re-running.
+   Deferred until targeted-search orchestrator design.

--- a/reports/hippocampus/olm_hippocampus_drilldown_Winterer2019.md
+++ b/reports/hippocampus/olm_hippocampus_drilldown_Winterer2019.md
@@ -1,0 +1,262 @@
+# Evidence Drill-down: Winterer et al. 2019
+*Supporting: olm_hippocampus → 0727 Lamp5 Lhx6 Gaba_1; olm_hippocampus → 0785 Sst Gaba_6; olm_hippocampus → 0769 Sst Gaba_3; olm_hippocampus → 0788 Sst Gaba_6; olm_hippocampus → 0789 Sst Gaba_6*
+*[← Back to summary report](olm_hippocampus_summary.md)*
+
+---
+
+**Winterer J, Maier N, Ziegler C, Lorcini K, Isomura Y, Schmitz D, Bhatt DL, Bhatt DL**
+Single-cell RNA-Seq characterization of anatomically identified OLM interneurons in different transgenic mouse lines
+*European Journal of Neuroscience* 2019 · PMID:31420995 · DOI:10.1111/ejn.14549
+
+· [GEO:GSE124847](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE124847)
+
+---
+
+## Why this paper matters for this mapping
+
+Winterer et al. 2019 performed single-cell RNA sequencing on 46 OLM interneurons that were individually patch-clamped and electrophysiologically characterised in acute hippocampal slices, collected using two independent Cre-driver lines (Htr3a-Cre::Ai14 and Sst-Cre::Ai14), and then subjected to post-hoc morphological reconstruction after DAB staining to verify OLM identity. This triple-validation approach — transgenic targeting, electrophysiology, and confirmed axonal projection to stratum lacunosum-moleculare with horizontal soma and dendrites in stratum oriens — provides exceptionally strong evidence for the mapping, because cells entered the transcriptomic dataset only after their OLM identity was independently confirmed at the anatomical level. Critically, this paper resolves a long-standing species discrepancy regarding Npy expression, demonstrating at both transcript and protein levels that mouse OLM cells consistently co-express Npy, overturning a prior rat-based exclusion criterion (Katona et al. 2014) and a mouse transcriptomic usage of Npy as an OLM-exclusion marker (Harris et al. 2018). The raw data (GEO:GSE124847) are available for direct re-mapping to WMBv1, and the MapMyCells annotation transfer reported in the facts file used this dataset to map 46 OLM cells, strongly supporting the parent Sst Gaba_3 supertype (43/46 cells, F1=0.67 at SUPERTYPE level).
+
+---
+
+## Per-property evidence
+
+### Sst · alignment with 0769 Sst Gaba_3: CONSISTENT
+
+> oriens-lacunosum moleculare (OLM) interneurons. OLMs express somatostatin (Sst), generate feedback inhibition and play important roles in theta oscillations and fear encoding
+> — Winterer et al. 2019, Molecular Markers and Gene Expression <!-- quote_key: 201041756_69dc904d -->
+
+Winterer et al. state Sst expression as a defining characteristic of OLM interneurons in their introduction, framing all subsequent scRNA-seq results in that context. The alignment is CONSISTENT: cluster 0769 Sst Gaba_3 [CS20230722_CLUS_0769] belongs to the Sst Gaba subclass (053 Sst Gaba [CS20230722_SUBC_053]), meaning Sst expression is constitutive at the subclass level across this cluster. The Sst subclass assignment directly mirrors the canonical definition stated here. This quote is also relevant to the edges for clusters 0785, 0788, and 0789 Sst Gaba_6 [CS20230722_CLUS_0785/0788/0789], all of which also carry CONSISTENT Sst marker alignment.
+
+---
+
+> we found consistent expression of Sst and Reln, and sparse expression of Pvalb across both OLM neuron types
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_2d5a5fb3 -->
+
+This quantitative scRNA-seq result confirms that Sst expression is consistent (not variable) across the 46 morphologically verified OLM cells from both transgenic lines, and that Pvalb is sparse — reinforcing that OLM cells are an Sst-dominant, Pvalb-negative population. The alignment is CONSISTENT with all five candidate clusters carrying the Sst Gaba subclass designation. The sparse Pvalb finding also matters for cluster differentiation: OLM cells are not a PV+ type, consistent with the classical negative-marker profile. Reln co-expression with Sst is a known feature of hippocampal interneuron subpopulations *(note: Reln is expressed in CA1 stratum oriens interneurons in the mouse hippocampus, and its co-expression with Sst here narrows the identity further, though atlas-side Reln expression is not assessed for these clusters)*.
+
+---
+
+### GABAergic identity · alignment with 0769 Sst Gaba_3: CONSISTENT
+
+> Independent of the Cre line used for cell collection, we found consistent expression of GABA release‐related Gad1, Gad2 and Slc6a1 in all OLM interneurons. By contrast, glutamate release‐related vesicular glutamate transporter Slc17a7 (detected in 2/46 cells) and Slc17a6 (detected in 1/46 cells) genes were virtually not expressed across the whole population.
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_1d024a35 -->
+
+All 46 morphologically verified OLM cells expressed the canonical GABAergic biosynthesis and transport genes (Gad1, Gad2, Slc6a1), while glutamatergic transporter genes were absent from virtually the entire population. The alignment is CONSISTENT across all five candidate clusters, which are all assigned to GABA NT class in WMBv1. The Slc17a7/Slc17a6 absence finding robustly excludes any glutamatergic contamination of this population, strengthening the NT identity claim. This evidence holds for all five edges.
+
+---
+
+### Chrna2 · alignment with 0769 Sst Gaba_3: APPROXIMATE
+
+> as well as expression of Chrna2, which has been used as a marker for hippocampal OLM interneurons
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_bd56f851 -->
+
+Winterer et al. confirm Chrna2 expression in their morphologically verified OLM cells, corroborating its status as an OLM-defining marker. For cluster 0769 Sst Gaba_3 [CS20230722_CLUS_0769], the alignment is APPROXIMATE: the ABC Atlas HPF/GABA/Chrna2 filter retains the parent Sst Gaba_3 supertype, indicating Chrna2 is expressed across this supertype, but the expression is scattered across sibling clusters (not restricted to cluster 0769 specifically) — expression across supertype not specific to one cluster. The Chrna2 evidence from Winterer et al. most directly implicates the Sst Gaba_3 supertype as a whole rather than cluster 0769 individually. For the three Sst Gaba_6 clusters (0785, 0788, 0789), this same Chrna2 evidence is DISCORDANT: the ABC Atlas filter eliminates the Sst Gaba_6 supertype entirely *(distant region — stronger counter-evidence; the classical type may still be a subtype of this T-type but not the Sst Gaba_6 population specifically)*. For the Lamp5 Lhx6 cluster 0727, Chrna2 is NOT_ASSESSED (absent from atlas metadata for this cluster).
+
+---
+
+### mGluR1 (Grm1) · alignment with 0769 Sst Gaba_3: NOT_ASSESSED
+
+> we found both Elfn1 and Grm1 to be present throughout the cell population
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_b1ead2e9 -->
+
+Winterer et al. report Grm1 (mGluR1) expression throughout the OLM cell population — consistent with prior literature identifying mGluR1 as a defining OLM marker (cited in the classical node definition). The quantification in the facts file places Grm1 detection at 44/46 OLM cells (96%). However, the alignment is NOT_ASSESSED for all five candidate clusters: Grm1 does not appear in cluster-level defining_markers or neuropeptides in the atlas metadata, so the atlas-side value cannot be evaluated. This is a protein-level marker in prior literature confirmed at transcript level here, but it cannot be used to distinguish between candidate clusters until atlas-side Grm1 expression is resolved. The co-expression of Elfn1 *(note: Elfn1 is a postsynaptic density protein known to enrich at synapses of SST interneurons and promote short-term plasticity at those synapses — its expression here is consistent with OLM identity, though it is not specific to OLM cells among hippocampal Sst interneurons)* is also not assessable at the atlas cluster level.
+
+---
+
+### Npy · alignment with 0769 Sst Gaba_3: CONSISTENT
+
+> we found a surprisingly consistent expression of Npy in OLMs
+> — Winterer et al. 2019, Molecular Markers and Gene Expression <!-- quote_key: 201041756_8d16e821 -->
+
+This brief but consequential statement establishes Npy transcript co-expression in OLM cells. The surprise qualifier signals that this conflicts with prior expectations. The alignment is CONSISTENT with cluster 0769 Sst Gaba_3 [CS20230722_CLUS_0769], which carries the full neuropeptide triad (Sst, Npy, Pnoc) in its atlas metadata. This evidence is relevant to the 0727 Lamp5 Lhx6 Gaba_1 edge, where Npy is DISCORDANT (absent from that cluster's metadata), making the Npy finding a discriminating datum favouring the Sst Gaba_3 clusters over the Lamp5 Lhx6 candidate.
+
+---
+
+> we found consistent expression of Npy. This observation was striking, because an earlier study showed the lack of NPY in OLM cells (0/4) in the rat hippocampus (Katona et al., 2014), and expression of its gene was previously used to exclude OLM identity in single‐cell transcriptomic samples in mouse (Harris et al., 2018).
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_9991ee9f -->
+
+This is the full quantitative statement, resolving the inter-study discrepancy explicitly. Winterer et al. demonstrate that the rat data (Katona et al. 2014: 0/4 OLM cells NPY-positive) do not translate to mouse, and that use of Npy as an OLM-exclusion criterion in Harris et al. 2018 was incorrect for the mouse. *(note: this is a species difference — rat OLM cells appear to lack Npy while mouse OLM cells consistently express it; cross-species differences for this marker are confirmed within this paper)* The alignment is CONSISTENT for clusters 0769, 0785, 0788, and 0789 (all carry Npy in their neuropeptide profiles), and DISCORDANT for cluster 0727 Lamp5 Lhx6 Gaba_1 [CS20230722_CLUS_0727] which lacks Npy.
+
+---
+
+> we were able to confirm the presence of NPY in 3 out of 5 OLM neurons
+> — Winterer et al. 2019, Results 3.5 <!-- quote_key: 201041756_6f670235 -->
+
+This protein-level confirmation (3/5 cells by immunostaining) elevates Npy from a transcript observation to a verified protein-level finding, directly strengthening the neuropeptide alignment. The alignment remains CONSISTENT for clusters carrying Npy (0769, 0785, 0788, 0789). The protein detection rate (60%) is lower than the mRNA detection rate, which is expected given the sensitivity differences between immunohistochemistry and scRNA-seq *(note: IHC detection of neuropeptides can vary with antibody sensitivity and fixation protocols; the transcript data showing consistent Npy mRNA is likely a more complete reflection of expression prevalence)*.
+
+---
+
+### Pnoc · alignment with 0769 Sst Gaba_3: CONSISTENT
+
+> we detected Pnoc in both Htr3aCre‐OLM (14/23) and SstCre‐OLM (13/23)
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_1d20426d -->
+
+Pnoc is detected in approximately 60% of OLM cells in both transgenic lines (27/46 total). The alignment is CONSISTENT for cluster 0769 Sst Gaba_3 [CS20230722_CLUS_0769], which carries Pnoc in its atlas metadata as part of the full neuropeptide triad. The fact that Pnoc is not expressed in 100% of OLM cells is consistent with sub-cluster heterogeneity within the Sst Gaba_3 supertype *(note: Thulin et al. 2025, referenced in the classical node definition, identify three Sst/Pnoc subclusters with differential connectivity — partial Pnoc expression across the OLM population is consistent with this heterogeneity)*. Pnoc alignment is DISCORDANT for cluster 0785 Sst Gaba_6 [CS20230722_CLUS_0785] (Pnoc absent from that cluster's metadata), and CONSISTENT for clusters 0788 and 0789 (both carry Pnoc). The Pnoc finding also broadly supports the connection noted in the facts file between OLM identity and Sst/Pnoc co-expression.
+
+---
+
+### MGE origin / Lhx6 · alignment with 0769 Sst Gaba_3: CONSISTENT
+
+> all Htr3aCre‐OLM and SstCre‐OLM neurons consistently expressed MGE‐associated marker genes
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_807e85c2 -->
+
+This quote (claims: lhx6_positive, mge_origin, satb1_positive, sox6_positive) establishes that both transgenic OLM subtypes are MGE-derived, expressing Lhx6, Satb1, and Sox6 without exception. The alignment is CONSISTENT with the Sst Gaba subclass, which belongs to the MGE-derived GABA class (07 CTX-MGE GABA [CS20230722_CLAS_07]), confirmed by the MapMyCells annotation transfer (45/46 cells mapped to 07 CTX-MGE GABA at class level, F1=0.68, group_purity=1.0). This finding is critically DISCORDANT with the Lamp5 Lhx6 subclass assignment of cluster 0727, which is a CGE-derived lineage *(note: Lamp5 Lhx6 clusters in WMBv1 are classified under CGE-derived interneurons; canonical OLM cells as defined by MGE origin are inconsistent with a CGE lineage assignment, making this lineage finding a strong argument against cluster 0727)*.
+
+---
+
+> we analysed expression of key developmental marker genes: including CGE‐associated Prox1, Htr3a and Sp8, as well as MGE‐associated Lhx6, Satb1 and Sox6
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_0670df0d -->
+
+This methodological statement establishes the systematic framework for the developmental origin analysis. It shows that both CGE and MGE marker sets were tested, making the conclusion of MGE origin a genuine discrimination rather than a partial test.
+
+---
+
+> We detected Htr3a, Prox1 and Sp8 in 5, 1 and 1 out of 23 Htr3a‐OLMs, respectively. By contrast, all Htr3aCre‐OLM and SstCre‐OLM neurons consistently expressed MGE‐associated marker genes
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_8c9b1b66 -->
+
+CGE markers (Htr3a, Prox1, Sp8) are detected in only 5/23, 1/23, and 1/23 cells respectively, while all 46 OLM cells express the MGE markers. This quantitative contrast strongly confirms MGE origin. The sparse Htr3a detection (5/23 of the Htr3a-Cre-targeted cells) is notable: even the Htr3a-Cre line, which should preferentially label Htr3a-expressing cells, captured OLM cells that transcriptomically are predominantly MGE-type. This supports the conclusion that Htr3a-Cre OLM cells are a morphologically and transcriptomically distinct population from canonical CGE-derived, Htr3a-expressing interneurons. This directly strengthens the CONSISTENT MGE-origin alignment for all Sst Gaba clusters and reinforces the DISCORDANT lineage argument against the Lamp5 Lhx6 cluster 0727.
+
+---
+
+> Additional regression analysis furthermore supported the strong correlation between developmental marker expression for SstCre‐OLM and Htr3aCre‐OLM types (R = 0.99)
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_a4e5b13e -->
+
+The near-perfect correlation (R = 0.99) in developmental marker profiles across the two transgenic lines confirms that both lines capture the same transcriptomic population and that the MGE origin conclusion is robust across collection method. This supports the claim that OLM identity maps to a single, coherent transcriptomic population — consistent with the MapMyCells result showing convergence of both Sst-OLM and Htr3a-OLM subtypes on the same Sst Gaba_3 supertype.
+
+---
+
+### Htr3a · alignment with 0769 Sst Gaba_3: CONSISTENT
+
+> our results revealed surprisingly infrequent expression of Htr3a in only ~10% of OLMs and an apparently specific expression of the 5-HT3b subunit-coding gene Htr3b in Htr3aCre-OLMs
+> — Winterer et al. 2019, Molecular Markers and Gene Expression <!-- quote_key: 201041756_90146223 -->
+
+Htr3a is expressed in only ~10% of OLMs overall, despite the use of an Htr3a-Cre driver line. This makes Htr3a a negative indicator for OLM identity rather than a positive marker. The alignment for this property relative to all five candidate clusters is best characterised as CONSISTENT with their Sst subclass (not Htr3a) assignment, reinforcing that OLM cells — even those captured via Htr3a-Cre — transcriptomically belong to the Sst, not the Lamp5/Htr3a, lineage.
+
+---
+
+> we found infrequent expression of Htr3a in both Htr3aCre‐OLM (5/23) and SstCre‐OLM (2/23) types
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_cf49e910 -->
+
+The quantitative data (5/23 and 2/23) confirm Htr3a is sparse in both OLM subtypes. This aligns with the Sst Gaba subclass assignment of the best candidate clusters, where Htr3a would not be a defining marker.
+
+---
+
+### Transcriptomic homogeneity · alignment with 0769 Sst Gaba_3 (population character)
+
+> OLMs constitute a highly homogenous transcriptomic population
+> — Winterer et al. 2019, Molecular Markers and Gene Expression <!-- quote_key: 201041756_afab0ca7 -->
+
+This summary characterisation is relevant to interpreting the MapMyCells scatter across sibling clusters 0767–0774 within the Sst Gaba_3 supertype. Winterer et al.'s own analysis concluded OLM cells form a homogeneous population, yet the annotation transfer scatters them across multiple clusters within Sst Gaba_3. This tension suggests the within-supertype scatter reflects limitations of the cluster-level reference resolution for this population rather than genuine heterogeneity in the source cells. The evidence supports mapping at SUPERTYPE rather than cluster level as the appropriate resolution for OLM identity.
+
+---
+
+> these comparisons suggest strong similarities between our OLM cells and Harris et al.’s Sst cells, with exception of Npy expression
+> — Winterer et al. 2019, Results 3.4 <!-- quote_key: 201041756_390db1a8 -->
+
+Winterer et al. directly contextualise their data against Harris et al. 2018's Sst cell transcriptomic clusters, finding broad similarity except for Npy. This supports the mapping to the Sst Gaba subclass in WMBv1 and the CONSISTENT Npy neuropeptide alignment for the Sst Gaba_3 clusters.
+
+---
+
+### Morphology and electrophysiology (identity confirmation)
+
+> cells that were included in the study were first reconstructed after DAB staining to identify the morphological characteristics of OLM cells, including the axonal projection to the lacunosum moleculare, the horizontally orientated soma and dendritic branching in the oriens
+> — Winterer et al. 2019, Molecular Markers and Gene Expression <!-- quote_key: 201041756_c6648415 -->
+
+This is the inclusion criterion for the dataset. Cells entered the transcriptomic corpus only after morphological confirmation of: (1) axon projecting to stratum lacunosum-moleculare [UBERON:0007637], (2) horizontal soma, and (3) dendritic branching in stratum oriens [UBERON:0014548]. This strict gate means the transcriptomic data are anchored to anatomically defined OLM identity — a critical strength for the mapping. The atlas-side location comparison for cluster 0769 [CS20230722_CLUS_0769] is APPROXIMATE: CA1 stratum oriens [MBA:399] is the primary OLM location (87 cells in the cluster), matching the classical definition, but there is additional spread to prosubiculum (61 cells) and posterior amygdala (95 cells) *(adjacent region — could reflect registration boundary error; weak counter-evidence)* for the prosubiculum, which borders CA1. The posterior amygdala spread is more concerning *(note: the posterior amygdala is not adjacent to CA1 stratum oriens; this spread is anatomically distant and may indicate that cluster 0769 contains non-OLM Sst interneurons from extrahippocampal regions)*.
+
+---
+
+> All cells that were included in the study were first reconstructed after DAB staining to identify the morphological characteristics of OLM cells, including the axonal projection to the lacunosum moleculare, the horizontally orientated soma and dendritic branching in the oriens
+> — Winterer et al. 2019, Results 3.1 <!-- quote_key: 201041756_7b9b4800 -->
+
+This is the methods confirmation (in the Results section) of the same inclusion criterion. The duplication reinforces that morphological verification was a hard gate, not a post-hoc annotation.
+
+---
+
+> we morphologically characterized the recorded cells, and only proceeded with those for electrophysiological analysis and single‐cell RNA sequencing which had axonal and/or dendritic morphology stereotypical to OLM cells
+> — Winterer et al. 2019, Results 3.0 <!-- quote_key: 201041756_eb2447af -->
+
+This statement documents the sequential gating: morphological characterisation preceded both electrophysiological recording and scRNA-seq, meaning all 46 cells in the dataset had confirmed OLM morphology before any molecular data were collected. The phrase "axonal and/or dendritic morphology stereotypical to OLM cells" indicates that not all cells required complete axonal reconstruction — some may have qualified on dendritic features alone. This is a minor caveat but does not materially weaken the dataset quality.
+
+---
+
+> We observed these typical features of OLM interneurons in both Htr3aCre‐OLM and SstCre‐OLM cells (sag potential: 0.51 ± 0.02 vs. 0.47± 0.03 mV; frequency adaptation ratio: 0.52 ± 0.03 vs. 0.43 ± 0.04; maximum AP firing: 53.2 ± 4.0 Hz vs. 62.2 ± 3.5 Hz; and RMP: −62.4 ± 1.2 vs. −63.4 ± 1.7, respectively).
+> — Winterer et al. 2019, Results 3.2 <!-- quote_key: 201041756_1fea12c0 -->
+
+The electrophysiological parameters (sag potential, frequency adaptation, maximum firing rate, resting membrane potential) are quantitatively consistent across both transgenic OLM subtypes and match the classical OLM electrophysiology profile described in the classical node definition (pronounced sag, regular-to-adapting firing, high input resistance, theta-range spiking). The alignment for electrophysiology is NOT_ASSESSED against the atlas clusters, as WMBv1 cluster metadata does not include electrophysiological parameters. These data function as additional identity confirmation rather than a discriminating atlas comparison.
+
+---
+
+> In acute hippocampal brain slices, we identified OLM neurons based on tdTomato expression using the Htr3a‐Cre::Ai14 and Sst‐Cre::Ai14 transgenic lines. Single cells were electrophysiologically characterized, and their cytosolic mRNA was subsequently aspirated. Single‐cell RNA sequencing was performed after confirming OLM identity by post hoc visualization of axons and dendrites.
+> — Winterer et al. 2019, Figure 1 caption <!-- quote_key: 201041756_9dce8a8e -->
+
+This figure caption concisely summarises the full experimental workflow: fluorescent targeting → electrophysiology → mRNA aspiration → scRNA-seq → post-hoc morphological confirmation. The workflow is explicitly sequential, confirming that no cell contributed transcriptomic data unless its OLM identity was verified at multiple independent levels. This is the strongest structural source of evidential confidence for the dataset.
+
+---
+
+### Syt1/Syt2 profile
+
+> we detected consistent expression of Syt1 and lack of Syt2. This is in accordance with previous literature, as Syt2 has been reported to be associated with Pvalb+ cells
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_8340e0a0 -->
+
+Syt1 positivity and Syt2 negativity in OLM cells aligns with their Pvalb-sparse profile (confirmed earlier in the dataset) and distinguishes OLM cells from fast-spiking, Syt2-positive PV+ interneurons. This is NOT_ASSESSED against the atlas clusters (Syt1/Syt2 expression is not in the cluster-level metadata fields used for comparison), but it provides additional molecular evidence distinguishing OLM from chandelier and basket cell populations.
+
+---
+
+### Additional markers (Gria4, Kcnc2, Kcnd3, Cacna1a, Cacna1g)
+
+> we found consistent expression of Gria4, Kcnc2, Kcnd3, Cacna1a and Cacna1g, which have been described to be present in OLMs
+> — Winterer et al. 2019, Results 3.3 <!-- quote_key: 201041756_708ee6a6 -->
+
+These ion channel subunits (AMPA receptor subunit Gria4; voltage-gated K+ channels Kcnc2/Kcnd3; voltage-gated Ca2+ channels Cacna1a/Cacna1g) are confirmed as consistent markers in the OLM transcriptome. Their alignment against the atlas candidate clusters is NOT_ASSESSED (none of these appear in cluster-level defining_markers or neuropeptides in the WMBv1 metadata). They serve as additional molecular context supporting the coherent OLM transcriptomic signature but cannot discriminate between the candidate clusters.
+
+---
+
+### Dataset availability
+
+> Raw sequences are deposited and freely available under NCBI GEO # GSE124847.
+> — Winterer et al. 2019, Data Availability <!-- quote_key: 201041756_83f848d5 -->
+
+GEO:GSE124847 is the source dataset used in the MapMyCells annotation transfer documented in the facts file. The data are freely available and have already been used to generate the annotation transfer evidence for all five edges in this mapping.
+
+---
+
+## Summary scorecard
+
+| Property | Paper finding | Atlas alignment | Quote key |
+|---|---|---|---|
+| Sst (introduction) | OLM-defining, consistent expression | CONSISTENT | 201041756_69dc904d |
+| Sst (scRNA-seq result) | Consistent in all 46 cells; Pvalb sparse | CONSISTENT | 201041756_2d5a5fb3 |
+| GABAergic identity | Gad1/Gad2/Slc6a1 all cells; Slc17a7/Slc17a6 absent | CONSISTENT | 201041756_1d024a35 |
+| Chrna2 | Confirmed expression in OLM cells | APPROXIMATE (0769); DISCORDANT (0785/0788/0789) | 201041756_bd56f851 |
+| mGluR1 (Grm1) | Present throughout (44/46 cells) | NOT_ASSESSED | 201041756_b1ead2e9 |
+| Npy (brief statement) | Surprisingly consistent expression | CONSISTENT | 201041756_8d16e821 |
+| Npy (with species context) | Consistent; overturn rat exclusion criterion | CONSISTENT (0769/0785/0788/0789); DISCORDANT (0727) | 201041756_9991ee9f |
+| Npy (protein confirmation) | 3/5 OLM cells NPY+ by immunostaining | CONSISTENT | 201041756_6f670235 |
+| Pnoc | ~60% of cells in both lines | CONSISTENT (0769/0788/0789); DISCORDANT (0785) | 201041756_1d20426d |
+| MGE origin / Lhx6 | All cells express Lhx6, Satb1, Sox6 | CONSISTENT (Sst clusters); DISCORDANT (0727 Lamp5 Lhx6) | 201041756_807e85c2 |
+| CGE markers absent | Htr3a/Prox1/Sp8 rare or absent | CONSISTENT | 201041756_8c9b1b66 |
+| MGE correlation across lines | R = 0.99 between both OLM subtypes | CONSISTENT | 201041756_a4e5b13e |
+| Htr3a (introduction) | ~10% of OLMs; Htr3b specific to Htr3a-line | CONSISTENT | 201041756_90146223 |
+| Htr3a (quantified) | 5/23 and 2/23 in each line | CONSISTENT | 201041756_cf49e910 |
+| Transcriptomic homogeneity | OLMs are homogeneous population | Population character | 201041756_afab0ca7 |
+| Harris Sst similarity | Broad similarity except Npy | CONSISTENT | 201041756_390db1a8 |
+| Morphology (methods) | DAB reconstruction; axon to SLM; horizontal soma; dendrites in SO | APPROXIMATE (location) | 201041756_c6648415 |
+| Morphology (results) | Same criteria confirmed in results | APPROXIMATE (location) | 201041756_7b9b4800 |
+| Inclusion criterion | Morphology gate before scRNA-seq | Identity confirmation | 201041756_eb2447af |
+| Electrophysiology | Sag, adaptation, firing rate, RMP consistent across lines | NOT_ASSESSED | 201041756_1fea12c0 |
+| Experimental workflow | Transgenic → ephys → aspiration → scRNA-seq → post-hoc morphology | Identity confirmation | 201041756_9dce8a8e |
+| Syt1/Syt2 | Syt1 consistent; Syt2 absent (PV-negative signature) | NOT_ASSESSED | 201041756_8340e0a0 |
+| Additional ion channels | Gria4, Kcnc2, Kcnd3, Cacna1a, Cacna1g all consistent | NOT_ASSESSED | 201041756_708ee6a6 |
+| Dataset accession | GEO:GSE124847 freely available | Evidence source | 201041756_83f848d5 |
+
+---
+
+## Critical gap
+
+Winterer et al. 2019 did not map their cells to WMBv1 directly — this paper predates the atlas. While the MapMyCells annotation transfer using GEO:GSE124847 provides strong supertype-level support (Sst Gaba_3, F1=0.67, 43/46 cells), OLM cells scatter across sibling clusters 0767–0774 at cluster level, and cluster 0769 specifically received 0/46 cells (cells preferentially map to cluster 0768, 22/46). The connection therefore requires resolution at cluster level: the specific bridging experiment needed is Chrna2-Cre driver line + MapMyCells at F1 ≥ 0.80 at CLUSTER level — see Proposed experiments in the summary report. Importantly, GEO:GSE124847 data are available for direct re-mapping without new experiments, and could be used for deeper cluster-level resolution using updated MapMyCells parameters or alternative reference datasets.
+
+---
+
+*Drill-down generated from: references.json (corpus_id: 201041756)*
+*Quotes: source_method=primary, asta_report, status=verified, validated*

--- a/reports/hippocampus/olm_hippocampus_summary.md
+++ b/reports/hippocampus/olm_hippocampus_summary.md
@@ -1,5 +1,5 @@
 # Oriens-Lacunosum Moleculare (O-LM) interneuron — WMBv1 Mapping Report
-*draft · 2026-03-25 · Source: `kb/draft/hippocampus/hippocampus_GABA_stratum_oriens_stubs.yaml`*
+*draft · 2026-03-25 · Source: `kb/draft/hippocampus/hippocampus_OLM.yaml`*
 
 > ⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted.
 > All edges require expert review before use.
@@ -13,27 +13,19 @@
 > projection targets are not reflected in atlas cluster location fields and
 > are not used in mapping assessments.
 
-The O-LM interneuron is defined in part by its axonal projection: the soma resides in stratum oriens [UBERON:0014548] while the axon travels vertically and terminates exclusively in stratum lacunosum-moleculare [UBERON:0007637], where it innervates the apical tufts of pyramidal cells. Because WMBv1 MERFISH location records soma position only, the SLM axonal arborisation — a hallmark feature distinguishing O-LM cells from other stratum oriens interneurons such as oriens-bistratified and back-projecting cells — is invisible to the atlas. Matching on MERFISH location therefore captures only the somatic half of the morphological definition and cannot discriminate axonal projection targets.
+The O-LM interneuron is defined in part by its axonal projection target: the soma and dendrites reside in stratum oriens [UBERON:0014548], but the axon travels vertically through strata pyramidale and radiatum to arborize exclusively in stratum lacunosum-moleculare [UBERON:0007637], where it innervates the apical tufts of pyramidal cells. Because WMBv1 MERFISH location records soma position only, the hallmark SLM axonal arborization is invisible to the atlas. Absence of SLM soma signal in an atlas cluster is therefore expected for OLM cells and must not be treated as a contra-indicator. The MERFISH location data captures only the somatic half of the OLM morphological definition and cannot discriminate axonal projection targets across strata.
 
 ---
 
-## Classical type
+## Classical type properties
 
 | Property | Value | References |
 |---|---|---|
-| Soma location | stratum oriens of hippocampus [UBERON:0014548] (CA1); stratum lacunosum-moleculare of hippocampus [UBERON:0007637] (axon terminal zone) | [1], [2], [3] |
+| Soma location | stratum oriens of hippocampus [UBERON:0014548] (CA1); axon projects to stratum lacunosum-moleculare of hippocampus [UBERON:0007637] | [1], [2], [3] |
 | Neurotransmitter | GABAergic | [4], [5] |
-| Defining markers | Sst, Chrna2, mGluR1/Grm1 | Sst: [6], [7]; Chrna2: [2], [8], [7]; mGluR1: [6], [7] |
-| Negative markers | PV, CB, CR, NOS, VIP | — |
+| Defining markers | Sst, Chrna2, mGluR1/Grm1. Direct detection rates from re-analysis of GSE124847 raw counts (46 OLM cells, Winterer 2019 [7]): Grm1 96% (44/46 cells); Chrna2 detected in a substantial fraction (specific cluster-level rate not available); Sst 100% (46/46 cells). | Sst: [6], [7]; Chrna2: [2], [8], [7]; mGluR1: [6], [7] |
+| Negative markers | PV, CB (Calb1), CR (Calb2), NOS, VIP | — |
 | Neuropeptides | Sst, Npy, Pnoc | Sst: [7]; Npy: [7]; Pnoc: [9], [7] |
-
-**Notes on marker quantification.** Detection rates from re-analysis of GSE124847 raw counts (Winterer et al. 2019 [7]): Sst (100% of OLM cells), Chrna2 (35%), mGluR1/Grm1 (96%). Chrna2 is detected in a minority of cells at transcript level in this dataset but remains the most OLM-specific marker available [2], [8].
-
-**Morphology summary.** Large horizontally oriented soma at the stratum oriens/alveus border. Horizontal dendrites in stratum oriens densely decorated with long spines. Axon projects vertically through stratum pyramidale and radiatum, arborizing extensively in stratum lacunosum-moleculare with densely packed varicosities. Minor axon collaterals remain in stratum oriens.
-
-**Electrophysiology.** Regular-to-fast spiking, tonic or mildly adapting firing. Pronounced sag response (Ih via HCN2 h-channels). Theta resonance (4–12 Hz). High input resistance, slow membrane time constants. Anti-Hebbian LTP dependent on Ca²⁺-permeable AMPA receptors.
-
-**Heterogeneity note.** The OLM class contains molecularly heterogeneous subpopulations. Thulin et al. 2025 [9] identify three Sst/Pnoc subclusters with differential dorsal–ventral connectivity. These may warrant separate nodes in future iterations.
 
 ---
 
@@ -41,8 +33,8 @@ The O-LM interneuron is defined in part by its axonal projection: the soma resid
 
 | Rank | WMBv1 cluster | Supertype | Cells | Confidence | Key property alignment | Verdict |
 |---|---|---|---|---|---|---|
-| 1 | 0769 Sst Gaba_3 [CS20230722_CLUS_0769] | Sst Gaba_3 | 243 | 🟡 MODERATE | Chrna2 APPROXIMATE · Npy CONSISTENT | Best candidate |
-| 2 | 0727 Lamp5 Lhx6 Gaba_1 [CS20230722_CLUS_0727] | Lamp5 Lhx6 Gaba_1 | 98 | 🔴 LOW | Npy DISCORDANT · Sst APPROXIMATE | Speculative |
+| 1 | 0769 Sst Gaba_3 [CS20230722_CLUS_0769] | Sst Gaba_3 | 243 | 🟡 MODERATE | Neuropeptide triad CONSISTENT · Chrna2 APPROXIMATE | Best candidate |
+| 2 | 0727 Lamp5 Lhx6 Gaba_1 [CS20230722_CLUS_0727] | Lamp5 Lhx6 | 98 | 🔴 LOW | Sst APPROXIMATE · Npy DISCORDANT | Speculative |
 | — | 0785 Sst Gaba_6 [CS20230722_CLUS_0785] | Sst Gaba_6 | 186 | ⚪ UNCERTAIN | Chrna2 DISCORDANT | Eliminated (Chrna2) |
 | — | 0788 Sst Gaba_6 [CS20230722_CLUS_0788] | Sst Gaba_6 | 50 | ⚪ UNCERTAIN | Chrna2 DISCORDANT | Eliminated (Chrna2) |
 | — | 0789 Sst Gaba_6 [CS20230722_CLUS_0789] | Sst Gaba_6 | 177 | ⚪ UNCERTAIN | Chrna2 DISCORDANT | Eliminated (Chrna2) |
@@ -56,28 +48,34 @@ Total: 5 edges. Relationship type: TYPE_A_SPLITS (classical OLM maps across mult
 ### Supporting evidence
 
 - **GABA neurotransmitter type consistent.** The cluster belongs to the Sst Gaba subclass, fully consistent with the GABAergic identity of O-LM cells [4], [5].
-- **Sst subclass consistent.** The cluster is defined at the subclass level by Sst expression, directly matching the canonical OLM marker [6], [7].
+- **Sst subclass consistent.** The cluster is defined at subclass level by Sst expression, directly matching the canonical OLM marker [6], [7].
 - **Full neuropeptide triad matched.** Cluster 0769 carries all three OLM neuropeptides — Sst, Npy, and Pnoc — the complete triad expected for OLM cells [7], [9]. No other evaluated cluster achieves this combination without missing at least one peptide.
-- **Best CA1 stratum oriens signal.** Atlas metadata shows 87 cells located in CA1 SO (MBA:399), the primary soma location of O-LM cells. This is the strongest CA1 SO count among all evaluated clusters.
+- **Best CA1 stratum oriens signal.** Atlas metadata shows 87 cells in CA1 SO, the primary soma location of O-LM cells [1], [2], [3]. This is the strongest CA1 SO count among all evaluated clusters.
 - **Chrna2 expression retained at supertype level.** ABC Atlas filtering on HPF anatomy, GABAergic NT, and Chrna2 expression retains the Sst Gaba_3 supertype while eliminating Sst Gaba_6 entirely [A]. Chrna2 expression is scattered across clusters of this supertype and is not a defining marker at cluster level, but its presence at the supertype level is consistent with an OLM marker profile.
-- **Annotation transfer strongly supports parent Sst Gaba_3 supertype.** MapMyCells annotation transfer of 46 OLM interneurons (GSE124847, Winterer et al. 2019 [7]; cell_type_mapper v1.7.1, raw normalization; WMBv1 CCN20230722) mapped 43/46 cells (93%) to the Sst Gaba_3 supertype (F1 = 0.67 at supertype level; group purity = 0.96; median bootstrap = 1.0). At broader levels the mapping is essentially perfect: 45/46 cells map to Sst Gaba subclass (F1 = 0.68) and to class 07 CTX-MGE GABA (F1 = 0.68). The Sst Gaba_3 supertype, which contains cluster 0769, is the dominant transcriptomic attractor for OLM cells in this atlas.
+- **Annotation transfer strongly supports parent Sst Gaba_3 supertype.** MapMyCells annotation transfer of 46 OLM interneurons (GEO:GSE124847, Winterer et al. 2019 [7]; cell_type_mapper v1.7.1, raw normalization; WMBv1 CCN20230722) mapped 43/46 cells (group purity = 0.96) to the Sst Gaba_3 supertype (F1 = 0.67 at supertype level; median bootstrap = 1.0). At broader levels the mapping is robust: 45/46 cells map to Sst Gaba subclass (F1 = 0.68) and to class 07 CTX-MGE GABA (F1 = 0.68). The Sst Gaba_3 supertype, which contains cluster 0769, is the dominant transcriptomic attractor for OLM cells in this atlas.
+
+### Marker evidence provenance
+
+- **Sst (defining marker):** Evidence is both protein-level (ISH in morphologically reconstructed cells, [6]) and transcript-level (scRNA-seq, [7]). Hooft et al. 2000 [6] confirmed Sst by in situ hybridisation in cells whose axon was reconstructed into stratum lacunosum-moleculare — cell-type specificity is high. Winterer et al. 2019 [7] confirm 100% Sst detection in 46 OLM cells from GSE124847 (re-analysis of raw counts). Sst is CONSISTENT at subclass level for cluster 0769. No provenance concerns.
+- **Chrna2 (defining marker):** Evidence is transcript-level / lineage-based (Chrna2-Cre transgenic mice used to target OLM cells, validated by electrophysiology and morphology, [8]; reviewed in [2]). Leão et al. 2012 [8] identified Chrna2 as a specific OLM marker using optogenetics and patch-clamp on Chrna2-Cre-targeted cells — cell-type specificity is high. In atlas metadata, Chrna2 expression is described as scattered across clusters of the Sst Gaba_3 supertype, not as a defining marker at cluster 0769 specifically. The ABC Atlas filter [A] retains Sst Gaba_3 overall but the per-cluster Chrna2 status for 0769 is unresolved (APPROXIMATE alignment). Source-side Chrna2 detection in OLM cells is well-supported; target-side is only APPROXIMATE. A query of per-cluster Chrna2 expression in the ABC Atlas would resolve whether 0769 or its sibling clusters (e.g. 0768) show higher Chrna2 enrichment.
+- **mGluR1 / Grm1 (defining marker):** Evidence is protein-level (immunostaining paired with electrophysiology and ISH in reconstructed cells, [6]) and transcript-level (scRNA-seq re-analysis, [7]). Hooft et al. 2000 [6] confirmed mGluR1 and mGluR5 protein expression in cells with recorded OLM electrophysiology and morphological reconstruction — cell-type specificity is high. Source-side: Grm1 detected in 44/46 OLM cells (96%) by raw-count re-analysis of GSE124847. **Target-side: Grm1 is not resolvable from atlas metadata for cluster 0769** — it does not appear in the cluster's defining_markers or neuropeptides fields. Source-side confirmed at 96%; target-side still unresolvable from atlas metadata. This is a substantive gap.
+- **Negative markers (PV, CB/Calb1, CR/Calb2, NOS, VIP):** All five are listed on the classical node without a primary citation in the reference index. Exclusion of PV and Calb1 is classically used to distinguish OLM from basket and bistratified cells; exclusion of VIP and CR from interneurons in stratum oriens is a common working assumption. However, no specific citation testing morphology-confirmed OLM cells for these markers appears in the reference index. This is a provenance gap. A targeted cite-traverse for "calbindin OLM hippocampus", "parvalbumin OLM hippocampus", and "VIP OLM hippocampus" is recommended to supply primary citations.
+- **Npy (neuropeptide):** Transcript-level evidence from scRNA-seq [7]. Winterer et al. 2019 [7] report "a surprisingly consistent expression of Npy in OLMs." Cell-type specificity is good — the dataset uses Sst-Cre-selected OLM cells confirmed by morphology. Npy is CONSISTENT at atlas level for cluster 0769.
+- **Pnoc (neuropeptide):** Transcript-level evidence from scRNA-seq [9]. Thulin et al. 2025 [9] identify three Sst/Pnoc subclusters within OLM cells with differential dorsal–ventral connectivity. Pnoc co-expression with Sst is used to define the OLM group in single-cell transcriptomic analysis — cell-type specificity is good. Pnoc is CONSISTENT at atlas level for cluster 0769.
 
 ### Concerns
 
-- **Location APPROXIMATE — extra-hippocampal spread.** While CA1 SO is well represented (87 cells), the cluster also contains 61 cells in prosubiculum and 95 cells in posterior amygdala. The prosubiculum is adjacent to CA1 *(adjacent region — could reflect registration boundary error; weak counter-evidence)*. The posterior amygdala is anatomically distant *(distant region — stronger counter-evidence; canonical OLM cells may still be a subtype of the Sst Gaba_3 T-type, but not the CA1 population specifically)*. The cluster appears to aggregate Sst interneurons from multiple hippocampal-adjacent structures rather than being OLM-specific.
-- **SLM absent from MERFISH location data.** The defining axonal projection to stratum lacunosum-moleculare is not recorded (MERFISH records soma position only — see location note above). Absence of SLM soma signal is expected for OLM cells and is not diagnostic here.
-- **Annotation transfer resolves to supertype, not cluster 0769.** Although Sst Gaba_3 supertype receives strong OLM signal, cluster 0769 specifically received 0/46 cells from the annotation transfer. OLM cells preferentially mapped to sibling cluster 0768 (15/46 cells after bootstrap filtering; best cluster-level F1 = 0.47 for 0768). The mapping is most appropriate at supertype rather than cluster level; the edge to 0769 is a placeholder for the Sst Gaba_3 supertype rather than a confirmed cluster-level match.
-- **mGluR1 (Grm1) not resolvable from atlas metadata.** Grm1 is detected in 96% of OLM cells (GSE124847 re-analysis), but is absent from the cluster's defining_markers or neuropeptides fields in WMBv1 — the comparison cannot be made at cluster level at this time.
-- **Cluster may include non-OLM Sst interneurons.** Prosubiculum (61 cells) and posterior amygdala (95 cells) inflate cell count and reduce specificity for an OLM assignment.
+- **Location APPROXIMATE — extra-hippocampal spread.** CA1 SO is well represented (87 cells), but the cluster also contains 61 cells in prosubiculum and 95 cells in posterior amygdala. The prosubiculum is immediately adjacent to CA1 in the hippocampal formation *(adjacent region — could reflect registration boundary error; weak counter-evidence)*. The posterior amygdala is anatomically distant from CA1 stratum oriens *(distant region — stronger counter-evidence; classical OLM cells may still be a subtype of the Sst Gaba_3 T-type, but not the CA1 stratum oriens population specifically)*. The cluster likely aggregates Sst interneurons from multiple hippocampal-adjacent structures rather than being OLM-specific.
+- **Annotation transfer resolves to supertype, not cluster 0769 specifically.** Although Sst Gaba_3 supertype receives strong OLM signal, cluster 0769 received 0/46 cells from the annotation transfer. OLM cells preferentially mapped to sibling cluster 0768 Sst Gaba_3 (15/46 cells after bootstrap filtering; best cluster-level F1 = 0.47 for cluster 0768 [CS20230722_CLUS_0768]). The mapping is currently most appropriate at supertype rather than cluster level.
+- **Chrna2 APPROXIMATE at cluster level.** Chrna2 expression is present across the Sst Gaba_3 supertype but is not confirmed as a defining marker at cluster 0769 specifically.
+- **mGluR1 (Grm1) NOT_ASSESSED at atlas level.** Despite source-side 96% detection, Grm1 cannot be cross-checked against cluster-level atlas metadata.
 
 ### What would upgrade confidence
 
-- **Annotation transfer at higher resolution (refined experiment).** A round of MapMyCells using a Chrna2-Cre-enriched CA1 stratum oriens dataset would add `AnnotationTransferEvidence` and test whether Chrna2-selected OLM cells converge on cluster 0769 vs 0768 or remain scattered across the Sst Gaba_3 supertype.
-  - *What has already been done:* MapMyCells run on GSE124847 (46 OLM interneurons, Winterer et al. [7]), F1 = 0.67 at Sst Gaba_3 supertype. This resolved subclass (Sst Gaba) and supertype identity and eliminated Sst Gaba_6 and Lamp5 Lhx6 subclasses.
-  - *What remains unresolved:* The within-supertype cluster identity (0769 vs 0768). The existing dataset mixes Sst-OLM and Htr3a-OLM subtypes and is not Chrna2-enriched.
-  - *Refined version:* MapMyCells of Chrna2-Cre-selected CA1 SO neurons. Target: F1 ≥ 0.80 at CLUSTER level within Sst Gaba_3. Expected output: `AnnotationTransferEvidence` on edge_olm_to_wmb_clus_0769.
-- **Targeted transcriptomics of Chrna2+ stratum oriens neurons.** MERFISH or targeted scRNA-seq with spatial layer annotation restricted to Chrna2+ CA1 SO cells would identify which WMBv1 cluster(s) contain Chrna2-high OLM cells, and would add Grm1/mGluR1 expression data on the atlas side. Expected output: `LiteratureEvidence` or `AnnotationTransferEvidence`. Resolves open questions 1 and the Grm1 NOT_ASSESSED caveat.
-- **Morphological validation of CA1 SO cells in cluster 0769.** Patch-seq of CA1 SO cells mapped to this cluster would confirm OLM morphology (axon in SLM) and add `LiteratureEvidence` for the TYPE_A_SPLITS relationship, resolving open question 2.
+- **Chrna2-Cre MapMyCells at cluster resolution (AnnotationTransferEvidence).** Mapping with a Chrna2-Cre-enriched CA1 stratum oriens dataset would test whether Chrna2-selected OLM cells converge on cluster 0769 vs 0768. What has already been done: GSE124847 annotation transfer resolved to Sst Gaba_3 supertype (F1 = 0.67) but placed 0/46 cells at cluster 0769. The existing dataset is not Chrna2-enriched and mixes Sst-OLM and Htr3a-OLM subtypes. Refined target: F1 ≥ 0.80 at CLUSTER level within Sst Gaba_3. Expected output: `AnnotationTransferEvidence` distinguishing whether the edge should point to 0769 or 0768. Resolves open question 2.
+- **Grm1 cluster-level expression query (ATLAS_QUERY).** Querying the ABC Atlas or Allen Cell Types Database for Grm1 expression per cluster within Sst Gaba_3 would convert the NOT_ASSESSED alignment to CONSISTENT or DISCORDANT. Expected output: `ATLAS_QUERY` evidence item. Given the 96% source-side detection, this is a high-priority cross-check.
+- **Targeted transcriptomics of Chrna2+ stratum oriens neurons (LiteratureEvidence or AnnotationTransferEvidence).** MERFISH or scRNA-seq with Chrna2 spatial annotation in CA1 SO. Resolves open question 1 and the Grm1 NOT_ASSESSED gap.
+- **Primary citations for OLM negative markers (LiteratureEvidence).** A cite-traverse on "calbindin OLM hippocampus", "parvalbumin OLM hippocampus", and "VIP OLM hippocampus" would supply citations for PV, Calb1, Calb2, NOS, and VIP negative markers on the classical node — currently all lack primary citations.
 
 ---
 
@@ -86,99 +84,124 @@ Total: 5 edges. Relationship type: TYPE_A_SPLITS (classical OLM maps across mult
 ### Supporting evidence
 
 - **GABA neurotransmitter type consistent.** GABAergic identity is shared with O-LM cells [4], [5].
-- **Both SO and SLM layers represented.** Atlas metadata shows cells in CA3 SO (MBA:486) and CA3 SLM (MBA:471) — both layers of the OLM morphological circuit are present, consistent with a cell type whose soma sits in SO and whose axon innervates SLM.
+- **Both SO and SLM layers represented.** Atlas metadata shows cells in CA3 SO (MBA:486) and CA3 SLM (MBA:471). Both layers of the OLM morphological circuit are present — consistent with a cell type whose soma sits in SO and whose axon zone is SLM. Note that WMBv1 MERFISH records soma position only; cells appearing in SLM in this atlas carry somata in SLM, which is atypical for canonical OLM (whose somata are in SO).
 - **Sst and Pnoc neuropeptides present.** Two of three OLM neuropeptides (Sst, Pnoc) are detected, consistent with partial peptide overlap.
+
+### Marker evidence provenance
+
+- **Sst:** In cluster 0727, Sst appears in neuropeptides but is NOT a defining marker — the subclass is Lamp5 Lhx6, not Sst. Sst expression is present at a level insufficient to define the subclass. The alignment is APPROXIMATE. For OLM, Sst is a defining marker confirmed by ISH in reconstructed cells [6]; a cluster where Sst is only a secondary neuropeptide feature is a substantially weaker match. *(note: it is biologically conceivable that some CA3 Lamp5 Lhx6 interneurons co-express Sst at transcript level without Sst being their primary defining marker.)*
+- **Chrna2:** Not present in this cluster's atlas metadata (alignment NOT_ASSESSED rather than DISCORDANT — absent from metadata rather than confirmed absent at cell level). However, the ABC Atlas Chrna2 filter [A] retained Sst Gaba_3 while leaving Lamp5 Lhx6 unmentioned among surviving supertypes, implying Chrna2 is not characteristically expressed in this lineage. Source-side Chrna2 is well-established as OLM-specific [8], [2]; target-side absence (even if unconfirmed) is a concern.
+- **Npy:** OLM cells consistently express Npy [7]; cluster 0727 has Npy absent (DISCORDANT). This is a marker-level mismatch independent of subclass identity.
+- **mGluR1 / Grm1:** NOT_ASSESSED for this cluster. Source-side 96% detection in 46 OLM cells (GSE124847 re-analysis). Target-side unresolvable from atlas metadata. Same gap as for cluster 0769. Source-side confirmed at 96%; target-side still unresolvable from atlas metadata.
+- **Negative markers:** Same provenance concern as for cluster 0769 — no primary citations in the reference index for PV, Calb1, Calb2, NOS, VIP as OLM negative markers.
 
 ### Concerns
 
-- **Subclass DISCORDANT — Lamp5 Lhx6, not Sst.** This cluster belongs to the Lamp5 Lhx6 subclass. Canonical OLM cells are Sst-defined and MGE-derived. Lamp5 Lhx6 cells are also Lhx6+ (hence MGE-derived) but form a distinct lineage branch in the WMBv1 taxonomy. Sst appears in the neuropeptides field here, not as a defining marker — biologically surprising for a cluster proposed to capture canonical OLM identity.
-- **Npy DISCORDANT.** This cluster lacks Npy, which is consistently expressed in OLM cells [7]. Npy absence disrupts the full neuropeptide triad that helps distinguish OLM from related Sst interneuron types.
-- **Location APPROXIMATE — CA3-enriched, not CA1.** SO and SLM are present but in CA3, not CA1. CA3 is adjacent to CA1 *(adjacent region — could reflect a CA3 OLM-like population or registration overlap; weak counter-evidence on location alone)*, but the absence of CA1 SO signal is notable for canonical OLM.
-- **Annotation transfer: zero cells mapped to Lamp5 Lhx6 subclass.** MapMyCells (GSE124847, 46 OLM cells) mapped 0/46 cells to the Lamp5 Lhx6 subclass; all 45 classified cells mapped to Sst Gaba subclass. This is strong direct counter-evidence against this cluster as an OLM target.
-- **Chrna2 and mGluR1 not assessable.** Both defining OLM markers cannot be evaluated from cluster metadata.
+- **Subclass mismatch — Lamp5 Lhx6, not Sst.** This is the primary biological concern. Canonical OLM cells are Sst-defined and MGE-derived [4], [5], [6]. Lamp5 Lhx6 subclass cells form a distinct lineage branch in the WMBv1 taxonomy. Sst appears in neuropeptides only, not as a defining marker — biologically surprising for a cluster proposed to capture canonical OLM identity. *(note: Lhx6 is characteristically expressed in MGE-derived cells, so Lamp5 Lhx6 cells do share the MGE origin, but their transcriptomic divergence from the Sst subclass is a meaningful concern.)*
+- **Npy DISCORDANT.** Cluster 0727 lacks Npy; Winterer et al. 2019 [7] document consistent Npy expression in OLM cells. This disrupts the full neuropeptide triad that distinguishes OLM from related Sst SO interneuron types.
+- **Location APPROXIMATE — CA3-enriched, not CA1.** SO and SLM are present but in CA3, not CA1. CA3 is adjacent to CA1 *(adjacent region — could reflect a CA3 OLM-like population or registration overlap; weak counter-evidence on location alone)*, but the absence of CA1 SO signal is notable for canonical OLM cells [2], [3].
+- **Annotation transfer: zero cells mapped to Lamp5 Lhx6 subclass.** MapMyCells (GEO:GSE124847, 46 OLM cells) mapped 0/46 cells to the Lamp5 Lhx6 subclass; all 45 classified cells mapped to Sst Gaba subclass. This is strong direct counter-evidence against this cluster as an OLM target.
+- **Chrna2 and mGluR1 not assessable from atlas metadata.** Both defining OLM markers cannot be evaluated from cluster-level fields.
 
 ### What would upgrade confidence
 
-- **Patch-seq of Lamp5-Lhx6 neurons in CA3 stratum oriens.** Would add `LiteratureEvidence` directly testing whether Lamp5-Lhx6 CA3 SO cells have OLM morphology (axon in SLM) and Chrna2/mGluR1 expression. Without morphological and marker confirmation the Lamp5 Lhx6 subclass assignment argues against OLM identity.
-- **Chrna2-Cre + MapMyCells (refined experiment).** Annotation transfer of Chrna2-Cre-selected CA1 SO neurons would test whether any cells map to the Lamp5 Lhx6 subclass, adding `AnnotationTransferEvidence` to this edge. If none map, the edge would be formally demoted to UNCERTAIN.
-  - *What has already been done:* General OLM annotation transfer (GSE124847) already maps 0/46 cells to the Lamp5 Lhx6 subclass.
-  - *What remains unresolved:* Whether the Chrna2+ OLM subpopulation specifically maps here (unlikely given the existing result, but a Chrna2-enriched dataset would provide definitive evidence).
+- **Patch-seq of Lamp5-Lhx6 neurons in CA3 stratum oriens (LiteratureEvidence).** Patch-seq targeting Lamp5-Cre or Lhx6-Cre neurons in CA3 SO would test directly whether any carry OLM morphology (axon in SLM), OLM electrophysiology (theta resonance, Ih sag), and OLM markers (Sst, Chrna2, Grm1). Target: morphological reconstruction in ≥5 cells. Without morphological confirmation, the Lamp5 Lhx6 subclass assignment argues strongly against OLM identity. Resolves open question 3.
+- **Chrna2-Cre MapMyCells (AnnotationTransferEvidence).** Annotation transfer of Chrna2-Cre-selected CA1 SO neurons would determine whether any cells map to Lamp5 Lhx6, adding `AnnotationTransferEvidence` to this edge. The existing result (0/46 cells from a broader OLM dataset) already argues against this, but a Chrna2-enriched source dataset would be definitive. Resolves open question 3.
+- **Targeted literature search.** A cite-traverse for "Lamp5 Lhx6 stratum oriens" or "CGE OLM interneuron hippocampus" would determine whether any published study has described OLM morphology in Lamp5 Lhx6 cells. This gap is addressable by literature review without new experiments and could either elevate or eliminate this edge.
 
 ---
 
 ## Eliminated candidates
 
-All three remaining clusters — 0785 Sst Gaba_6 [CS20230722_CLUS_0785], 0788 Sst Gaba_6 [CS20230722_CLUS_0788], and 0789 Sst Gaba_6 [CS20230722_CLUS_0789] — share a single disqualifying signal: **Chrna2 DISCORDANT**. ABC Atlas filtering on HPF anatomy, GABAergic NT, and Chrna2 expression eliminates the entire Sst Gaba_6 supertype [A]. All three clusters belong to this supertype. In parallel, MapMyCells annotation transfer of 46 OLM cells (GSE124847, Winterer et al. [7]) mapped 0/46 cells to the Sst Gaba_6 supertype; all 45 classified cells went to Sst Gaba_3 instead. Two independent lines of evidence — atlas expression filtering and annotation transfer — converge on the same conclusion.
+All three remaining clusters — 0785 Sst Gaba_6 [CS20230722_CLUS_0785], 0788 Sst Gaba_6 [CS20230722_CLUS_0788], and 0789 Sst Gaba_6 [CS20230722_CLUS_0789] — share a single disqualifying signal: **Chrna2 DISCORDANT across all three**. ABC Atlas filtering on HPF anatomy, GABAergic NT, and Chrna2 expression eliminates the entire Sst Gaba_6 supertype [A]. All three clusters belong to this supertype. MapMyCells annotation transfer of 46 OLM cells (GEO:GSE124847, Winterer et al. [7]) independently mapped 0/46 cells to Sst Gaba_6 for each cluster; all 45 classified cells went to Sst Gaba_3 instead. Two independent lines of evidence — atlas Chrna2 expression filtering and annotation transfer — converge on the same conclusion for all three clusters.
 
 ### 0785 Sst Gaba_6 [CS20230722_CLUS_0785] · 186 cells
 
-- **Chrna2 DISCORDANT (strong).** ABC Atlas Chrna2 expression filter eliminates the Sst Gaba_6 supertype entirely [A]. Chrna2 is a defining marker of OLM cells; its absence at the supertype level is a principal disqualifier.
-- **Annotation transfer: 0/46 cells** mapped to Sst Gaba_6. Zero transcriptomic support for OLM identity.
-- **Location APPROXIMATE — CA3 SO, not CA1 SO.** CA3 is adjacent to CA1 *(adjacent region — weak counter-evidence on location alone)*, but Chrna2 absence and annotation transfer failure are the primary disqualifiers.
-- **Pnoc DISCORDANT.** Pnoc is absent from this cluster, inconsistent with the OLM neuropeptide profile [9].
-- **CA3-enriched, no CA1 SO.** Classical OLM is best characterized in CA1; CA3 enrichment without CA1 representation is inconsistent with canonical OLM anatomy.
+- **Chrna2 DISCORDANT (strong counter-evidence).** ABC Atlas Chrna2 expression filter eliminates the Sst Gaba_6 supertype entirely [A]. Chrna2 is a defining OLM marker [8]; its absence at supertype level is the principal disqualifier.
+- **Annotation transfer: 0/46 cells** mapped to Sst Gaba_6 supertype. Zero transcriptomic support for OLM identity.
+- **Pnoc DISCORDANT.** Pnoc is absent from this cluster, inconsistent with the OLM neuropeptide profile [9]. This is an additional independent marker-level mismatch.
+- **Location APPROXIMATE — CA3 SO only, not CA1 SO.** CA3 SO (39 cells) and CA3 SLM (11 cells) are present. CA3 is adjacent to CA1 *(adjacent region — weak counter-evidence on location alone)*. However, Chrna2 absence and annotation transfer failure are the primary disqualifiers, not location.
+- **Open question:** Given Chrna2 absence and Pnoc discordance, cluster 0785 likely represents a non-OLM Sst stratum oriens interneuron type — possibly oriens-bistratified or back-projecting. No experiments are proposed for this edge pending resolution of supertype identity.
 
 ### 0788 Sst Gaba_6 [CS20230722_CLUS_0788] · 50 cells
 
-- **Chrna2 DISCORDANT (strong).** Same argument as 0785: Sst Gaba_6 supertype eliminated by ABC Atlas Chrna2 expression filter [A].
-- **Annotation transfer: 0/46 cells** mapped to Sst Gaba_6.
-- **Location APPROXIMATE — mixed CA1/CA3 SO, SLM absent.** Small cell counts in SO (CA1 SO: 8 cells, CA3 SO: 13 cells) and no SLM signal. Marginal anatomical alignment.
-- **Low total cell count (50 cells).** Possible contamination from corpus callosum (4 cells noted in caveats). Cluster reliability is uncertain.
-- **Full neuropeptide triad present (plus Cort).** This is the only Sst Gaba_6 cluster with all three OLM neuropeptides — in isolation this would be noteworthy, but it is outweighed by the Chrna2 and annotation transfer disqualifiers.
+- **Chrna2 DISCORDANT (strong counter-evidence).** Sst Gaba_6 supertype eliminated by ABC Atlas Chrna2 expression filter [A].
+- **Annotation transfer: 0/46 cells** mapped to Sst Gaba_6 supertype.
+- **Location APPROXIMATE — small CA1/CA3 SO counts, SLM absent.** CA1 SO: 8 cells, CA3 SO: 13 cells. The CA1 SO signal is present but based on very few cells. CA1 and CA3 are adjacent supertypes *(adjacent regions — weak counter-evidence on location alone)*.
+- **Low cell count (50 total).** Four corpus callosum cells may represent contamination; cluster reliability is uncertain.
+- **Full neuropeptide triad present (plus Cort).** The presence of Sst, Npy, and Pnoc is notable but outweighed by the Chrna2 disqualifier and zero annotation transfer support.
 
 ### 0789 Sst Gaba_6 [CS20230722_CLUS_0789] · 177 cells
 
-- **Chrna2 DISCORDANT (strong).** Sst Gaba_6 supertype eliminated by Chrna2 expression filter [A].
-- **Annotation transfer: 0/46 cells** mapped to Sst Gaba_6.
-- **Location APPROXIMATE — CA3 SO only, no CA1 SO or SLM.** No CA1 SO or SLM signal at all. CA3 is adjacent to CA1 *(adjacent region — weak counter-evidence on location alone)*, but the absence of CA1 and SLM representation is notable.
-- **Major amygdala component (~28% of cells).** Medial amygdala (31 cells) and posterior amygdala (18 cells) together account for ~28% of this cluster. The amygdala is anatomically distant from hippocampal CA1 *(distant region — stronger counter-evidence; any OLM-like cells in amygdala would constitute a distinct population from canonical hippocampal OLM cells)*.
+- **Chrna2 DISCORDANT (strong counter-evidence).** Sst Gaba_6 supertype eliminated by Chrna2 expression filter [A].
+- **Annotation transfer: 0/46 cells** mapped to Sst Gaba_6 supertype.
+- **Location APPROXIMATE — CA3 SO only, no CA1 SO or SLM.** No CA1 SO signal at all; 25 cells in CA3 SO only. CA3 is adjacent to CA1 *(adjacent region — weak counter-evidence on location alone)*, but the complete absence of CA1 representation is notable.
+- **Major amygdala component (~28% of cluster).** Medial amygdala (31 cells) and posterior amygdala (18 cells) together comprise approximately 28% of this cluster. The posterior amygdala is anatomically distant from hippocampal CA1 stratum oriens *(distant region — stronger counter-evidence; amygdalar Sst interneurons represent a distinct population from canonical hippocampal OLM cells)*.
 
 ---
 
 ## Proposed experiments
 
-### Group 1 — Chrna2-Cre targeted annotation transfer (MapMyCells)
+### Annotation transfer — status of completed work
 
-**What has already been done.** MapMyCells annotation transfer of GSE124847 (46 OLM interneurons, Winterer et al. 2019 [7]; cell_type_mapper v1.7.1; WMBv1 CCN20230722) resolved subclass (Sst Gaba), supertype (Sst Gaba_3), and eliminated Sst Gaba_6 and Lamp5 Lhx6 subclasses. F1 = 0.67 at supertype level; 0/46 cells mapped to cluster 0769 specifically.
+MapMyCells annotation transfer (GEO:GSE124847, Winterer et al. 2019 [7]; cell_type_mapper v1.7.1, default parameters, raw normalization; WMBv1 CCN20230722) has already been run on 46 OLM interneurons.
 
-**What remains unresolved.** The within-Sst-Gaba_3 cluster identity (0769 vs sibling cluster 0768). The existing dataset is not Chrna2-enriched and mixes Sst-OLM and Htr3a-OLM subtypes.
+**What this resolved:** Sst Gaba subclass (F1 = 0.68), Sst Gaba_3 supertype (F1 = 0.67, group purity 0.96) confirmed as the OLM mapping target. Sst Gaba_6 supertype eliminated (F1 = 0.0 for all three clusters). Lamp5 Lhx6 subclass eliminated (F1 = 0.0). Both Sst-OLM and Htr3a-OLM subtypes from GSE124847 converge on Sst Gaba_3.
 
-**Refined experiment — Chrna2-Cre-selected CA1 SO → MapMyCells.**
+**What remains unresolved:** The within-Sst-Gaba_3 cluster identity. OLM cells scattered across sibling clusters 0767–0774; best cluster-level recipient was 0768 Sst Gaba_3 (F1 = 0.47, 15/46 cells), not 0769. The existing source dataset is not Chrna2-enriched.
 
-- **What:** MapMyCells (cell_type_mapper, WMBv1 CCN20230722) on Chrna2-Cre-selected CA1 stratum oriens neurons
+A refined annotation transfer experiment using a Chrna2-Cre-selected source is therefore still warranted and is listed as Experiment 1 below.
+
+---
+
+### Group 1 — Chrna2-Cre enriched annotation transfer (MapMyCells)
+
+- **What:** MapMyCells (cell_type_mapper, WMBv1 CCN20230722) on Chrna2-Cre-selected CA1 stratum oriens neurons. Differs from the completed round in using Chrna2 lineage selection to reduce contamination by non-OLM Sst SO interneurons.
 - **Target:** F1 ≥ 0.80 at CLUSTER level within Sst Gaba_3
-- **Expected output:** `AnnotationTransferEvidence` on edge_olm_to_wmb_clus_0769
-- **Resolves:** Open questions 1 and 2; whether the edge should be reassigned from 0769 to 0768 or broadened to supertype level
+- **Expected output:** `AnnotationTransferEvidence` on edge_olm_to_wmb_clus_0769; would determine whether the edge should point to 0769, 0768, or remain at Sst Gaba_3 supertype level
+- **Resolves:** Open questions 1 and 2
 
-### Group 2 — MERFISH or targeted scRNA-seq of Chrna2+ stratum oriens neurons
+### Group 2 — Targeted scRNA-seq or MERFISH of Chrna2+ stratum oriens neurons
 
-- **What:** MERFISH or targeted scRNA-seq with spatial layer annotation restricted to Chrna2+ CA1 SO neurons
-- **Target:** Cluster-level WMBv1 assignment of ≥30 Chrna2+ OLM cells with layer confirmation (soma in SO)
-- **Expected output:** `LiteratureEvidence` or `AnnotationTransferEvidence` on edge_olm_to_wmb_clus_0769; would also provide atlas-side Grm1/mGluR1 expression data
-- **Resolves:** Open question 1 (OLM morphology of CA1 SO cells in 0769); Grm1 NOT_ASSESSED caveat on all edges
+- **What:** MERFISH or targeted scRNA-seq with spatial layer annotation restricted to Chrna2+ CA1 SO neurons; or query of an existing MERFISH dataset that includes Chrna2 in its probe panel
+- **Target:** WMBv1 cluster assignment of ≥30 Chrna2+ OLM cells with layer confirmation (soma in SO)
+- **Expected output:** `LiteratureEvidence` or `AnnotationTransferEvidence` on edge_olm_to_wmb_clus_0769; would also provide atlas-side Grm1/mGluR1 expression data at cluster level
+- **Resolves:** Open question 1; Grm1 NOT_ASSESSED gap on all MODERATE and LOW edges
 
 ### Group 3 — Patch-seq of stratum oriens interneurons
 
-- **What:** Patch-seq (simultaneous electrophysiology, morphology reconstruction, scRNA-seq) of CA1 and CA3 stratum oriens interneurons
-- **Target:** WMBv1 cluster assignment with confirmed OLM morphology (axon in SLM) and Chrna2/mGluR1 expression for ≥10 cells per cluster
-- **Expected output:** `LiteratureEvidence` on edge_olm_to_wmb_clus_0769 (confirm OLM morphology) and edge_olm_to_wmb_clus_0727 (test whether Lamp5-Lhx6 CA3 SO cells have OLM morphology)
-- **Resolves:** Open question 2 (cluster 0769 vs 0768 within Sst Gaba_3); open question 3 (Lamp5-Lhx6 OLM morphology); would also address whether the amygdala population in 0769 is biologically related to OLM
+- **What:** Patch-seq (simultaneous electrophysiology, morphology reconstruction, scRNA-seq) of CA1 and CA3 stratum oriens interneurons; targeting both Sst-Cre and Lamp5-Cre neurons
+- **Target:** WMBv1 cluster assignment with confirmed OLM morphology (axon in SLM) and Chrna2/Grm1 expression in ≥10 cells per cluster
+- **Expected output:** `LiteratureEvidence` on edge_olm_to_wmb_clus_0769 (morphological confirmation of CA1 SO cells in 0769) and edge_olm_to_wmb_clus_0727 (test whether any Lamp5 Lhx6 CA3 SO cells carry OLM morphology)
+- **Resolves:** Open questions 1, 2, and 3
+
+### Group 4 — Atlas query: Grm1 cluster-level expression
+
+- **What:** Query ABC Atlas or Allen Cell Types Database for Grm1 expression specifically in clusters 0767–0774 (Sst Gaba_3 supertype)
+- **Target:** Identify which cluster within Sst Gaba_3 shows highest Grm1 detection rate; compare against 96% source-side rate
+- **Expected output:** `ATLAS_QUERY` evidence item converting the NOT_ASSESSED Grm1 alignment to CONSISTENT or DISCORDANT
+- **Resolves:** Grm1 NOT_ASSESSED gap on all MODERATE and LOW edges (open across edge_olm_to_wmb_clus_0769 and edge_olm_to_wmb_clus_0727)
+
+### Group 5 — Targeted literature search: OLM negative markers
+
+- **What:** Cite-traverse on "calbindin OLM hippocampus", "calretinin OLM hippocampus", "parvalbumin OLM hippocampus", "NOS OLM hippocampus", "VIP OLM hippocampus". Objective: find primary studies that confirmed OLM identity (morphological reconstruction or electrophysiology) and tested PV, Calb1, Calb2, NOS, VIP expression.
+- **Target:** ≥1 primary citation per negative marker with morphology-confirmed OLM cells
+- **Expected output:** `LiteratureEvidence` for each negative marker on the classical node
+- **Resolves:** Marker evidence provenance gap for all five negative markers; no new experiments required beyond literature search
 
 ---
 
 ## Open questions
 
-1. **Are the CA1 SO cells in cluster 0769 [CS20230722_CLUS_0769] OLM-morphology?** Atlas metadata shows 87 CA1 SO cells but MERFISH records soma position only — axonal projection to SLM is unverified. What are the posterior amygdala cells (n=95) within the same cluster? *(edge_olm_to_wmb_clus_0769)*
+1. **Are the CA1 SO cells in cluster 0769 [CS20230722_CLUS_0769] OLM-morphology?** Atlas MERFISH records soma position only — axonal projection to SLM is unverified for the 87 CA1 SO cells. What are the posterior amygdala cells (n=95) within the same cluster? *(edge_olm_to_wmb_clus_0769)*
 
-2. **Why do OLM cells map to cluster 0768 rather than 0769 in the annotation transfer?** Do clusters 0768 and 0769 differ in hippocampal enrichment, Chrna2 expression, or other properties relevant to OLM identity? Should the edge be reassigned to 0768 or broadened to Sst Gaba_3 supertype level? *(edge_olm_to_wmb_clus_0769)*
+2. **Why do OLM cells map to cluster 0768 rather than 0769 in the annotation transfer?** Do clusters 0768 Sst Gaba_3 and 0769 Sst Gaba_3 differ in hippocampal enrichment, Chrna2 expression, or other OLM-relevant properties? Should the edge be reassigned to 0768 or broadened to Sst Gaba_3 supertype level? *(edge_olm_to_wmb_clus_0769)*
 
-3. **Is Sst expression in cluster 0727 Lamp5 Lhx6 Gaba_1 [CS20230722_CLUS_0727] biologically meaningful for OLM?** Does this cluster contain cells with OLM morphology or electrophysiology? The Lamp5 Lhx6 lineage is unexpected for canonical MGE-derived Sst+ OLM cells. *(edge_olm_to_wmb_clus_0727)*
+3. **Is Sst expression in cluster 0727 Lamp5 Lhx6 Gaba_1 [CS20230722_CLUS_0727] biologically meaningful for OLM identity?** Does this cluster contain cells with OLM morphology or electrophysiology? The Lamp5 Lhx6 subclass lineage is unexpected for canonical MGE-derived Sst+ OLM cells. *(edge_olm_to_wmb_clus_0727)*
 
-4. **Given Chrna2 absence from Sst Gaba_6, is cluster 0785 [CS20230722_CLUS_0785] a non-OLM Sst stratum oriens type?** If so, what classical interneuron type does it represent (oriens-bistratified, back-projecting, other)? *(edge_olm_to_wmb_clus_0785)*
+4. **Given Chrna2 absence from Sst Gaba_6, are clusters 0785, 0788, and 0789 non-OLM Sst stratum oriens types?** If so, what classical interneuron types do they represent (oriens-bistratified, back-projecting, hippocampal Sst without OLM morphology, other)? *(shared across edges 0785, 0788, 0789)*
 
-5. **Are the CA3 SO / CA1 SO cells in cluster 0788 [CS20230722_CLUS_0788] OLM-morphology?** What are the corpus callosum cells (n=4) — biological or contamination? *(edge_olm_to_wmb_clus_0788)*
-
-6. **Are the CA3 SO cells in cluster 0789 [CS20230722_CLUS_0789] OLM-like?** What is the biological identity of the amygdala population (~28% of cluster, 49 cells total)? *(edge_olm_to_wmb_clus_0789)*
+5. **What is the biological identity of the posterior amygdala population in cluster 0769 (n=95) and 0789 (n=49)?** Are these Sst interneurons molecularly related to hippocampal OLM cells, or are they co-clustered incidentally? *(edges 0769 and 0789)*
 
 ---
 

--- a/schema/celltype_mapping.yaml
+++ b/schema/celltype_mapping.yaml
@@ -26,6 +26,10 @@
 #                               AnnotationTransferEvidence: source_species, target_species added;
 #                               nt_consistent_with_classical deprecated (superseded by property_comparisons);
 #                               OntologyTerm: name_in_source added as required field (always record)
+# Version: 0.6.2 (2026-04-21) — MappingRelationship.CANDIDATE_SYNONYM: split-first extraction default;
+#                               provisional same-type edges resolvable by curation
+# Version: 0.6.1 (2026-04-21) — TypeSynonym class + SynonymType enum + CellTypeNode.synonyms field;
+#                               evidence-backed synonym capture for lit mining query expansion
 # Version: 0.6.0 (2026-04-09) — AnatomicalLocation class (OntologyTerm mixin) + CellCompartment enum (BREAKING);
 #                               anatomical_location range: OntologyTerm → AnatomicalLocation on CellTypeNode
 #                               and AtlasMetadataEvidence; formalises soma vs projection location (S2)
@@ -173,6 +177,23 @@ enums:
           A type description being built up from multiple evidence types; may eventually
           become a new or revised CL term. Not yet anchored to a single classical or T-type definition.
 
+  # ── Synonym type ────────────────────────────────────────────────
+  SynonymType:
+    description: Category of alternative name for a cell type.
+    permissible_values:
+      ABBREVIATION:
+        description: Short form or acronym, e.g. "OLM" for "oriens-lacunosum moleculare"
+      HISTORICAL:
+        description: Deprecated or superseded name still found in older literature
+      ATLAS_LABEL:
+        description: >
+          An atlas cluster or cell set label used as a cell type name in papers
+          (e.g. "Sst Gaba_3" used to refer to OLM cells in an atlas-integrated study)
+      CROSS_SPECIES:
+        description: Name used for the equivalent type in a different species
+      INFORMAL:
+        description: Community-specific colloquial term not formally defined in a publication
+
   # ── Taxonomy levels ─────────────────────────────────────────────
   # TaxonomyLevel enum removed in v0.4: level names are atlas-specific.
   # taxonomy_level fields now use free strings. Common values:
@@ -225,6 +246,23 @@ enums:
       UNCERTAIN:
         description: >
           Evidence is insufficient or contradictory to determine relationship type.
+      CANDIDATE_SYNONYM:
+        description: >
+          The two nodes may refer to the same cell type but this has not been
+          confirmed by a curator. Used by extraction agents when two names or
+          descriptions appear to overlap but the evidence is insufficient to merge.
+
+          This is a provisional relationship: extraction agents should prefer
+          creating two nodes + CANDIDATE_SYNONYM over collapsing to one node
+          (split-first principle — merging is easier than splitting).
+
+          Resolution: a curator either confirms (→ migrate evidence to one node,
+          mark the other deprecated, or record as EQUIVALENT) or rejects
+          (→ document the distinguishing feature in caveats; change to a more
+          specific relationship type such as PARTIAL_OVERLAP or UNCERTAIN).
+
+          Queryable: "show all unresolved CANDIDATE_SYNONYM edges" surfaces
+          pending curation decisions without blocking KB construction.
 
   # ── Mapping confidence ──────────────────────────────────────────
   MappingConfidence:
@@ -616,6 +654,39 @@ classes:
           embedding full text in the KB YAML. Set by asta-report-ingest and
           cite-traverse workflows. Reports dereference to include snippet text.
 
+  TypeSynonym:
+    description: >
+      An alternative name or abbreviation for a cell type, with evidence provenance.
+      Captures the name as used in specific sources — abbreviations, historical terms,
+      atlas labels, informal community terms. Sources cite the papers where this name
+      is used or defined, enabling synonym-expanded queries in lit mining.
+
+      Population guidance: extract synonyms as the first processing step for each paper.
+      Set snippet to the passage where the name is introduced or defined. Multiple
+      sources if the term appears across several papers.
+    attributes:
+      term:
+        required: true
+        description: >
+          The synonym string exactly as used in the source. Required.
+          Examples: "OLM", "O-LM interneuron", "oriens-lacunosum moleculare cell",
+          "Sst Gaba_3" (when used as a cell type name in a paper).
+      synonym_type:
+        range: SynonymType
+        description: >
+          Category of synonym — ABBREVIATION, HISTORICAL, ATLAS_LABEL,
+          CROSS_SPECIES, or INFORMAL. Omit if unclear.
+      sources:
+        multivalued: true
+        inlined_as_list: true
+        range: PropertySource
+        description: >
+          Papers where this synonym is used for this cell type. Each PropertySource:
+          ref = citing paper; snippet = passage where name is defined or first used
+          (quote_key also accepted); method = how the name is used in context
+          (e.g. "primary label throughout", "defined in introduction as abbreviation").
+          Multiple sources if the term appears across multiple papers.
+
   MarkerSource:
     is_a: PropertySource
     mixins:
@@ -807,6 +878,22 @@ classes:
       name:
         required: true
         description: Human-readable name, e.g. "Lugaro cell", "CB PLI Gly-Gaba_2 (supertype 1145)"
+      synonyms:
+        range: TypeSynonym
+        multivalued: true
+        inlined_as_list: true
+        description: >
+          Alternative names and abbreviations for this cell type, with evidence provenance.
+          Populated during literature mining — synonym extraction is the first processing
+          step for each paper (both survey and targeted paths). Used to expand queries
+          in subsequent searches.
+
+          Include all forms that appear in the literature or atlases: abbreviations
+          (OLM), long forms if non-obvious, historical names, atlas labels used as
+          cell type names. Do NOT include the canonical name field value itself.
+
+          For ATLAS_TRANSCRIPTOMIC nodes: include the atlas cluster label in synonyms
+          only if that label is used as a cell type name in at least one non-atlas paper.
       definition_basis:
         required: true
         range: DefinitionBasis

--- a/src/evidencell/paths.py
+++ b/src/evidencell/paths.py
@@ -5,6 +5,7 @@ artefacts, and reports lives here.
 """
 
 from pathlib import Path
+import yaml
 
 
 def repo_root() -> Path:
@@ -15,6 +16,40 @@ def repo_root() -> Path:
             return p
         p = p.parent
     raise RuntimeError("Cannot locate repo root (no schema/ directory found)")
+
+
+def find_node_file(node_id: str) -> Path:
+    """Return the YAML file that contains the CellTypeNode with this node_id.
+
+    This is the stable interface between workflows and KB file layout.
+    Workflows should always call this rather than constructing paths directly —
+    the implementation will change as the KB is restructured:
+
+      Phase 0 (current): scan kb/draft/ and kb/mappings/ for a YAML containing
+        the node_id. Slow for large corpora but correct.
+      Phase 1 (post-M8): query kb/index.db (SQLite node→file map). Fast O(1).
+      Phase 2 (post-M7): direct path kb/nodes/{region}/{node_id}.yaml.
+
+    Raises FileNotFoundError if no YAML in the KB contains the node_id.
+    """
+    root = repo_root()
+    for kb_dir in (root / "kb" / "draft", root / "kb" / "mappings"):
+        if not kb_dir.exists():
+            continue
+        for yaml_file in sorted(kb_dir.rglob("*.yaml")):
+            try:
+                with yaml_file.open() as fh:
+                    data = yaml.safe_load(fh)
+            except Exception:
+                continue
+            nodes = data.get("nodes", []) if isinstance(data, dict) else []
+            for node in nodes:
+                if isinstance(node, dict) and node.get("id") == node_id:
+                    return yaml_file
+    raise FileNotFoundError(
+        f"Node '{node_id}' not found in any KB YAML under kb/draft/ or kb/mappings/. "
+        "Check node_id spelling or run 'just qc' to validate the KB."
+    )
 
 
 def region_from_graph(graph_file: Path) -> str:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from evidencell.paths import (
+    find_node_file,
     region_from_graph,
     refs_path_for_graph,
     refs_path_for_region,
@@ -63,3 +64,20 @@ def test_reports_dir_for_region():
 def test_research_dir_for_region():
     root = repo_root()
     assert research_dir_for_region("cerebellum") == root / "research" / "cerebellum"
+
+
+def test_find_node_file_known_node():
+    """find_node_file returns a YAML path containing the requested node."""
+    path = find_node_file("olm_hippocampus")
+    assert path.exists()
+    assert path.suffix == ".yaml"
+    import yaml
+    data = yaml.safe_load(path.read_text())
+    node_ids = [n.get("id") for n in data.get("nodes", []) if isinstance(n, dict)]
+    assert "olm_hippocampus" in node_ids
+
+
+def test_find_node_file_missing_node():
+    """find_node_file raises FileNotFoundError for unknown node_id."""
+    with pytest.raises(FileNotFoundError, match="not found in any KB YAML"):
+        find_node_file("this_node_does_not_exist_xyz")

--- a/workflows/lit-review.md
+++ b/workflows/lit-review.md
@@ -1,5 +1,8 @@
 # Literature Review Orchestrator
 
+> **STATUS: UNDER DEVELOPMENT — EXPERIMENTAL. DO NOT USE IN REGULAR WORKFLOWS.**
+> Design is being revised. See `planning/` for current thinking on discovery vs targeted search.
+
 You are a literature review coordinator. You delegate to focused subagents with
 **exact prompts** — you never search, extract, or synthesize directly. Data flows
 through files on disk, not through context windows.


### PR DESCRIPTION
Planning:
- planning/adaptive_mapping_loop_design.md: AT-before-edge-framing design
- planning/workflow_architecture_design.md: Survey vs Targeted architecture, pipeline diagram, synonym capture, KB flags, cite-traverse as skill, split-first principle

Schema (v0.6.2):
- v0.6.1: TypeSynonym class + SynonymType enum + CellTypeNode.synonyms field
- v0.6.2: MappingRelationship.CANDIDATE_SYNONYM for split-first extraction default

KB interface:
- src/evidencell/paths.py: find_node_file(node_id) — stable interface across M7/M8 file layout restructuring; tests added
- workflows/lit-review.md: marked EXPERIMENTAL DO NOT USE

ROADMAP:
- ADAPT milestone added
- ARCH milestone added (Survey/Targeted refactor)
- M7 updated: per-node file layout, depends on M8
- M8 updated: KB index + taxonomy DB, do before M7

Reports:
- olm_hippocampus_summary.md regenerated (validated)
- olm_hippocampus_drilldown_Winterer2019.md added (25 verbatim quotes, validated)