### PR TITLE
Fix/uberon mba name fallback

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -390,6 +390,42 @@ sources and heterogeneity notes should be in `sources` or `notes` fields.
 Convention rule for CLAUDE.md: "never put data in YAML comments that could go
 in a structured field."
 
+**S4. Dual MBA + UBERON anatomy annotation.** 🔲 Pending
+
+Classical nodes currently use UBERON IDs for soma locations, but UBERON→MBA xref
+coverage is poor (many hippocampal layer terms have no MBA xref, or map to wrong
+MBA regions — e.g. UBERON:0005383 "stratum oriens" → MBA:672 "Caudoputamen").
+The `find_candidates()` name-based fallback (`_resolve_mba_by_name`) mitigates
+this at query time, but the root cause is that lit-extracted annotations don't
+capture MBA IDs.
+
+**Goal**: Annotate classical node anatomy with **both** UBERON and MBA IDs at
+ingest time. MBA is the spatial reference for atlas matching; UBERON provides
+cross-species semantic grounding.
+
+**Implementation options**:
+- MBA lookup via OLS4 (`mcp__ols4__search` for MBA terms) during lit extraction
+- Local MBA label matching against the taxonomy DB `anat_terms` table
+- Shared skill (`.claude/skills/annotate-anatomy.md`) usable by both
+  `asta-report-ingest` and `survey` orchestrators
+
+**Touches**: `asta-report-ingest.md`, `survey.md` (when built), potentially a
+shared anatomy annotation skill. Also consider adding MBA→UBERON cross-references
+to `anat_terms` table for bidirectional lookup.
+
+**S5. Iterative mapping refinement infrastructure.** 🔲 Pending
+
+Current workflow gates (Step 1, Step 4) assume human review at each mapping.
+At scale (15+ types per region), this doesn't work. Need infrastructure for:
+- Liberal initial KB writes (LOW/UNCERTAIN confidence edges written without
+  per-edge curator approval)
+- Iterative confidence upgrade as evidence accumulates (lit review, AT, expression
+  cross-checks)
+- Pruning: strong counter-evidence triggers edge removal or downgrade, with
+  provenance trail
+- Batch review: curator reviews a region's mapping table periodically, not
+  per-edge as generated
+
 ### Open questions
 - Should `CROSS_SPECIES_EXTRAPOLATION` be a structured field on `MappingEdge` (more queryable) or remain a free-text caveat?
 

--- a/kb/draft/hippocampus/hippocampus_GABAergic_interneurons.yaml
+++ b/kb/draft/hippocampus/hippocampus_GABAergic_interneurons.yaml
@@ -1,15 +1,19 @@
 name: Hippocampal GABAergic interneurons — draft classical types
-description: |
-  Draft evidence graph for classical hippocampal GABAergic interneuron types extracted from ASTA deep research report. Node properties are synthesis-derived and require primary literature verification. Edges empty pending mapping evidence.
-target_atlas: TBD
+description: 'Draft evidence graph for classical hippocampal GABAergic interneuron types extracted from ASTA deep research
+  report. Node properties are synthesis-derived and require primary literature verification. Edges empty pending mapping evidence.
+
+  '
+target_atlas: WMBv1 (CCN20230722)
 brain_region:
   id: UBERON:0002421
   label: hippocampal formation
   name_in_source: hippocampus
 species: null
 creation_date: '2026-04-09'
-notes: |
-  All nodes are CLASSICAL_MULTIMODAL. Species field left null — most evidence is from rat and mouse; species must be confirmed per-node from primary sources. Marker ncbi_gene_ids left null — require NodeNormalization lookup.
+notes: 'All nodes are CLASSICAL_MULTIMODAL. Species field left null — most evidence is from rat and mouse; species must be
+  confirmed per-node from primary sources. Marker ncbi_gene_ids left null — require NodeNormalization lookup.
+
+  '
 nodes:
 - id: pv_basket_cell_hippocampus
   name: Parvalbumin-positive basket cell
@@ -95,8 +99,10 @@ nodes:
       scope: rat hippocampus
       quote_key: 10540334_418c51dd
   neuropeptides: []
-  electrophysiology_class: |
-    Fast-spiking (80% of PV+ INs); sustained firing >200 Hz; bursts up to 150 Hz during ripples; short-duration APs with large rapid AHPs
+  electrophysiology_class: 'Fast-spiking (80% of PV+ INs); sustained firing >200 Hz; bursts up to 150 Hz during ripples; short-duration
+    APs with large rapid AHPs
+
+    '
   ephys_sources:
   - ref: PMID:33150866
     method: patch clamp
@@ -124,8 +130,10 @@ nodes:
     method: review
     scope: hippocampus
     quote_key: 259953057_cf3393b3
-  morphology_notes: |
-    Perisomatic-targeting interneuron forming dense plexus of inhibitory terminals on soma of pyramidal cells; axon collaterals confined to pyramidal layer; single basket cell contacts >1500 pyramidal neurons and 60 other PV+ interneurons
+  morphology_notes: 'Perisomatic-targeting interneuron forming dense plexus of inhibitory terminals on soma of pyramidal cells;
+    axon collaterals confined to pyramidal layer; single basket cell contacts >1500 pyramidal neurons and 60 other PV+ interneurons
+
+    '
   morphology_sources:
   - ref: PMID:7472426
     method: biocytin fill in vivo
@@ -145,8 +153,10 @@ nodes:
       label: basket cell
       name_in_source: basket cell
     mapping_type: BROAD
-    mapping_notes: |
-      CL:0000118 covers perisomatic-targeting GABAergic interneurons but does not capture PV-specific identity. No hippocampus-specific PV basket cell term exists in CL.
+    mapping_notes: 'CL:0000118 covers perisomatic-targeting GABAergic interneurons but does not capture PV-specific identity.
+      No hippocampus-specific PV basket cell term exists in CL.
+
+      '
   definition_references:
   - PMID:7472426
   - PMID:29383328
@@ -154,9 +164,13 @@ nodes:
   - PMID:29321728
   - PMID:26441554
   is_terminal: false
-  notes: |
-    Four morphological subtypes within PV+ INs (basket, axo-axonic, bistratified, radiatum-targeting). 7-14 PV transcriptomic subtypes in CA1. Activity inversely coupled with CCK basket cell activity.
-    [cite_traverse_2026_04_10] PMID:39401246: the most representative ones, the PV-expressing basket and bistratified cells, the NOS-expressing ivy cells and 2 types of interneuron-selective interneurons (ISI 1 and 3) that express calretinin
+  notes: 'Four morphological subtypes within PV+ INs (basket, axo-axonic, bistratified, radiatum-targeting). 7-14 PV transcriptomic
+    subtypes in CA1. Activity inversely coupled with CCK basket cell activity.
+
+    [cite_traverse_2026_04_10] PMID:39401246: the most representative ones, the PV-expressing basket and bistratified cells,
+    the NOS-expressing ivy cells and 2 types of interneuron-selective interneurons (ISI 1 and 3) that express calretinin
+
+    '
 - id: cck_basket_cell_hippocampus
   name: Cholecystokinin-positive basket cell
   definition_basis: CLASSICAL_MULTIMODAL
@@ -252,8 +266,10 @@ nodes:
       method: immunohistochemistry
       scope: rat hippocampus
       quote_key: 480205_62cd73ae
-  electrophysiology_class: |
-    Regular-spiking; low in vivo firing frequency (2-10 Hz); during theta oscillations fire at 8.8 +/- 3.3 Hz on ascending phase; 1.7 +/- 2.0 Hz during ripples; episode-dependent firing
+  electrophysiology_class: 'Regular-spiking; low in vivo firing frequency (2-10 Hz); during theta oscillations fire at 8.8
+    +/- 3.3 Hz on ascending phase; 1.7 +/- 2.0 Hz during ripples; episode-dependent firing
+
+    '
   ephys_sources:
   - ref: PMID:16237182
     method: in vivo recording + juxtacellular labeling
@@ -277,8 +293,10 @@ nodes:
       vs. KChIP4e and DPP6S)
     support: SUPPORT
     source: cite_traverse_2026_04_10
-  morphology_notes: |
-    Perisomatic-targeting interneuron; CB1R+ axon terminals surround somata and proximal dendrites of pyramidal neurons; 96.9% of CCK+ INs express CB1. Dense plexus of inhibitory terminals on soma and proximal dendrites.
+  morphology_notes: 'Perisomatic-targeting interneuron; CB1R+ axon terminals surround somata and proximal dendrites of pyramidal
+    neurons; 96.9% of CCK+ INs express CB1. Dense plexus of inhibitory terminals on soma and proximal dendrites.
+
+    '
   morphology_sources:
   - ref: PMID:10341254
     method: immunohistochemistry + EM
@@ -302,8 +320,10 @@ nodes:
       label: basket cell
       name_in_source: basket cell
     mapping_type: BROAD
-    mapping_notes: |
-      CL:0000118 covers perisomatic morphology but does not capture CCK/CB1R marker identity or regular-spiking firing pattern. No CCK-specific basket cell term in CL.
+    mapping_notes: 'CL:0000118 covers perisomatic morphology but does not capture CCK/CB1R marker identity or regular-spiking
+      firing pattern. No CCK-specific basket cell term in CL.
+
+      '
   definition_references:
   - PMID:10341254
   - PMID:16237182
@@ -311,10 +331,15 @@ nodes:
   - PMID:33529646
   - PMID:26441554
   is_terminal: false
-  notes: |
-    CCK cells are remarkably diverse, extending beyond Sncg transcriptomic class. Activity inversely scales with PV cell activity.
+  notes: 'CCK cells are remarkably diverse, extending beyond Sncg transcriptomic class. Activity inversely scales with PV
+    cell activity.
+
     [cite_traverse_2026_04_10] PMID:26689544: CCK+ interneurons are the plastic and dynamic gate-keepers of neuronal circuits
-    [cite_traverse_2026_04_10] PMID:28009257: CCK+ basket cells have never been observed to receive direct monosynaptic excitement from local CA1 pyramidal cells
+
+    [cite_traverse_2026_04_10] PMID:28009257: CCK+ basket cells have never been observed to receive direct monosynaptic excitement
+    from local CA1 pyramidal cells
+
+    '
 - id: axo_axonic_cell_hippocampus
   name: Axo-axonic (chandelier) cell
   definition_basis: CLASSICAL_MULTIMODAL
@@ -376,8 +401,10 @@ nodes:
       have lower firing rates despite their low firing threshold
     support: SUPPORT
     source: cite_traverse_2026_04_10
-  morphology_notes: |
-    PV+ interneuron specifically targeting axon initial segment of pyramidal cells; cartridge-like axonal bouton arrays. Controls spike initiation.
+  morphology_notes: 'PV+ interneuron specifically targeting axon initial segment of pyramidal cells; cartridge-like axonal
+    bouton arrays. Controls spike initiation.
+
+    '
   morphology_sources:
   - ref: PMID:23162426
     method: review
@@ -393,15 +420,19 @@ nodes:
       label: pvalb chandelier GABAergic interneuron
       name_in_source: axo-axonic cell
     mapping_type: EXACT
-    mapping_notes: |
-      CL:4023036 definition matches precisely: cartridge boutons targeting exclusively AIS of pyramidal cells, fast-spiking PV+ interneuron.
+    mapping_notes: 'CL:4023036 definition matches precisely: cartridge boutons targeting exclusively AIS of pyramidal cells,
+      fast-spiking PV+ interneuron.
+
+      '
   definition_references:
   - PMID:23162426
   - PMID:33150866
   - PMID:7472426
   is_terminal: false
-  notes: |
-    One of three canonical PV+ interneuron subtypes alongside basket and bistratified cells. Limited hippocampus-specific ephys data in this reference set.
+  notes: 'One of three canonical PV+ interneuron subtypes alongside basket and bistratified cells. Limited hippocampus-specific
+    ephys data in this reference set.
+
+    '
 - id: bistratified_cell_hippocampus
   name: Bistratified cell
   definition_basis: CLASSICAL_MULTIMODAL
@@ -492,8 +523,9 @@ nodes:
       method: intersectional genetics
       scope: mouse hippocampus
       quote_key: 269246896_c084d5c0
-  electrophysiology_class: |
-    Regular-spiking; mediates feedforward inhibition of CA1 pyramidal cells together with basket cells
+  electrophysiology_class: 'Regular-spiking; mediates feedforward inhibition of CA1 pyramidal cells together with basket cells
+
+    '
   ephys_sources:
   - ref: PMID:26594151
     method: in vitro recording
@@ -503,8 +535,10 @@ nodes:
     method: patch clamp
     scope: mouse hippocampus
     quote_key: 221276443_e917908b
-  morphology_notes: |
-    Dendritic-targeting interneuron with axonal arbor in stratum oriens and stratum radiatum; innervates dendritic domains of pyramidal cells.
+  morphology_notes: 'Dendritic-targeting interneuron with axonal arbor in stratum oriens and stratum radiatum; innervates
+    dendritic domains of pyramidal cells.
+
+    '
   morphology_sources:
   - ref: PMID:26594151
     method: electrophysiology + morphology
@@ -529,18 +563,26 @@ nodes:
       label: bistratified cell
       name_in_source: bistratified cell
     mapping_type: BROAD
-    mapping_notes: |
-      CL:0004247 is retinal-focused. The hippocampal bistratified interneuron (Pvalb/Sst/Tac1+, axon in SO and SR) has no dedicated CL term.
+    mapping_notes: 'CL:0004247 is retinal-focused. The hippocampal bistratified interneuron (Pvalb/Sst/Tac1+, axon in SO and
+      SR) has no dedicated CL term.
+
+      '
   definition_references:
   - PMID:26594151
   - PMID:38640347
   - PMID:23162426
   - PMID:33150866
   is_terminal: false
-  notes: |
-    Sst::Tac1 intersectional genetics targets bistratified cells that overwhelmingly target fast-spiking interneurons (Chamberland et al., 2024).
-    [cite_traverse_2026_04_10] PMID:26594151: Separate FFI by basket and bistratified respectively modulated CA1PC threshold and gain
-    [cite_traverse_2026_04_10] PMID:33361464: This earlier study focused on seven dendritic-targeting neuron types: Pyramidal, Bistratified, Ivy, Neurogliaform, Perforant Path-Associated, Schaffer Collateral-Associated
+  notes: 'Sst::Tac1 intersectional genetics targets bistratified cells that overwhelmingly target fast-spiking interneurons
+    (Chamberland et al., 2024).
+
+    [cite_traverse_2026_04_10] PMID:26594151: Separate FFI by basket and bistratified respectively modulated CA1PC threshold
+    and gain
+
+    [cite_traverse_2026_04_10] PMID:33361464: This earlier study focused on seven dendritic-targeting neuron types: Pyramidal,
+    Bistratified, Ivy, Neurogliaform, Perforant Path-Associated, Schaffer Collateral-Associated
+
+    '
 - id: olm_cell_ca1
   name: Oriens-Lacunosum Moleculare (O-LM) cell
   definition_basis: CLASSICAL_MULTIMODAL
@@ -675,8 +717,10 @@ nodes:
       method: single-cell RT-PCR
       scope: mouse OLM
       quote_key: 201041756_1d20426d
-  electrophysiology_class: |
-    Regular-to-fast spiking with adapting firing pattern; prominent hyperpolarization-induced sag (Ih hallmark); theta-frequency phase-locked firing; theta spiking resonance dependent on HCN channels
+  electrophysiology_class: 'Regular-to-fast spiking with adapting firing pattern; prominent hyperpolarization-induced sag
+    (Ih hallmark); theta-frequency phase-locked firing; theta spiking resonance dependent on HCN channels
+
+    '
   ephys_sources:
   - ref: PMID:30987110
     method: patch clamp
@@ -694,8 +738,11 @@ nodes:
     method: review
     scope: hippocampus
     quote_key: 14052756_939155df
-  morphology_notes: |
-    Soma and horizontal dendrites confined to stratum oriens, often with spines; axon projects perpendicularly through SR to stratum lacunosum-moleculare where it forms dense varicose terminal arbor; collateral axons also in stratum oriens. Large elongated soma at oriens-alveus border. Stereotyped morphology first described by Cajal (1893).
+  morphology_notes: 'Soma and horizontal dendrites confined to stratum oriens, often with spines; axon projects perpendicularly
+    through SR to stratum lacunosum-moleculare where it forms dense varicose terminal arbor; collateral axons also in stratum
+    oriens. Large elongated soma at oriens-alveus border. Stereotyped morphology first described by Cajal (1893).
+
+    '
   morphology_sources:
   - ref: PMID:20421280
     method: biocytin fill
@@ -734,10 +781,19 @@ nodes:
   - PMID:29487503
   - PMID:37652281
   is_terminal: false
-  notes: |
-    No CL term exists for OLM cell. CL:4023017 'sst GABAergic interneuron' is nearest superclass but does not capture OLM-specific morphology. Molecularly heterogeneous: contains a PV+ subpopulation with distinct theta vs gamma coupling. Npy expression is consistent in mouse but absent in rat (species difference). Ndnf::Nkx2-1 intersection selectively targets OLM cells. At least 3 Chrna2+ subclusters identified.
-    [cite_traverse_2026_04_10] PMID:19176803: horizontal interneurons in stratum oriens of the hippocampal CA1 area are often studied as a single group of interneurons, they include several cell types in addition to O-LM cells
-    [cite_traverse_2026_04_10] PMID:20463218: dendrite-targeting inhibitory interneurons, such as oriens lacunosum-moleculare (O-LM) cells, regulate dendritic Na+ or Ca2+ spikes and synaptic plasticity by innervating dendritic domains of principal neurons
+  notes: 'No CL term exists for OLM cell. CL:4023017 ''sst GABAergic interneuron'' is nearest superclass but does not capture
+    OLM-specific morphology. Molecularly heterogeneous: contains a PV+ subpopulation with distinct theta vs gamma coupling.
+    Npy expression is consistent in mouse but absent in rat (species difference). Ndnf::Nkx2-1 intersection selectively targets
+    OLM cells. At least 3 Chrna2+ subclusters identified.
+
+    [cite_traverse_2026_04_10] PMID:19176803: horizontal interneurons in stratum oriens of the hippocampal CA1 area are often
+    studied as a single group of interneurons, they include several cell types in addition to O-LM cells
+
+    [cite_traverse_2026_04_10] PMID:20463218: dendrite-targeting inhibitory interneurons, such as oriens lacunosum-moleculare
+    (O-LM) cells, regulate dendritic Na+ or Ca2+ spikes and synaptic plasticity by innervating dendritic domains of principal
+    neurons
+
+    '
 - id: hippocampo_septal_cell_ca1
   name: Hippocampo-septal (HS) cell
   definition_basis: CLASSICAL_MULTIMODAL
@@ -797,8 +853,10 @@ nodes:
     ncbi_gene_id: null
   electrophysiology_class: Not characterized in available reference set
   ephys_sources: []
-  morphology_notes: |
-    Long-range projecting SOM+ interneuron with soma in stratum oriens; projects to medial septum. Distinguished from OLM cell by presence of long-range projection axon.
+  morphology_notes: 'Long-range projecting SOM+ interneuron with soma in stratum oriens; projects to medial septum. Distinguished
+    from OLM cell by presence of long-range projection axon.
+
+    '
   morphology_sources:
   - ref: PMID:27997999
     method: morphological reconstruction
@@ -827,13 +885,17 @@ nodes:
       label: sst chodl GABAergic interneuron
       name_in_source: hippocampo-septal cell
     mapping_type: RELATED
-    mapping_notes: |
-      CL:4023121 partially overlaps (long-range projecting SST+ INs) but HS cells are hippocampus-specific and may not express Chodl.
+    mapping_notes: 'CL:4023121 partially overlaps (long-range projecting SST+ INs) but HS cells are hippocampus-specific and
+      may not express Chodl.
+
+      '
   definition_references:
   - PMID:27997999
   is_terminal: false
-  notes: |
-    Very limited reference coverage (1 quote). Ephys not characterized. Relationship to Chodl+ long-range projecting cortical INs unclear. One of two main SOM+ types in CA1 alongside OLM cells.
+  notes: 'Very limited reference coverage (1 quote). Ephys not characterized. Relationship to Chodl+ long-range projecting
+    cortical INs unclear. One of two main SOM+ types in CA1 alongside OLM cells.
+
+    '
 - id: neurogliaform_cell_hippocampus
   name: Neurogliaform cell (NGC)
   definition_basis: CLASSICAL_MULTIMODAL
@@ -972,8 +1034,10 @@ nodes:
     method: patch clamp
     scope: mouse hippocampus
     quote_key: 2405079_a85327b9
-  morphology_notes: |
-    Dense, compact axonal arbor providing volume transmission of GABA; small round soma; short radiating dendrites. Spider-like morphology.
+  morphology_notes: 'Dense, compact axonal arbor providing volume transmission of GABA; small round soma; short radiating
+    dendrites. Spider-like morphology.
+
+    '
   morphology_sources:
   - ref: PMID:20147544
     method: intracellular labeling + immunochemistry
@@ -993,14 +1057,18 @@ nodes:
       label: neurogliaform cell
       name_in_source: neurogliaform cell
     mapping_type: EXACT
-    mapping_notes: |
-      CL:0000693 definition matches well: small round soma, multiple short radiating dendrites, dense branched axonal mesh. Not region-restricted.
+    mapping_notes: 'CL:0000693 definition matches well: small round soma, multiple short radiating dendrites, dense branched
+      axonal mesh. Not region-restricted.
+
+      '
   definition_references:
   - PMID:20147544
   - PMID:41473287
   is_terminal: false
-  notes: |
-    nNOS+ NGCs derived from MGE share properties with Ivy cells; nNOS- NGCs arise from CGE. Two developmental lineages with overlapping morphology. Transcriptomic identity defined by Lamp5/Id2 expression.
+  notes: 'nNOS+ NGCs derived from MGE share properties with Ivy cells; nNOS- NGCs arise from CGE. Two developmental lineages
+    with overlapping morphology. Transcriptomic identity defined by Lamp5/Id2 expression.
+
+    '
 - id: ivy_cell_hippocampus
   name: Ivy cell (IvC)
   definition_basis: CLASSICAL_MULTIMODAL
@@ -1110,8 +1178,10 @@ nodes:
     method: patch clamp
     scope: mouse hippocampus
     quote_key: 2405079_a85327b9
-  morphology_notes: |
-    Dense local axonal arbor; soma typically in or near stratum pyramidale; NOS-expressing. Similar to NGC but different laminar position.
+  morphology_notes: 'Dense local axonal arbor; soma typically in or near stratum pyramidale; NOS-expressing. Similar to NGC
+    but different laminar position.
+
+    '
   morphology_sources:
   - ref: PMID:20147544
     method: intracellular labeling
@@ -1132,10 +1202,18 @@ nodes:
   - PMID:20147544
   - PMID:39401246
   is_terminal: false
-  notes: |
-    No dedicated CL term. Ivy cells and nNOS+ NGCs may constitute a single subtype despite laminar differences. One of most representative CA1 interneuron types. Both MGE and CGE developmental origins reported.
-    [cite_traverse_2026_04_10] PMID:20147544: IvCs and nNOS+ NGCs have completely overlapping developmental, electrophysiological, morphological, and neurochemical properties, suggesting that these cells constitute a single unique interneuron subtype despite differences in laminar organization
-    [cite_traverse_2026_04_10] PMID:20147544: our findings reveal that IvCs and nNOS ϩ NGCs have completely overlapping developmental, electrophysiological, morphological, and neurochemical properties, suggesting that these cells constitute a single unique interneuron subtype despite differences in laminar organization
+  notes: 'No dedicated CL term. Ivy cells and nNOS+ NGCs may constitute a single subtype despite laminar differences. One
+    of most representative CA1 interneuron types. Both MGE and CGE developmental origins reported.
+
+    [cite_traverse_2026_04_10] PMID:20147544: IvCs and nNOS+ NGCs have completely overlapping developmental, electrophysiological,
+    morphological, and neurochemical properties, suggesting that these cells constitute a single unique interneuron subtype
+    despite differences in laminar organization
+
+    [cite_traverse_2026_04_10] PMID:20147544: our findings reveal that IvCs and nNOS ϩ NGCs have completely overlapping developmental,
+    electrophysiological, morphological, and neurochemical properties, suggesting that these cells constitute a single unique
+    interneuron subtype despite differences in laminar organization
+
+    '
 - id: is_interneuron_hippocampus
   name: Interneuron-specific (IS) interneuron
   definition_basis: CLASSICAL_MULTIMODAL
@@ -1237,8 +1315,10 @@ nodes:
       cells is likely to be found within this group of CR-positive interneurons.
     support: SUPPORT
     source: cite_traverse_2026_04_10
-  morphology_notes: |
-    Selectively contacts other interneurons rather than pyramidal cells; plays disinhibitory role in circuit. Identified by ultrastructural evidence of selective interneuron targeting.
+  morphology_notes: 'Selectively contacts other interneurons rather than pyramidal cells; plays disinhibitory role in circuit.
+    Identified by ultrastructural evidence of selective interneuron targeting.
+
+    '
   morphology_sources:
   - ref: PMID:24671999
     method: electron microscopy
@@ -1267,16 +1347,22 @@ nodes:
       label: VIP GABAergic interneuron
       name_in_source: VIP interneuron
     mapping_type: BROAD
-    mapping_notes: |
-      CL:4023016 captures VIP+ subset (IS-2 and IS-3) but not IS-1 (CR+/VIP-). The defining functional feature — selective interneuron targeting for disinhibition — is not encoded in any CL term.
+    mapping_notes: 'CL:4023016 captures VIP+ subset (IS-2 and IS-3) but not IS-1 (CR+/VIP-). The defining functional feature
+      — selective interneuron targeting for disinhibition — is not encoded in any CL term.
+
+      '
   definition_references:
   - PMID:24671999
   - PMID:37467748
   - PMID:39401246
   is_terminal: false
-  notes: |
-    Three subtypes: IS-1 (CR+), IS-2 (VIP+), IS-3 (CR+/VIP+). Majority of VIP subclass are IS cells. Ephys not extensively characterized. CL mapping only covers VIP+ subtypes.
-    [cite_traverse_2026_04_10] PMID:23162426: a subgroup of interneurons, the so-called interneuron-specific (IS) interneurons, specializes in innervating exclusively other GABAergic cells
+  notes: 'Three subtypes: IS-1 (CR+), IS-2 (VIP+), IS-3 (CR+/VIP+). Majority of VIP subclass are IS cells. Ephys not extensively
+    characterized. CL mapping only covers VIP+ subtypes.
+
+    [cite_traverse_2026_04_10] PMID:23162426: a subgroup of interneurons, the so-called interneuron-specific (IS) interneurons,
+    specializes in innervating exclusively other GABAergic cells
+
+    '
 - id: oriens_oriens_cell_hippocampus
   name: Oriens-oriens (O-O) cell
   definition_basis: CLASSICAL_MULTIMODAL
@@ -1313,15 +1399,20 @@ nodes:
   neuropeptides: []
   electrophysiology_class: null
   ephys_sources: []
-  morphology_notes: |
-    Axon confined to stratum oriens, distinguishing it from OLM (axon to str. lacunosum-moleculare) and bistratified (axon in radiatum + oriens). Identified by Sst;;Nos1 intersectional strategy.
+  morphology_notes: 'Axon confined to stratum oriens, distinguishing it from OLM (axon to str. lacunosum-moleculare) and bistratified
+    (axon in radiatum + oriens). Identified by Sst;;Nos1 intersectional strategy.
+
+    '
   morphology_sources: []
   cl_mapping: null
   definition_references:
   - PMID:39401246
   is_terminal: false
-  notes: |
-    Stub from cite-traverse (2026-04-10). Identified by Chamberland et al. (2024) using Sst;;Nos1 intersectional Cre/Flp. Almost exclusively represented by Sst;;Nos1-INs (n = 12/15). Distinct from OLM by axon confinement to stratum oriens. Evidence thin — single study.
+  notes: 'Stub from cite-traverse (2026-04-10). Identified by Chamberland et al. (2024) using Sst;;Nos1 intersectional Cre/Flp.
+    Almost exclusively represented by Sst;;Nos1-INs (n = 12/15). Distinct from OLM by axon confinement to stratum oriens.
+    Evidence thin — single study.
+
+    '
 - id: trilaminar_cell_hippocampus
   name: Trilaminar cell
   definition_basis: CLASSICAL_MULTIMODAL
@@ -1353,18 +1444,25 @@ nodes:
   - symbol: Sst
     ncbi_gene_id: null
   neuropeptides: []
-  electrophysiology_class: |
-    Unique high-frequency burst firing pattern distinguishing it from other long-range projecting GABAergic cells.
+  electrophysiology_class: 'Unique high-frequency burst firing pattern distinguishing it from other long-range projecting
+    GABAergic cells.
+
+    '
   ephys_sources: []
-  morphology_notes: |
-    Long-range projecting GABAergic interneuron with axon spanning str. oriens, pyramidale, and radiatum (trilaminar). Projects to subiculum and medial septum. Distinguished from HS cell by firing pattern and PV+/M2R+ marker profile.
+  morphology_notes: 'Long-range projecting GABAergic interneuron with axon spanning str. oriens, pyramidale, and radiatum
+    (trilaminar). Projects to subiculum and medial septum. Distinguished from HS cell by firing pattern and PV+/M2R+ marker
+    profile.
+
+    '
   morphology_sources: []
   cl_mapping: null
   definition_references:
   - PMID:28646648
   is_terminal: false
-  notes: |
-    Stub from cite-traverse (2026-04-10). Well-documented by Somogyi lab (Katona et al. 2017). Long-range projection cell distinct from hippocampo-septal cell. PV+/M2R+/SOM-.
+  notes: 'Stub from cite-traverse (2026-04-10). Well-documented by Somogyi lab (Katona et al. 2017). Long-range projection
+    cell distinct from hippocampo-septal cell. PV+/M2R+/SOM-.
+
+    '
 - id: vip_basket_cell_hippocampus
   name: VIP-positive basket cell
   definition_basis: CLASSICAL_MULTIMODAL
@@ -1389,8 +1487,10 @@ nodes:
   neuropeptides: []
   electrophysiology_class: null
   ephys_sources: []
-  morphology_notes: |
-    Perisomatic-targeting VIP+ interneuron providing inhibition to pyramidal cell somata. Asynchronous GABA release. Functionally distinct from IS interneurons despite shared VIP expression.
+  morphology_notes: 'Perisomatic-targeting VIP+ interneuron providing inhibition to pyramidal cell somata. Asynchronous GABA
+    release. Functionally distinct from IS interneurons despite shared VIP expression.
+
+    '
   morphology_sources:
   - ref: PMID:24671999
     method: paired recordings, optogenetics, VIP-eGFP mouse line
@@ -1401,9 +1501,13 @@ nodes:
   definition_references:
   - PMID:24671999
   is_terminal: false
-  notes: |
-    Stub from cite-traverse (2026-04-10). Described by Tyan et al. (2014). Unlike IS cells (which target other interneurons), VIP basket cells provide perisomatic inhibition to pyramidal neurons. Evidence from single primary characterisation.
-    [cite_traverse_2026_04_10] PMID:24671999: VIP-positive basket cells provided perisomatic inhibition to CA1 pyramidal neurons with the asynchronous GABA release and were not connected with O/A interneurons
+  notes: 'Stub from cite-traverse (2026-04-10). Described by Tyan et al. (2014). Unlike IS cells (which target other interneurons),
+    VIP basket cells provide perisomatic inhibition to pyramidal neurons. Evidence from single primary characterisation.
+
+    [cite_traverse_2026_04_10] PMID:24671999: VIP-positive basket cells provided perisomatic inhibition to CA1 pyramidal neurons
+    with the asynchronous GABA release and were not connected with O/A interneurons
+
+    '
 - id: r_lm_cell_hippocampus
   name: Radiatum-lacunosum moleculare (R-LM) cell
   definition_basis: CLASSICAL_MULTIMODAL
@@ -1438,15 +1542,20 @@ nodes:
   neuropeptides: []
   electrophysiology_class: null
   ephys_sources: []
-  morphology_notes: |
-    SST+ interneuron with axon projecting through radiatum to lacunosum-moleculare. Identified in GIN transgenic mice.
+  morphology_notes: 'SST+ interneuron with axon projecting through radiatum to lacunosum-moleculare. Identified in GIN transgenic
+    mice.
+
+    '
   morphology_sources: []
   cl_mapping: null
   definition_references:
   - PMID:10818134
   is_terminal: false
-  notes: |
-    Stub from cite-traverse (2026-04-10). THIN EVIDENCE — described in one study (Oliva et al. 2000) using GIN transgenic labelling. Unclear how it maps to modern transcriptomic taxonomy. May need targeted literature search to confirm as distinct type.
+  notes: 'Stub from cite-traverse (2026-04-10). THIN EVIDENCE — described in one study (Oliva et al. 2000) using GIN transgenic
+    labelling. Unclear how it maps to modern transcriptomic taxonomy. May need targeted literature search to confirm as distinct
+    type.
+
+    '
 - id: p_lm_cell_hippocampus
   name: Pyramidale-lacunosum moleculare (P-LM) cell
   definition_basis: CLASSICAL_MULTIMODAL
@@ -1477,15 +1586,19 @@ nodes:
   neuropeptides: []
   electrophysiology_class: null
   ephys_sources: []
-  morphology_notes: |
-    SST+ interneuron with soma in stratum pyramidale and axon projecting to lacunosum-moleculare. Identified in GIN transgenic mice.
+  morphology_notes: 'SST+ interneuron with soma in stratum pyramidale and axon projecting to lacunosum-moleculare. Identified
+    in GIN transgenic mice.
+
+    '
   morphology_sources: []
   cl_mapping: null
   definition_references:
   - PMID:10818134
   is_terminal: false
-  notes: |
-    Stub from cite-traverse (2026-04-10). THIN EVIDENCE — described in one study (Oliva et al. 2000). Same caveat as R-LM cell.
+  notes: 'Stub from cite-traverse (2026-04-10). THIN EVIDENCE — described in one study (Oliva et al. 2000). Same caveat as
+    R-LM cell.
+
+    '
 - id: lth_cell_hippocampus
   name: Low-threshold high-Ih (LTH) cell
   definition_basis: CLASSICAL_MULTIMODAL
@@ -1519,8 +1632,9 @@ nodes:
       source: cite_traverse_2026_04_10
   negative_markers: []
   neuropeptides: []
-  electrophysiology_class: |
-    Strong spike frequency adaptation, high Ih. Distinguished from OLM cells by physiological clustering.
+  electrophysiology_class: 'Strong spike frequency adaptation, high Ih. Distinguished from OLM cells by physiological clustering.
+
+    '
   ephys_sources: []
   morphology_notes: null
   morphology_sources: []
@@ -1528,6 +1642,1117 @@ nodes:
   definition_references:
   - PMID:34250732
   is_terminal: false
-  notes: |
-    Stub from cite-traverse (2026-04-10). THIN EVIDENCE — single study (Hewitt et al. 2021) using physiological clustering of SST-Cre Ai14 cells. May overlap with oriens-oriens or other SST+ subtypes. Needs targeted lit search.
-edges: []
+  notes: 'Stub from cite-traverse (2026-04-10). THIN EVIDENCE — single study (Hewitt et al. 2021) using physiological clustering
+    of SST-Cre Ai14 cells. May overlap with oriens-oriens or other SST+ subtypes. Needs targeted lit search.
+
+    '
+- id: CS20230722_CLUS_0732
+  name: 0732 Pvalb chandelier Gaba_1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  taxonomy_id: CCN20230722
+  cell_set_accession: CS20230722_CLUS_0732
+- id: CS20230722_CLUS_0739
+  name: 0739 Pvalb Gaba_2
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  taxonomy_id: CCN20230722
+  cell_set_accession: CS20230722_CLUS_0739
+- id: CS20230722_SUPT_0179
+  name: 0179 Vip Gaba_7
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  taxonomy_id: CCN20230722
+  cell_set_accession: CS20230722_SUPT_0179
+- id: CS20230722_SUPT_0193
+  name: 0193 RHP-COA Ndnf Gaba_1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  taxonomy_id: CCN20230722
+  cell_set_accession: CS20230722_SUPT_0193
+- id: CS20230722_SUPT_0203
+  name: 0203 Lamp5 Lhx6 Gaba_1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  taxonomy_id: CCN20230722
+  cell_set_accession: CS20230722_SUPT_0203
+- id: CS20230722_SUPT_0204
+  name: 0204 Pvalb chandelier Gaba_1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  taxonomy_id: CCN20230722
+  cell_set_accession: CS20230722_SUPT_0204
+- id: CS20230722_SUPT_0206
+  name: 0206 Pvalb Gaba_2
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  taxonomy_id: CCN20230722
+  cell_set_accession: CS20230722_SUPT_0206
+- id: CS20230722_SUPT_0216
+  name: 0216 Sst Gaba_3
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  taxonomy_id: CCN20230722
+  cell_set_accession: CS20230722_SUPT_0216
+- id: CS20230722_SUPT_0219
+  name: 0219 Sst Gaba_6
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  taxonomy_id: CCN20230722
+  cell_set_accession: CS20230722_SUPT_0219
+edges:
+- id: edge_pv_basket_cell_hippocampus_to_CS20230722_SUPT_0206
+  type_a: pv_basket_cell_hippocampus
+  type_b: CS20230722_SUPT_0206
+  relationship: PARTIAL_OVERLAP
+  confidence: LOW
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Pvalb subclass and GABA neurotransmitter type are fully consistent with PV basket cell identity. CA1 stratum
+      oriens (818 cells) and CA3 stratum oriens (152 cells) include appropriate perisomatic interneuron locations; however,
+      the supertype also spans piriform area (959 cells), indicating it is not hippocampus-specific. Defining markers (Cort,
+      Adamts15, Vwc2l, Ets1) do not include Pvalb directly but Pvalb is prominent in child cluster MERFISH data. The supertype
+      name "Pvalb Gaba_2" is consistent with PV+ identity. Partial overlap declared because (a) the supertype spans multiple
+      regions beyond hippocampus and (b) the PV basket cell is one of several PV+ morphological subtypes (basket, axo-axonic,
+      bistratified) that share high transcriptomic similarity and may not be separable at supertype level.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_CA1_stratum_pyramidale
+    node_a_value: CA1 stratum pyramidale (UBERON:0005401) — soma
+    node_b_value: CA1 stratum oriens (MBA:399, 818 cells); CA1 pyramidal layer not listed
+    alignment: APPROXIMATE
+    notes: 'Classical soma location is stratum pyramidale; atlas shows CA1 SO as dominant hippocampal location. Both are perisomatic
+      layers; some soma placement discrepancy may reflect soma-in-SO border cells or atlas resolution limits.
+
+      '
+  - property: marker_Pvalb
+    node_a_value: Pvalb — defining marker (immunohistochemistry, rat and mouse)
+    node_b_value: Pvalb subclass; Pvalb in MERFISH marker set of child cluster 0739
+    alignment: CONSISTENT
+  - property: marker_Gad1
+    node_a_value: Gad1 — defining marker
+    node_b_value: not present in supertype defining_markers; GABA nt_type consistent
+    alignment: APPROXIMATE
+  - property: marker_Gad2
+    node_a_value: Gad2 — defining marker
+    node_b_value: not present in supertype defining_markers; GABA nt_type consistent
+    alignment: APPROXIMATE
+  - property: negative_marker_Cnr1
+    node_a_value: Cnr1 — negative marker (absent)
+    node_b_value: not present in supertype markers
+    alignment: NOT_ASSESSED
+  caveats:
+  - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
+    description: 'Supertype spans hippocampus (CA1 SO, CA3 SO) and piriform area; not hippocampus-specific. Multiple PV+ morphological
+      subtypes (basket, axo-axonic, bistratified) co-populate the Pvalb Gaba subclass with high transcriptomic similarity
+      (Bomkamp et al. 2019 PMID:33398060) and may not be separable at supertype level.
+
+      '
+  - caveat_type: MARKER_NOT_SPECIFIC
+    description: 'Cnr1 negative marker status unverifiable from atlas supertype metadata.
+
+      '
+- id: edge_pv_basket_cell_hippocampus_to_CS20230722_CLUS_0739
+  type_a: pv_basket_cell_hippocampus
+  type_b: CS20230722_CLUS_0739
+  relationship: PARTIAL_OVERLAP
+  confidence: LOW
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Child of SUPT_0206 (Pvalb Gaba_2). Hippocampal enrichment: CA1 SO (124 cells), CA3 SO (80 cells), CA1 pyramidal
+      layer (26 cells), CA1 SR (45 cells). GABA consistent. Pvalb in MERFISH markers confirms PV identity. Neuropeptides include
+      Cck (score 7.6), Pthlh, Cort, Tac1 — no Cck association expected for PV basket cells; Cck is a defining marker of CCK
+      basket cells. This neuropeptide profile is discordant and suggests the cluster may contain mixed PV+/CCK+ identities,
+      or that Cck peptide co-expression occurs at low level in some PV neurons. Partial overlap declared for same reasons
+      as parent supertype.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_CA1_stratum_pyramidale
+    node_a_value: CA1 stratum pyramidale (UBERON:0005401) — soma
+    node_b_value: CA1 pyramidal layer (MBA:407, 26 cells); CA1 SO (MBA:399, 124 cells)
+    alignment: APPROXIMATE
+    notes: Small CA1 pyramidal layer count; main hippocampal signal in SO.
+  - property: marker_Pvalb
+    node_a_value: Pvalb — defining marker
+    node_b_value: Pvalb in MERFISH markers
+    alignment: CONSISTENT
+  - property: marker_Gad1
+    node_a_value: Gad1 — defining marker
+    node_b_value: not in cluster defining_markers; GABA NT consistent
+    alignment: APPROXIMATE
+  - property: marker_Gad2
+    node_a_value: Gad2 — defining marker
+    node_b_value: not in cluster defining_markers; GABA NT consistent
+    alignment: APPROXIMATE
+  - property: negative_marker_Cnr1
+    node_a_value: Cnr1 — negative marker (absent)
+    node_b_value: not present in cluster markers
+    alignment: NOT_ASSESSED
+  - property: neuropeptide_Cck
+    node_a_value: Cck not expected (Cnr1-negative PV cells)
+    node_b_value: Cck present (expression score 7.6)
+    alignment: DISCORDANT
+    notes: 'High Cck neuropeptide score is unexpected for a PV basket cell, which should be Cnr1/CB1R-negative. Could indicate
+      cluster contains CCK-co-expressing PV cells, or that cluster boundaries do not align cleanly to classical types.
+
+      '
+  caveats:
+  - caveat_type: MARKER_NOT_SPECIFIC
+    description: 'Cck neuropeptide at high expression score in this cluster is discordant with expected PV basket cell identity
+      (Cnr1-negative). May indicate mixed cluster content or non-specific peptide expression.
+
+      '
+  - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
+    description: 'PV+ hippocampal interneurons (basket, axo-axonic, bistratified) have high transcriptomic similarity and
+      are not cleanly separated at cluster level (PMID:33398060). This cluster likely contains multiple classical PV subtypes.
+
+      '
+- id: edge_cck_basket_cell_hippocampus_to_CS20230722_SUPT_0179
+  type_a: cck_basket_cell_hippocampus
+  type_b: CS20230722_SUPT_0179
+  relationship: UNCERTAIN
+  confidence: UNCERTAIN
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'GABA neurotransmitter type is consistent. Hippocampal locations present: CA1 SO (24 cells), CA1 pyramidal
+      layer (11 cells), CA1 SR (26 cells), CA3 SO (25 cells), CA3 pyramidal layer (23 cells), CA3 SR (17 cells). Perisomatic
+      targeting location is consistent with basket cell morphology. However, the parent subclass is "Vip Gaba" — CCK basket
+      cells are not primarily defined by Vip expression. CCK basket cells express Cnr1/CB1R as a defining marker; Vip subclass
+      identity is unexpected. Defining markers (Vip, Qrfpr, Stk32a, Igfbp4) do not include Cck or Cnr1. This is a surprising
+      candidate with low confidence pending transcriptomic validation of CCK+/CB1R+ basket cells against Vip subclass.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_CA1_stratum_pyramidale
+    node_a_value: CA1 stratum pyramidale (UBERON:0005401) — soma
+    node_b_value: CA1 pyramidal layer (MBA:407, 11 cells); CA1 SO (MBA:399, 24 cells)
+    alignment: APPROXIMATE
+    notes: Perisomatic locations present but sparse. Supertype has distributed hippocampal signal.
+  - property: marker_Cck
+    node_a_value: Cck — defining marker
+    node_b_value: not present in supertype defining_markers
+    alignment: NOT_ASSESSED
+    notes: Cck not listed in supertype markers; cannot confirm from metadata alone.
+  - property: marker_Cnr1
+    node_a_value: Cnr1 — defining marker
+    node_b_value: not present in supertype defining_markers
+    alignment: NOT_ASSESSED
+    notes: Cnr1/CB1R not present in atlas supertype metadata; key CCK basket marker unverifiable.
+  - property: marker_Vglut3
+    node_a_value: Vglut3 — defining marker (CCK basket cells)
+    node_b_value: not present in supertype defining_markers
+    alignment: NOT_ASSESSED
+  - property: negative_marker_Pvalb
+    node_a_value: Pvalb — negative marker (absent)
+    node_b_value: not present in supertype markers; Vip subclass
+    alignment: CONSISTENT
+    notes: Absence of Pvalb consistent with CCK basket cell identity; Vip subclass is non-PV.
+  caveats:
+  - caveat_type: OTHER
+    description: 'Vip Gaba subclass identity is unexpected for CCK basket cells. CCK basket cells in hippocampus are classically
+      CGE-derived and can express Vip, but the defining identity is perisomatic CCK+/CB1R+ — not Vip-defined. This mapping
+      may reflect a CGE-derived CCK interneuron that co-expresses Vip, but requires transcriptomic validation (e.g., patch-seq
+      or single-cell RNA-seq of identified CCK basket cells).
+
+      '
+  - caveat_type: MARKER_NOT_SPECIFIC
+    description: 'Cck, Cnr1, and Vglut3 — the three canonical CCK basket cell markers — are all absent from the atlas supertype
+      metadata. The candidate is based on location match and CGE origin inference only.
+
+      '
+- id: edge_axo_axonic_cell_hippocampus_to_CS20230722_SUPT_0204
+  type_a: axo_axonic_cell_hippocampus
+  type_b: CS20230722_SUPT_0204
+  relationship: EQUIVALENT
+  confidence: LOW
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: SUPPORT
+    explanation: 'Supertype name "Pvalb chandelier Gaba_1" directly names the chandelier (= axo-axonic) cell type. Pvalb subclass,
+      GABA NT type are fully consistent. Pvalb present in DEFINING_SCOPED markers confirming PV+ identity. The CL mapping
+      for the classical node (CL:4023036 pvalb chandelier GABAergic interneuron) is EXACT, and the atlas supertype name makes
+      the identity explicit. EQUIVALENT declared because the atlas supertype is named for and defined by the chandelier/axo-axonic
+      cell type. Confidence is LOW (not MODERATE) because: (a) the supertype has only piriform area in its top anatomical
+      locations (194 cells) with no explicit hippocampal pyramidal layer entry at supertype level; (b) this is metadata-only
+      with no primary literature on the edge; (c) axo-axonic and basket PV cells have been reported to have high transcriptomic
+      overlap (PMID:33398060).
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_CA1_stratum_pyramidale
+    node_a_value: CA1 stratum pyramidale (UBERON:0005401) — soma
+    node_b_value: Piriform area (MBA:961, 194 cells) — no hippocampal pyramidal layer listed at supertype level
+    alignment: DISCORDANT
+    notes: 'Supertype anatomy dominated by piriform area. Hippocampal pyramidal layer not listed at supertype level. However,
+      child cluster 0732 has CA1 SO, CA1 SR, CA3 SO, and CA3 pyramidal layer entries, suggesting hippocampal chandelier cells
+      exist within this supertype at cluster level.
+
+      '
+  - property: marker_Pvalb
+    node_a_value: Pvalb — defining marker
+    node_b_value: Pvalb in DEFINING_SCOPED markers; Pvalb subclass
+    alignment: CONSISTENT
+  - property: type_identity
+    node_a_value: axo-axonic (chandelier) morphology — exclusive AIS targeting
+    node_b_value: supertype named 'Pvalb chandelier Gaba_1'
+    alignment: CONSISTENT
+    notes: Supertype name directly identifies the chandelier cell type.
+  caveats:
+  - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
+    description: 'Supertype anatomy is piriform-dominated at top level; hippocampal chandelier cells should be resolvable
+      at cluster level (see CLUS_0732 edge). Supertype likely spans multiple regions where axo-axonic cells occur.
+
+      '
+  - caveat_type: MARKER_NOT_SPECIFIC
+    description: 'High transcriptomic similarity between PV+ morphological subtypes (PMID:33398060) means chandelier-specific
+      markers are not fully resolved at supertype level from basket/bistratified cells in the metadata.
+
+      '
+- id: edge_axo_axonic_cell_hippocampus_to_CS20230722_CLUS_0732
+  type_a: axo_axonic_cell_hippocampus
+  type_b: CS20230722_CLUS_0732
+  relationship: EQUIVALENT
+  confidence: LOW
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: SUPPORT
+    explanation: 'Child of SUPT_0204 (Pvalb chandelier Gaba_1). Hippocampal locations: CA1 SO (38 cells), CA1 SR (23 cells),
+      CA3 SO (33 cells), CA3 pyramidal layer (23 cells), CA3 SR (15 cells), dentate gyrus granule cell layer (15 cells). Pvalb
+      in MERFISH markers confirms PV+ identity. Cluster name "0732 Pvalb chandelier Gaba_1" explicitly identifies it as a
+      hippocampal chandelier cell cluster. GABA consistent. Neuropeptides Cck (8.4), Pthlh, Npy present; Cck at high score
+      warrants noting but chandelier cells can have low-level peptide co-expression.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_CA1_stratum_pyramidale
+    node_a_value: CA1 stratum pyramidale (UBERON:0005401) — soma
+    node_b_value: CA1 SO (MBA:399, 38 cells); CA3 pyramidal layer (MBA:495, 23 cells)
+    alignment: APPROXIMATE
+    notes: 'CA1 pyramidal layer not listed; CA1 SO is the dominant hippocampal CA1 location. CA3 pyramidal layer present.
+      Some soma-in-SO placement may reflect atlas resolution.
+
+      '
+  - property: marker_Pvalb
+    node_a_value: Pvalb — defining marker
+    node_b_value: Pvalb in MERFISH markers; Pvalb chandelier subclass
+    alignment: CONSISTENT
+  - property: type_identity
+    node_a_value: axo-axonic (chandelier) morphology — exclusive AIS targeting
+    node_b_value: cluster named 'Pvalb chandelier Gaba_1'
+    alignment: CONSISTENT
+  caveats:
+  - caveat_type: MARKER_NOT_SPECIFIC
+    description: 'Cck neuropeptide (score 8.4) unexpectedly high for a chandelier cell. May indicate minor contamination or
+      genuine peptide co-expression. Requires primary source validation.
+
+      '
+  - caveat_type: OTHER
+    description: 'Dentate gyrus granule cell layer (15 cells) — chandelier cells in DG are less well characterized. May reflect
+      axo-axonic cells contacting granule cells or a distinct population.
+
+      '
+- id: edge_bistratified_cell_hippocampus_to_CS20230722_SUPT_0216
+  type_a: bistratified_cell_hippocampus
+  type_b: CS20230722_SUPT_0216
+  relationship: PARTIAL_OVERLAP
+  confidence: LOW
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Sst subclass and GABA NT type are consistent with bistratified cell co-expression of Pvalb and Sst. CA1
+      stratum oriens (818 cells) and prosubiculum (259 cells) and posterior amygdala (780 cells) present. Defining markers
+      include Reln (consistent with bistratified cells, which are Reln+) and Sp9 (not a canonical bistratified marker). Tac1
+      among DEFINING_SCOPED markers is directly consistent with bistratified cell identity (Chamberland et al. 2024 used Sst;;Tac1
+      intersection to target bistratified cells, PMID:38640347). Partial overlap declared because this supertype also contains
+      OLM cells (olm_cell_ca1 mapping, see separate edge) and HS cells — these classical types are not separable at supertype
+      level.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_CA1_stratum_pyramidale
+    node_a_value: CA1 stratum pyramidale (UBERON:0005401) — soma
+    node_b_value: CA1 stratum oriens (MBA:399, 818 cells) — no pyramidal layer listed
+    alignment: APPROXIMATE
+    notes: Dominant hippocampal signal in CA1 SO, not pyramidale. Bistratified cell soma classically in/near stratum pyramidale.
+  - property: marker_Pvalb
+    node_a_value: Pvalb — defining marker (co-expressed with Sst)
+    node_b_value: Sst subclass, not Pvalb; Pvalb not in supertype markers
+    alignment: DISCORDANT
+    notes: 'Bistratified cells co-express Pvalb and Sst (PMID:37467748). The Sst subclass placement is consistent with the
+      Sst component but the Pvalb component is not captured. High transcriptomic similarity within Sst subclass may place
+      bistratified closer to OLM cells than PV basket cells at transcriptomic level.
+
+      '
+  - property: marker_Sst
+    node_a_value: Sst — defining marker
+    node_b_value: Sst subclass
+    alignment: CONSISTENT
+  - property: marker_Tac1
+    node_a_value: Tac1 — defining marker (Sst;;Tac1 intersection targets bistratified cells)
+    node_b_value: Tac1 in DEFINING_SCOPED markers
+    alignment: CONSISTENT
+    notes: Tac1 DEFINING_SCOPED in this supertype is directly consistent with bistratified cell identity.
+  - property: neuropeptide_Sst
+    node_a_value: Sst — neuropeptide
+    node_b_value: Sst subclass defining
+    alignment: CONSISTENT
+  caveats:
+  - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
+    description: 'Sst Gaba_3 supertype contains at least three classical hippocampal types: OLM cells (Sst+/Chrna2+), bistratified
+      cells (Sst+/Pvalb+/Tac1+), and HS cells (Sst+, long-range projecting). These are not separable at supertype level. This
+      edge and the olm_cell_ca1 edge to the same supertype reflect this overlap explicitly.
+
+      '
+  - caveat_type: MARKER_NOT_SPECIFIC
+    description: 'Pvalb co-expression (defining for bistratified) is not captured at the supertype level — Sst subclass placement
+      may under-represent the PV component of bistratified cell identity.
+
+      '
+- id: edge_olm_cell_ca1_to_CS20230722_SUPT_0216
+  type_a: olm_cell_ca1
+  type_b: CS20230722_SUPT_0216
+  relationship: PARTIAL_OVERLAP
+  confidence: LOW
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Sst subclass and GABA NT type are fully consistent with OLM cell identity. CA1 stratum oriens (818 cells)
+      is the primary OLM soma location. Defining markers include Reln (OLM cells express Reelin per Winterer 2019 PMID:31420995)
+      and Sp9. Neuropeptide-related markers not resolved at supertype level but Sst subclass is the primary OLM subclass from
+      MapMyCells results on GSE124847 (43/46 OLM cells mapped to this supertype, F1=0.67). PARTIAL_OVERLAP declared because
+      the supertype also contains bistratified cells (Sst/Pvalb/Tac1) and HS cells (long-range Sst) that are not separable
+      here.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_CA1_stratum_oriens
+    node_a_value: CA1 stratum oriens (UBERON:0005383) — soma
+    node_b_value: CA1 stratum oriens (MBA:399, 818 cells)
+    alignment: CONSISTENT
+  - property: marker_Sst
+    node_a_value: Sst — defining marker
+    node_b_value: Sst subclass
+    alignment: CONSISTENT
+  - property: marker_Chrna2
+    node_a_value: Chrna2 — defining marker
+    node_b_value: not in supertype defining_markers; scattered expression in Sst Gaba_3 per ABC Atlas
+    alignment: APPROXIMATE
+    notes: 'ABC Atlas HPF/GABA/Chrna2 filter retains Sst Gaba_3 (unlike Sst Gaba_6). Chrna2 expression is present but scattered
+      across clusters within this supertype — consistent with partial OLM cell representation.
+
+      '
+  - property: marker_Reln
+    node_a_value: Reln — defining marker (RT-PCR in OLM cells, PMID:31420995)
+    node_b_value: Reln in DEFINING markers of supertype
+    alignment: CONSISTENT
+    notes: Reln as a defining supertype marker is consistent with OLM Reln expression.
+  - property: neuropeptide_Sst
+    node_a_value: Sst — neuropeptide
+    node_b_value: Sst subclass defining
+    alignment: CONSISTENT
+  - property: negative_marker_Pvalb
+    node_a_value: Pvalb — low/absent
+    node_b_value: Sst subclass (not Pvalb subclass)
+    alignment: CONSISTENT
+  caveats:
+  - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
+    description: 'Sst Gaba_3 supertype contains at least three classical hippocampal cell types: OLM cells, bistratified cells,
+      and HS cells. These are not separable at supertype level. This supertype-level edge reflects the best available resolution
+      from atlas metadata alone. Cluster-level resolution of OLM cells within this supertype requires MapMyCells annotation
+      transfer or Chrna2-Cre targeting.
+
+      '
+  - caveat_type: OTHER
+    description: 'Prosubiculum (259 cells) and posterior amygdala (780 cells) are prominent in this supertype; classical OLM
+      characterisation is primarily in CA1. The non-hippocampal cells in this supertype likely include non-OLM Sst interneurons.
+
+      '
+- id: edge_hippocampo_septal_cell_ca1_to_CS20230722_SUPT_0216
+  type_a: hippocampo_septal_cell_ca1
+  type_b: CS20230722_SUPT_0216
+  relationship: PARTIAL_OVERLAP
+  confidence: LOW
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Sst Gaba_3 supertype is MGE-derived Sst+ GABA interneuron in hippocampal stratum oriens (CA1 SO: 818 cells,
+      largest single location). HS cell is Sst+ GABAergic with soma in CA1 stratum oriens — both properties match. However,
+      the supertype also captures OLM cells and potentially bistratified cells; the HS-specific feature (long-range projection
+      to medial septum) is not resolvable from atlas metadata. The Reln defining marker of SUPT_0216 is inconsistent with
+      HS cell identity (Reln is an OLM marker). This is a shared supertype with OLM and other SO interneurons, not an HS-specific
+      target.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_stratum_oriens
+    node_a_value: CA1 stratum oriens (UBERON:0005383) — SOMA
+    node_b_value: Field CA1, stratum oriens (MBA:399, 818 cells)
+    alignment: CONSISTENT
+  - property: marker_Sst
+    node_a_value: Sst — defining marker (IHC, mouse hippocampus)
+    node_b_value: Sst Gaba subclass — Sst is subclass-level marker
+    alignment: CONSISTENT
+  - property: neuropeptide_Sst
+    node_a_value: Sst neuropeptide present
+    node_b_value: not present in supertype neuropeptide list (not assessed at this level)
+    alignment: NOT_ASSESSED
+  - property: marker_Reln
+    node_a_value: not listed — not a HS defining marker
+    node_b_value: Reln — DEFINING marker of SUPT_0216
+    alignment: DISCORDANT
+    notes: 'Reln is a known OLM marker (Chrna2::Reln coexpression confirmed). Its presence as a defining marker of this supertype
+      is consistent with OLM but not expected for HS cells. May indicate SUPT_0216 predominantly captures OLM-like cells.
+
+      '
+  - property: marker_Rbp4
+    node_a_value: not listed
+    node_b_value: Rbp4 — DEFINING marker of SUPT_0216
+    alignment: NOT_ASSESSED
+  caveats:
+  - caveat_type: OTHER
+    description: 'SUPT_0216 (Sst Gaba_3) is a shared supertype: MapMyCells annotation transfer of OLM interneurons (GSE124847)
+      maps 43/46 OLM cells to this supertype with F1=0.67. Bistratified cells (Pvalb/Sst/Tac1+) may also contribute. HS-specific
+      long-range projection identity cannot be verified from atlas metadata.
+
+      '
+  - caveat_type: MARKER_NOT_SPECIFIC
+    description: 'The Reln defining marker of SUPT_0216 is an OLM marker, not an HS marker. This may indicate the supertype
+      predominantly captures OLM rather than HS cells.
+
+      '
+  unresolved_questions:
+  - Does SUPT_0216 contain any long-range projecting Sst+ neurons or is it exclusively local-circuit (OLM)?
+  - Is there a more appropriate HS candidate outside the Sst Gaba_3 supertype (e.g. Chodl+ class)?
+- id: edge_neurogliaform_cell_hippocampus_to_CS20230722_SUPT_0193
+  type_a: neurogliaform_cell_hippocampus
+  type_b: CS20230722_SUPT_0193
+  relationship: PARTIAL_OVERLAP
+  confidence: LOW
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'RHP-COA Ndnf Gaba_1 supertype: Ndnf is a CGE lineage marker. Classical NGCs include an Ndnf+ CGE-derived
+      subpopulation (nNOS- NGCs, described by Tricoire et al. 2011). Supertype has cells in CA1 SLM (55 cells) and CA3 SLM
+      (52 cells) matching NGC soma location in stratum lacunosum-moleculare. Lamp5 is a NGC defining marker and is present
+      as DEFINING_SCOPED in the related SUPT_0203 but not in SUPT_0193; Ndnf is defining here. The Lamp5+/Id2+ profile of
+      CGE-derived NGCs (NGFC.C: Lhx6-/Lamp5+/Id2+/Ndnf+) partially aligns with Ndnf expression here, though the subclass is
+      RHP-COA Ndnf not hippocampus-specific.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_slm
+    node_a_value: CA1 stratum lacunosum-moleculare (UBERON:0005403) — SOMA
+    node_b_value: Field CA1, stratum lacunosum-moleculare (MBA:391, 55 cells); CA3 SLM (MBA:471, 52 cells)
+    alignment: CONSISTENT
+  - property: marker_Ndnf
+    node_a_value: not listed as classical marker — but Ndnf+ CGE-derived NGC subpopulation reported
+    node_b_value: Ndnf — DEFINING marker of SUPT_0193
+    alignment: APPROXIMATE
+    notes: 'Tricoire 2011 identifies Ndnf+ subset as CGE-derived NGCs (NGFC.C). Ndnf is not in classical defining_markers
+      list but is consistent with the known CGE lineage of nNOS- NGCs.
+
+      '
+  - property: marker_Nos1
+    node_a_value: Nos1 (nNOS) — defining marker (IHC, mouse hippocampus)
+    node_b_value: not present in SUPT_0193 markers
+    alignment: DISCORDANT
+    notes: 'Classical NGC node uses Nos1 as a defining marker, but this reflects the MGE-derived nNOS+ NGC majority. CGE-derived
+      NGCs (the lineage represented here) are nNOS-. The discordance is lineage-specific, not a global mismatch.
+
+      '
+  - property: marker_Lamp5
+    node_a_value: Lamp5 — defining marker (transcript, hippocampus)
+    node_b_value: not listed in SUPT_0193 markers
+    alignment: DISCORDANT
+    notes: 'Lamp5 is listed as DEFINING_SCOPED in SUPT_0203 (MGE Lamp5 Lhx6), not in this Ndnf CGE supertype. However, NGFC.C
+      annotation is Lhx6-/Lamp5+/Id2+/Ndnf+ — Lamp5 and Ndnf coexpression expected in this lineage.
+
+      '
+  - property: marker_Npy
+    node_a_value: Npy — defining marker (IHC, mouse hippocampus)
+    node_b_value: not present in SUPT_0193 markers
+    alignment: NOT_ASSESSED
+  - property: negative_marker_Sst
+    node_a_value: Sst — negative marker
+    node_b_value: Sst not in SUPT_0193 markers
+    alignment: CONSISTENT
+  - property: negative_marker_Pvalb
+    node_a_value: Pvalb — negative marker
+    node_b_value: Pvalb not in SUPT_0193 markers
+    alignment: CONSISTENT
+  - property: negative_marker_Calb2
+    node_a_value: Calb2 — negative marker
+    node_b_value: not assessed from metadata
+    alignment: NOT_ASSESSED
+  caveats:
+  - caveat_type: OTHER
+    description: 'SUPT_0193 subclass is RHP-COA Ndnf Gaba, which spans retrohippocampal and cortical amygdala regions in addition
+      to hippocampus proper. The classical NGC node is hippocampus-defined; this supertype may include non-hippocampal neurogliaform-like
+      cells.
+
+      '
+  - caveat_type: MARKER_NOT_SPECIFIC
+    description: 'The classical NGC node has Nos1 as a defining marker representing the majority MGE-derived NGC population.
+      This edge specifically represents the CGE-derived nNOS- NGC subtype only. The heterogeneous classical node partially
+      overlaps this supertype.
+
+      '
+- id: edge_neurogliaform_cell_hippocampus_to_CS20230722_SUPT_0203
+  type_a: neurogliaform_cell_hippocampus
+  type_b: CS20230722_SUPT_0203
+  relationship: UNCERTAIN
+  confidence: UNCERTAIN
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Lamp5 Lhx6 Gaba_1 supertype is MGE-derived (Lhx6+) Lamp5+ GABA interneuron. Classical NGCs include a nNOS+
+      MGE-derived subpopulation (NGFC.M: Lhx6+/Lamp5+/Id2+) described by Tricoire 2011 and Bhatt et al. 2023. This MGE lineage
+      has Lamp5 as a DEFINING_SCOPED marker and Lhx6 as DEFINING_SCOPED. However the atlas supertype lacks SLM representation
+      (no CA1 SLM cells; DG mol layer 263, CA3 SO 179, CA3 SR 235) — inconsistent with NGC soma position in SLM. This casts
+      doubt on this supertype as an NGC hippocampal candidate.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_slm
+    node_a_value: CA1 stratum lacunosum-moleculare (UBERON:0005403) — SOMA
+    node_b_value: Dentate gyrus mol layer (263), CA3 SO (179), CA3 SR (235) — no CA1 SLM
+    alignment: DISCORDANT
+    notes: 'Classical NGCs in hippocampus have soma in SLM. This supertype has no CA1 SLM representation. Makes it an unlikely
+      hippocampal NGC candidate.
+
+      '
+  - property: marker_Lamp5
+    node_a_value: Lamp5 — defining marker (transcript)
+    node_b_value: Lamp5 — DEFINING_SCOPED marker of SUPT_0203
+    alignment: CONSISTENT
+  - property: marker_Nos1
+    node_a_value: Nos1 (nNOS) — defining marker (IHC)
+    node_b_value: not present in SUPT_0203 markers
+    alignment: NOT_ASSESSED
+    notes: 'MGE-derived nNOS+ NGCs (NGFC.M) should express Nos1. Its absence from the atlas supertype defining markers is
+      unexpected and may indicate this supertype does not correspond to the nNOS+ NGC population.
+
+      '
+  - property: marker_Id2
+    node_a_value: Id2 — defining marker (transcript)
+    node_b_value: not present in SUPT_0203 markers
+    alignment: NOT_ASSESSED
+  - property: marker_Npy
+    node_a_value: Npy — defining marker (IHC)
+    node_b_value: not present in SUPT_0203 markers
+    alignment: NOT_ASSESSED
+  - property: negative_marker_Sst
+    node_a_value: Sst — negative marker
+    node_b_value: Sst not listed in SUPT_0203 markers
+    alignment: CONSISTENT
+  - property: negative_marker_Pvalb
+    node_a_value: Pvalb — negative marker
+    node_b_value: Pvalb not listed in SUPT_0203 markers
+    alignment: CONSISTENT
+  caveats:
+  - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
+    description: 'No CA1 SLM anatomical location in SUPT_0203. Classical NGC soma is in stratum lacunosum-moleculare. Location
+      mismatch significantly weakens this candidate for hippocampal NGCs.
+
+      '
+  - caveat_type: OTHER
+    description: 'This edge represents the MGE-derived (nNOS+, Lhx6+) NGC subtype only. Even within that subset, the SLM location
+      discordance makes this assignment uncertain. Consider Ivy cell (edge 3) as the primary Lamp5 Lhx6 candidate; hippocampal
+      NGC→Lamp5 Lhx6 may require targeted patch-seq to resolve.
+
+      '
+- id: edge_ivy_cell_hippocampus_to_CS20230722_SUPT_0203
+  type_a: ivy_cell_hippocampus
+  type_b: CS20230722_SUPT_0203
+  relationship: PARTIAL_OVERLAP
+  confidence: LOW
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Lamp5 Lhx6 Gaba_1 supertype is MGE-derived (Lhx6+) Lamp5+ GABA interneuron. Ivy cells are nNOS+ (Nos1+)
+      Lamp5+ GABAergic interneurons, soma near stratum pyramidale, MGE-derived (Lhx6+ expected). The supertype markers include
+      Lamp5 and Lhx6 as DEFINING_SCOPED, consistent with Ivy cell identity. Tricoire 2011 and Bhatt 2023 confirm Ivy cells
+      are NGFC.M type (Lhx6+/Lamp5+/Id2+). However, anatomy shows CA3 SO (179), CA3 SR (235), DG mol (263) with no CA1 stratum
+      pyramidale — Ivy cell preferred location in CA1 SP is absent.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_sp
+    node_a_value: CA1 stratum pyramidale (UBERON:0005401) — SOMA
+    node_b_value: DG mol layer (263), CA3 SO (179), CA3 SR (235) — no CA1 SP
+    alignment: DISCORDANT
+    notes: 'Classical Ivy cell soma is in or near CA1 stratum pyramidale. This supertype has no CA1 pyramidal layer representation.
+      CA3 is enriched — may reflect species difference or subregional bias in the atlas dataset.
+
+      '
+  - property: marker_Lamp5
+    node_a_value: Lamp5 — defining marker (transcript)
+    node_b_value: Lamp5 — DEFINING_SCOPED marker of SUPT_0203
+    alignment: CONSISTENT
+  - property: marker_Nos1
+    node_a_value: Nos1 (nNOS) — defining marker (IHC and transcript)
+    node_b_value: not present in SUPT_0203 markers
+    alignment: NOT_ASSESSED
+    notes: 'Nos1 expected for Ivy cells (Bhatt 2023: Grin3a expressed in both IvyC Lamp5+/Lhx6+ and NGC.M subsets). Absence
+      from atlas markers does not rule out expression — may not be a defining marker at this resolution.
+
+      '
+  - property: marker_Npy
+    node_a_value: Npy — defining marker (IHC)
+    node_b_value: not present in SUPT_0203 markers
+    alignment: NOT_ASSESSED
+  - property: neuropeptide_Npy
+    node_a_value: Npy neuropeptide present
+    node_b_value: not present in supertype neuropeptide list
+    alignment: NOT_ASSESSED
+  - property: negative_marker_Sst
+    node_a_value: Sst — negative marker
+    node_b_value: Sst not listed in SUPT_0203 markers
+    alignment: CONSISTENT
+  - property: negative_marker_Pvalb
+    node_a_value: Pvalb — negative marker
+    node_b_value: Pvalb not listed in SUPT_0203 markers
+    alignment: CONSISTENT
+  - property: negative_marker_Calb2
+    node_a_value: Calb2 — negative marker
+    node_b_value: not assessed from metadata
+    alignment: NOT_ASSESSED
+  caveats:
+  - caveat_type: OTHER
+    description: 'Ivy cells and nNOS+ NGCs (NGFC.M) are reported to share completely overlapping developmental, electrophysiological,
+      morphological, and neurochemical properties (Tricoire 2011), suggesting they may constitute a single interneuron subtype
+      distinguished only by laminar position. Edge 2b (NGC→SUPT_0203) and this edge may therefore overlap the same atlas population;
+      see edge_neurogliaform_cell_hippocampus_to_CS20230722_SUPT_0203.
+
+      '
+  - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
+    description: 'No CA1 stratum pyramidale cells in SUPT_0203 despite Ivy cell soma being canonically in CA1 SP. Atlas may
+      undersample CA1 SP Lamp5 Lhx6 cells, or the Ivy cell CA1 population is split across additional supertypes.
+
+      '
+  unresolved_questions:
+  - Are the CA3-enriched Lamp5 Lhx6 cells in SUPT_0203 Ivy cells, NGCs, or a distinct type?
+  - Is there a CA1 SP Lamp5 Lhx6 cluster capturing hippocampal Ivy cells at the cluster level?
+- id: edge_is_interneuron_hippocampus_to_CS20230722_SUPT_0179
+  type_a: is_interneuron_hippocampus
+  type_b: CS20230722_SUPT_0179
+  relationship: PARTIAL_OVERLAP
+  confidence: LOW
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Vip Gaba_7 supertype has Vip as a DEFINING marker consistent with IS-2 and IS-3 subtypes (VIP+/CR+). Hippocampal
+      anatomy present across multiple layers: CA1 SO (24), CA3 SO (25), CA1 SR (26), CA3 SR (17), CA1 SP (11), CA3 SP (23).
+      The multi-laminar CA1 distribution matches IS cell soma locations spanning SO, SR, and SLM. However, the classical IS
+      interneuron node covers three subtypes (IS-1: CR+/VIP-, IS-2: VIP+, IS-3: VIP+/CR+) — only IS-2 and IS-3 would map to
+      a VIP supertype. Qrfpr, Stk32a, Igfbp4 are additional defining markers with no correspondence established in classical
+      IS literature.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_stratum_oriens
+    node_a_value: CA1 stratum oriens (UBERON:0005383) — SOMA
+    node_b_value: Field CA1, stratum oriens (MBA:399, 24 cells)
+    alignment: CONSISTENT
+  - property: location_stratum_radiatum
+    node_a_value: CA1 stratum radiatum (UBERON:0005402) — SOMA
+    node_b_value: Field CA1, stratum radiatum (MBA:415, 26 cells)
+    alignment: CONSISTENT
+  - property: location_slm
+    node_a_value: CA1 stratum lacunosum-moleculare (UBERON:0005403) — SOMA
+    node_b_value: not in top anatomical locations listed
+    alignment: NOT_ASSESSED
+    notes: SLM is listed in the classical node but not a top-count location in this supertype.
+  - property: marker_Vip
+    node_a_value: Vip — defining marker (IHC/transgenic, hippocampus)
+    node_b_value: Vip — DEFINING marker of SUPT_0179
+    alignment: CONSISTENT
+  - property: marker_Calb2
+    node_a_value: Calb2 (calretinin) — defining marker (IHC, hippocampus)
+    node_b_value: not present in SUPT_0179 markers
+    alignment: NOT_ASSESSED
+    notes: 'IS-1 and IS-3 subtypes express calretinin (Calb2). Absence from atlas defining markers does not rule out expression
+      — may not be a defining marker at supertype resolution.
+
+      '
+  - property: neuropeptide_Vip
+    node_a_value: Vip neuropeptide present
+    node_b_value: not assessed from supertype metadata
+    alignment: NOT_ASSESSED
+  caveats:
+  - caveat_type: OTHER
+    description: 'The classical IS interneuron node is heterogeneous (IS-1/2/3 subtypes). IS-1 cells are VIP-negative (CR+
+      only) and would NOT map to a Vip supertype. This edge only represents IS-2 and IS-3 (VIP+) subtypes. A Calb2-expressing
+      but Vip-negative supertype may be a better candidate for IS-1.
+
+      '
+  - caveat_type: MARKER_NOT_SPECIFIC
+    description: 'VIP GABAergic interneurons in hippocampus include VIP basket cells (vip_basket_cell_hippocampus) in addition
+      to IS cells. The supertype may encompass both perisomatic VIP basket cells and disinhibitory IS cells; the interneuron-specific
+      targeting feature of IS cells is not resolvable from transcriptomic metadata alone.
+
+      '
+- id: edge_oriens_oriens_cell_hippocampus_to_CS20230722_SUPT_0219
+  type_a: oriens_oriens_cell_hippocampus
+  type_b: CS20230722_SUPT_0219
+  relationship: UNCERTAIN
+  confidence: UNCERTAIN
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Sst Gaba_6 supertype is Sst+ GABAergic interneuron enriched in CA3 (SO 305, SR 167, SP 261, lucidum 99).
+      O-O cell is Sst+/Nos1+ with axon confined to stratum oriens. Id3, Adamtsl1, Sp9 are defining markers with no correspondence
+      established in O-O classical literature. Critically, O-O cells were identified by Sst;;Nos1 intersectional genetics
+      (Chamberland 2024) and SUPT_0219 lacks Nos1 in its marker list, which is a potential concern. However, Nos1 may be expressed
+      without being a defining marker at supertype resolution. The CA3 enrichment of SUPT_0219 vs the CA1 description for
+      O-O cells is a further point of uncertainty. Evidence for O-O cell as a distinct classical type is thin (single study),
+      making this a PLAUSIBLE but unconfirmed assignment.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA
+    alignment: CONSISTENT
+  - property: location_stratum_oriens
+    node_a_value: CA1 stratum oriens (UBERON:0014548) — SOMA
+    node_b_value: Field CA3, stratum oriens (MBA:486, 305 cells) — CA3-enriched, not CA1
+    alignment: APPROXIMATE
+    notes: 'O-O cell defined in CA1 (Chamberland 2024). SUPT_0219 is CA3-enriched with no explicit CA1 SO entry in top locations.
+      This is a subregional mismatch.
+
+      '
+  - property: marker_Sst
+    node_a_value: Sst — defining marker
+    node_b_value: Sst — DEFINING marker of SUPT_0219 (via Sst Gaba subclass)
+    alignment: CONSISTENT
+  - property: marker_Nos1
+    node_a_value: Nos1 — defining marker (intersectional genetics, Sst;;Nos1 strategy)
+    node_b_value: not listed in SUPT_0219 markers
+    alignment: NOT_ASSESSED
+    notes: 'Nos1 is critical for the Sst;;Nos1 intersectional identification of O-O cells. Its absence from atlas defining
+      markers does not confirm absence of expression — may reflect different marker selection criteria.
+
+      '
+  - property: marker_Id3
+    node_a_value: not listed
+    node_b_value: Id3 — DEFINING marker of SUPT_0219
+    alignment: NOT_ASSESSED
+  - property: marker_Sp9
+    node_a_value: not listed
+    node_b_value: Sp9 — DEFINING marker of SUPT_0219
+    alignment: NOT_ASSESSED
+  caveats:
+  - caveat_type: OTHER
+    description: 'O-O cell evidence is thin: identified in a single study (Chamberland et al. 2024, PMID:38640347) using Sst;;Nos1
+      intersectional Cre/Flp. The assignment to SUPT_0219 is based on Sst co-expression alone; the Nos1 component is not confirmed
+      in the atlas supertype. CA3 vs CA1 enrichment mismatch further weakens this assignment.
+
+      '
+  - caveat_type: MARKER_NOT_SPECIFIC
+    description: 'Sst Gaba_6 subclass contains multiple supertypes. Without Nos1 verification at the atlas level, it is unclear
+      which (if any) Sst Gaba_6 supertype captures the O-O cell population. SUPT_0219 is a plausible candidate based on hippocampal
+      enrichment but remains unconfirmed.
+
+      '
+  unresolved_questions:
+  - Does SUPT_0219 express Nos1? If so, at what penetrance?
+  - Are the CA3 SO cells in SUPT_0219 analogous to the CA1 O-O cells described by Chamberland 2024?
+  - Is there a CA1 SO Sst+/Nos1+ supertype better matching O-O cell identity?
+- id: edge_trilaminar_cell_hippocampus_to_CS20230722_SUPT_0206
+  type_a: trilaminar_cell_hippocampus
+  type_b: CS20230722_SUPT_0206
+  relationship: PARTIAL_OVERLAP
+  confidence: LOW
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Pvalb Gaba_2 supertype is enriched in CA1 stratum oriens (493 cells) and CA3 stratum oriens (152 cells),
+      consistent with the trilaminar cell soma location in stratum oriens. Pvalb subclass is consistent with the PV+/Sst-
+      marker profile of the trilaminar cell. However, the trilaminar cell is defined by long-range projection to subiculum
+      and medial septum and a unique burst-firing pattern — properties that cannot be assessed from atlas metadata alone.
+      SUPT_0206 likely contains multiple PV+ interneuron types including PV basket cells, making overlap partial.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA (Pvalb Gaba subclass)
+    alignment: CONSISTENT
+  - property: location_stratum_oriens
+    node_a_value: stratum oriens (SOMA)
+    node_b_value: CA1 stratum oriens (493 cells), CA3 stratum oriens (152 cells)
+    alignment: CONSISTENT
+  - property: marker_Pvalb
+    node_a_value: Pvalb — defining marker
+    node_b_value: Pvalb Gaba subclass (Pvalb implicit)
+    alignment: CONSISTENT
+  - property: marker_M2R
+    node_a_value: M2R (Chrm2) — defining marker
+    node_b_value: not present in supertype defining markers
+    alignment: NOT_ASSESSED
+    notes: Chrm2 not represented in SUPT_0206 marker list; cannot confirm or exclude.
+  - property: negative_marker_Sst
+    node_a_value: Sst — negative marker
+    node_b_value: Sst absent from Pvalb Gaba_2 defining markers
+    alignment: CONSISTENT
+  caveats:
+  - caveat_type: AMBIGUOUS_MAPPING
+    description: 'SUPT_0206 (Pvalb Gaba_2) is the same supertype assigned to PV basket cells. The trilaminar cell and PV basket
+      cell share Pvalb expression and stratum oriens soma location; this supertype likely contains both types (and possibly
+      axo-axonic cells). No transcriptomic features distinguishing trilaminar cells from other PV+ interneurons are available
+      in the atlas metadata.
+
+      '
+  - caveat_type: MARKER_NOT_SPECIFIC
+    description: 'The key discriminating marker M2R (Chrm2) is not represented in SUPT_0206 defining markers. Long-range projection
+      identity cannot be assessed from metadata.
+
+      '
+  - caveat_type: SINGLE_STUDY
+    description: 'Trilaminar cell is well-documented by Katona et al. 2017 (Somogyi lab) but transcriptomic identity has not
+      been independently confirmed.
+
+      '
+- id: edge_vip_basket_cell_hippocampus_to_CS20230722_SUPT_0179
+  type_a: vip_basket_cell_hippocampus
+  type_b: CS20230722_SUPT_0179
+  relationship: UNCERTAIN
+  confidence: UNCERTAIN
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Vip Gaba_7 supertype has Vip as a defining marker, consistent with the VIP+ basket cell marker profile.
+      Atlas anatomy includes CA1 pyramidal layer (11 cells) and CA1 stratum oriens (24 cells), partially consistent with a
+      perisomatic-targeting cell soma in stratum pyramidale. However, SUPT_0179 has limited CA1 representation and is primarily
+      a CA3-enriched supertype (CA3 pyr 23, CA3 SO 25, CA3 SR 17, CA3 lucidum 11). Vip Gaba_7 is also the candidate supertype
+      for IS interneurons (interneuron-selective VIP+ types), making this assignment uncertain without functional/morphological
+      data.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA (Vip Gaba subclass)
+    alignment: CONSISTENT
+  - property: location_stratum_pyramidale
+    node_a_value: stratum pyramidale (SOMA)
+    node_b_value: CA1 pyramidal layer (11 cells); CA3 pyramidal layer (23 cells)
+    alignment: APPROXIMATE
+    notes: 'CA1 pyramidal layer present but low cell count. CA3-enriched overall. Stratum oriens cells (CA1 SO 24) may represent
+      a different VIP type.
+
+      '
+  - property: marker_Vip
+    node_a_value: Vip — defining marker
+    node_b_value: Vip — DEFINING marker in SUPT_0179
+    alignment: CONSISTENT
+  caveats:
+  - caveat_type: AMBIGUOUS_MAPPING
+    description: 'SUPT_0179 (Vip Gaba_7) is also the candidate supertype for IS interneurons (calretinin/VIP+ interneuron-selective
+      cells described in Tyan et al. 2014). VIP basket cells (perisomatic to pyramidal cells) and IS interneurons (targeting
+      other interneurons) are functionally distinct but share VIP expression. Without additional markers (e.g., Cnr1 for basket
+      identity, Calb2 for IS identity) this mapping cannot be resolved from atlas metadata.
+
+      '
+  - caveat_type: SINGLE_STUDY
+    description: 'VIP basket cell described in a single primary study (Tyan et al. 2014, PMID:24671999). Thin evidence base.
+
+      '
+  - caveat_type: LOW_CELL_COUNT
+    description: CA1 pyramidal layer representation in SUPT_0179 is very low (11 cells).
+- id: edge_r_lm_cell_hippocampus_to_CS20230722_SUPT_0216
+  type_a: r_lm_cell_hippocampus
+  type_b: CS20230722_SUPT_0216
+  relationship: UNCERTAIN
+  confidence: UNCERTAIN
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Sst Gaba_3 supertype has strong CA1 stratum oriens representation (818 cells) and Sst-subclass identity,
+      consistent with the SST+ R-LM cell soma location in stratum oriens. Reln is a defining marker of SUPT_0216, which may
+      distinguish it from OLM cells (Chrna2+/Reln+). However, R-LM cells were identified in GIN transgenic mice in a single
+      study (Oliva et al. 2000) without transcriptomic characterisation, so the match is speculative. The Sst Gaba_3 supertype
+      is also the primary candidate for OLM cells (based on MapMyCells annotation transfer with Chrna2-Cre data), meaning
+      this supertype likely contains multiple SST+ stratum oriens types.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA (Sst Gaba subclass)
+    alignment: CONSISTENT
+  - property: location_stratum_oriens
+    node_a_value: stratum oriens (SOMA)
+    node_b_value: CA1 stratum oriens (818 cells)
+    alignment: CONSISTENT
+  - property: marker_Sst
+    node_a_value: Sst — defining marker
+    node_b_value: Sst Gaba subclass (Sst implicit); Reln, Rbp4, Npffr1 are scoped defining markers
+    alignment: CONSISTENT
+  caveats:
+  - caveat_type: AMBIGUOUS_MAPPING
+    description: 'Sst Gaba_3 is also the primary OLM cell candidate supertype (MapMyCells annotation transfer, PMID:31420995
+      data, CS20230722_SUPT_0216). R-LM and OLM cells share SST+ identity and stratum oriens soma location; they cannot be
+      distinguished at this supertype level from metadata alone.
+
+      '
+  - caveat_type: SINGLE_STUDY
+    description: 'R-LM cell described in a single study (Oliva et al. 2000, PMID:10818134) using GIN transgenic mice. No subsequent
+      transcriptomic characterisation. May not be a transcriptomically separable type from OLM or P-LM cells.
+
+      '
+  - caveat_type: NO_DISCRIMINATING_MARKER
+    description: 'No axon-projection or laminar markers distinguishing R-LM from OLM are available in the atlas supertype
+      metadata.
+
+      '
+- id: edge_p_lm_cell_hippocampus_to_CS20230722_SUPT_0219
+  type_a: p_lm_cell_hippocampus
+  type_b: CS20230722_SUPT_0219
+  relationship: UNCERTAIN
+  confidence: UNCERTAIN
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: WEAK
+    explanation: 'The P-LM cell has its soma in stratum pyramidale and is SST+. SUPT_0219 (Sst Gaba_6) is SST-subclass and
+      has defining Sst marker. However, the atlas anatomy for SUPT_0219 is predominantly CA3 (CA3 SO 305, CA3 lucidum 99,
+      CA3 SR 167, CA3 pyr 261) with no CA1 representation. The P-LM cell is a CA1 type. This anatomical mismatch weakens the
+      candidate assignment. Assignment is retained as a placeholder pending richer evidence; the SST+ stratum pyramidale signature
+      provides weak but non-zero support.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA (Sst Gaba subclass)
+    alignment: CONSISTENT
+  - property: location_stratum_pyramidale
+    node_a_value: stratum pyramidale (SOMA)
+    node_b_value: CA3 pyramidal layer (261 cells); no CA1 pyramidal layer
+    alignment: DISCORDANT
+    notes: 'P-LM cell described in CA1; SUPT_0219 has no CA1 representation in atlas metadata. CA3 pyramidal layer cells present
+      but classical type not documented in CA3.
+
+      '
+  - property: marker_Sst
+    node_a_value: Sst — defining marker
+    node_b_value: Sst — DEFINING marker in SUPT_0219
+    alignment: CONSISTENT
+  caveats:
+  - caveat_type: DISCORDANT_ANATOMY
+    description: 'SUPT_0219 is a CA3-enriched supertype with no CA1 representation. The P-LM cell is a CA1 type described
+      in stratum pyramidale. This is the primary source of uncertainty. A CA1-enriched Sst supertype (e.g., SUPT_0216) may
+      be a better match, but the soma in stratum pyramidale (not oriens) motivated this distinct candidate.
+
+      '
+  - caveat_type: SINGLE_STUDY
+    description: 'P-LM cell described in a single study (Oliva et al. 2000, PMID:10818134). Not transcriptomically characterised.
+      May be the same transcriptomic type as R-LM cells; the two types were described together in one study and may not be
+      separable.
+
+      '
+  - caveat_type: AMBIGUOUS_MAPPING
+    description: 'R-LM and P-LM were identified in the same study and differ only in soma laminar position (stratum oriens
+      vs stratum pyramidale). Whether they constitute distinct transcriptomic types or a single type with variable soma location
+      is unknown.
+
+      '
+- id: edge_lth_cell_hippocampus_to_CS20230722_SUPT_0219
+  type_a: lth_cell_hippocampus
+  type_b: CS20230722_SUPT_0219
+  relationship: UNCERTAIN
+  confidence: UNCERTAIN
+  evidence:
+  - evidence_type: ATLAS_METADATA
+    supports: WEAK
+    explanation: 'The LTH (Low-Threshold High-Ih) cell is SST+ with soma in CA1 stratum oriens, defined by physiological clustering
+      (strong spike frequency adaptation, high Ih) in SST-Cre Ai14 mice (Hewitt et al. 2021). SUPT_0219 (Sst Gaba_6) is SST-subclass
+      consistent with SST-Cre labelling. Assignment to SUPT_0219 rather than SUPT_0216 is speculative — it is based on the
+      expectation that LTH may be a distinct SST+ type from OLM (which maps to SUPT_0216). The CA3-enriched anatomy of SUPT_0219
+      is discordant with the CA1 stratum oriens description of LTH cells. Overall support is weak.
+
+      '
+  property_comparisons:
+  - property: nt_type
+    node_a_value: GABAergic
+    node_b_value: GABA (Sst Gaba subclass)
+    alignment: CONSISTENT
+  - property: location_stratum_oriens
+    node_a_value: CA1 stratum oriens (SOMA)
+    node_b_value: CA3 stratum oriens (305 cells); no CA1 stratum oriens
+    alignment: DISCORDANT
+    notes: 'LTH cell described in CA1 stratum oriens; SUPT_0219 has no CA1 SO representation.
+
+      '
+  - property: marker_Sst
+    node_a_value: Sst — defining marker (SST-Cre labelling)
+    node_b_value: Sst — DEFINING marker in SUPT_0219
+    alignment: CONSISTENT
+  caveats:
+  - caveat_type: ELECTROPHYSIOLOGY_ONLY_DEFINITION
+    description: 'LTH cell is defined exclusively by physiological clustering (Hewitt et al. 2021, PMID:34250732) in a single
+      study. No morphological reconstruction or molecular markers beyond SST-Cre labelling. Transcriptomic identity is entirely
+      unknown; LTH may overlap with oriens-oriens cells (also SST+/Nos1+) or represent a physiological variant within an existing
+      transcriptomic type rather than a distinct type.
+
+      '
+  - caveat_type: DISCORDANT_ANATOMY
+    description: 'SUPT_0219 is CA3-enriched with no CA1 stratum oriens cells. LTH was characterised in CA1. Anatomical assignment
+      is the main weakness of this edge.
+
+      '
+  - caveat_type: SINGLE_STUDY
+    description: 'Single-study (single-lab) evidence for LTH as a distinct cell type. Classification stability across datasets
+      has not been established.
+
+      '
+  - caveat_type: AMBIGUOUS_MAPPING
+    description: 'LTH cells may overlap with OLM cells (both SST+, CA1 SO soma) at the transcriptomic level. If so, SUPT_0216
+      (not SUPT_0219) would be the correct target. The assignment to SUPT_0219 is a placeholder pending molecular characterisation.
+
+      '

--- a/src/evidencell/taxonomy_db.py
+++ b/src/evidencell/taxonomy_db.py
@@ -1407,6 +1407,77 @@ def _cmd_build_closure(taxonomy_id: str, mba_json: str) -> None:
     print(f"  anat_closure rows: {n_closure:,}")
 
 
+def _resolve_mba_by_name(con: "sqlite3.Connection", name: str) -> list[str]:
+    """Fallback: resolve an anatomical location name to MBA IDs by label matching.
+
+    Used when a UBERON ID has no xref in the MBA ontology.  Tries direct
+    substring match first, then applies Latin→English layer synonyms and
+    hippocampal field prefix normalisation (e.g. "CA1 stratum pyramidale"
+    → "Field CA1, pyramidal layer").
+    """
+    if not name:
+        return []
+
+    norm = name.lower().strip()
+
+    # Latin→English layer synonyms (hippocampal nomenclature)
+    _LAYER_SYNONYMS = {
+        "stratum pyramidale": "pyramidal layer",
+        "stratum moleculare": "molecular layer",
+    }
+
+    # 1. Direct substring match on MBA label (also try with commas/punctuation stripped)
+    rows = con.execute(
+        "SELECT anat_id FROM anat_terms WHERE LOWER(label) LIKE ?",
+        (f"%{norm}%",),
+    ).fetchall()
+    if rows:
+        return [r[0] for r in rows]
+
+    # 1b. Try keyword match — all significant words must appear in the label
+    words = [w for w in norm.split() if len(w) > 2]
+    if len(words) >= 2:
+        where = " AND ".join(["LOWER(label) LIKE ?"] * len(words))
+        params = [f"%{w}%" for w in words]
+        rows = con.execute(
+            f"SELECT anat_id FROM anat_terms WHERE {where}", params
+        ).fetchall()
+        if rows:
+            return [r[0] for r in rows]
+
+    # 2. Apply Latin→English synonyms and retry
+    norm_sub = norm
+    for latin, english in _LAYER_SYNONYMS.items():
+        if latin in norm:
+            norm_sub = norm.replace(latin, english)
+            break
+
+    # 3. Normalise hippocampal field prefixes: "CA1 ..." → "Field CA1, ..."
+    _FIELDS = {"ca1": "Field CA1", "ca2": "Field CA2", "ca3": "Field CA3"}
+    for abbrev, mba_prefix in _FIELDS.items():
+        if norm_sub.startswith(abbrev + " "):
+            layer_part = norm_sub[len(abbrev) + 1:]
+            pattern = f"{mba_prefix}%{layer_part}%"
+            rows = con.execute(
+                "SELECT anat_id FROM anat_terms WHERE LOWER(label) LIKE LOWER(?)",
+                (pattern,),
+            ).fetchall()
+            if rows:
+                return [r[0] for r in rows]
+            break  # only one field prefix possible
+
+    # 4. Try synonym-substituted name without field prefix
+    if norm_sub != norm:
+        rows = con.execute(
+            "SELECT anat_id FROM anat_terms WHERE LOWER(label) LIKE ?",
+            (f"%{norm_sub}%",),
+        ).fetchall()
+        if rows:
+            return [r[0] for r in rows]
+
+    return []
+
+
 def _cmd_find_candidates(
     graph_file: str,
     node_id: str,
@@ -1464,6 +1535,7 @@ def _cmd_find_candidates(
         nt_type = nt_obj
 
     # Extract soma locations only (skip AXON_TARGET, DENDRITE)
+    soma_locs: list[dict] = []
     anat_ids: list[str] = []
     for loc in classical.get("anatomical_location") or []:
         compartment = loc.get("compartment")
@@ -1471,30 +1543,66 @@ def _cmd_find_candidates(
             continue
         loc_id = loc.get("id")
         if loc_id:
+            soma_locs.append(loc)
             anat_ids.append(loc_id)
 
     db = TaxonomyDB(db_path)
 
-    # Resolve UBERON IDs to MBA IDs via anat_terms lookup
+    # Resolve UBERON IDs to MBA IDs via anat_terms lookup, with name fallback
     mba_ids: list[str] = []
-    uberon_ids: list[str] = []
-    for aid in anat_ids:
-        if aid.startswith("UBERON:"):
-            uberon_ids.append(aid)
-        else:
-            mba_ids.append(aid)
-
-    if uberon_ids:
-        with db._connect() as con:
-            for uid in uberon_ids:
-                rows = con.execute(
-                    "SELECT anat_id FROM anat_terms WHERE uberon_id = ?", (uid,)
-                ).fetchall()
-                resolved = [r[0] for r in rows]
-                if resolved:
-                    mba_ids.extend(resolved)
+    with db._connect() as con:
+        for loc in soma_locs:
+            aid = loc["id"]
+            if not aid.startswith("UBERON:"):
+                mba_ids.append(aid)
+                continue
+            rows = con.execute(
+                "SELECT anat_id, label FROM anat_terms WHERE uberon_id = ?", (aid,)
+            ).fetchall()
+            resolved = [r[0] for r in rows]
+            # Sanity check: if the xref-resolved MBA label shares no keywords
+            # with the source name, the xref is likely wrong (e.g. UBERON:0005383
+            # "stratum oriens" → MBA:672 "Caudoputamen").  Prefer name fallback.
+            name = loc.get("name_in_source") or loc.get("label") or ""
+            if resolved and name:
+                name_words = {w.lower() for w in name.split() if len(w) > 2}
+                xref_label = rows[0][1].lower()
+                xref_words = {w.strip(",") for w in xref_label.split() if len(w) > 2}
+                if not (name_words & xref_words):
+                    # No word overlap — likely wrong xref
+                    fallback = _resolve_mba_by_name(con, name)
+                    if fallback:
+                        print(
+                            f"  {aid} xref → {resolved} ({rows[0][1]}) — "
+                            f"name mismatch with {name!r}, using name fallback: "
+                            f"{fallback}",
+                            file=sys.stderr,
+                        )
+                        resolved = fallback
+                    else:
+                        print(
+                            f"  WARNING: {aid} xref → {resolved} ({rows[0][1]}) — "
+                            f"name mismatch with {name!r}, but no name fallback found",
+                            file=sys.stderr,
+                        )
+            if resolved:
+                mba_ids.extend(resolved)
+            else:
+                # Fallback: resolve by name_in_source or label
+                name = loc.get("name_in_source") or loc.get("label") or ""
+                fallback = _resolve_mba_by_name(con, name)
+                if fallback:
+                    mba_ids.extend(fallback)
+                    print(
+                        f"  {aid} has no MBA xref — resolved by name: "
+                        f"{name!r} → {fallback}",
+                        file=sys.stderr,
+                    )
                 else:
-                    print(f"  WARNING: {uid} has no MBA mapping — skipped", file=sys.stderr)
+                    print(
+                        f"  WARNING: {aid} ({name}) has no MBA mapping — skipped",
+                        file=sys.stderr,
+                    )
 
     print(f"Classical node: {node_id} ({classical.get('name', '?')})", file=sys.stderr)
     print(f"  NT type: {nt_type}", file=sys.stderr)


### PR DESCRIPTION


## Summary
- Add `_resolve_mba_by_name()` fallback for UBERON→MBA resolution when xref missing or wrong
- Add xref sanity check (detects name mismatches like UBERON:0005383 → Caudoputamen)
- Map all 15 hippocampal GABAergic interneuron types to WMBv1 atlas candidates (18 edges: 10 LOW, 8 UNCERTAIN)
- Add ROADMAP items S4 (dual MBA+UBERON annotation) and S5 (iterative refinement infrastructure)

## Key mappings
- SUPT_0216 (Sst Gaba_3): OLM, bistratified, HS, R-LM
- SUPT_0206 (Pvalb Gaba_2): PV basket, trilaminar  
- SUPT_0179 (Vip Gaba_7): IS interneuron, VIP basket, CCK basket
- SUPT_0204 (Pvalb chandelier): axo-axonic (EQUIVALENT)