### PR TITLE
At/ctx hpf taxonomy

### DIFF
--- a/inputs/taxonomies/CS202106160_meta.yaml
+++ b/inputs/taxonomies/CS202106160_meta.yaml
@@ -1,0 +1,11 @@
+# Taxonomy metadata input for CS202106160 (CTX-HPF — Mouse Cortex + Hippocampal Formation)
+# Source: Yao et al. 2021 (doi:10.1016/j.cell.2021.04.021)
+# CAS v5.3.0 format (Cell Annotation Schema)
+# Read by: just ingest-taxonomy-yaml inputs/taxonomies/CS202106160.json CS202106160
+
+taxonomy_name: "CTX-HPF (Mouse Cortex + Hippocampal Formation, Yao 2021)"
+species_id: NCBITaxon:10090
+species_label: Mus musculus
+tissue_id: UBERON:0000956
+tissue_label: cerebral cortex
+anatomy_ontology: null

--- a/inputs/taxonomies/test_cas_fixture.json
+++ b/inputs/taxonomies/test_cas_fixture.json
@@ -1,0 +1,60 @@
+{
+  "author_name": "Test Author",
+  "title": "Test CAS Taxonomy",
+  "description": "Minimal CAS v5.3.0 fixture for testing",
+  "cellannotation_schema_version": "5.3.0",
+  "labelsets": [
+    {"name": "class_label", "description": "Coarse level", "rank": 2},
+    {"name": "subclass_label", "description": "Fine level", "rank": 1},
+    {"name": "cluster_label", "description": "Finest level", "rank": 0}
+  ],
+  "annotations": [
+    {
+      "labelset": "class_label",
+      "cell_label": "GABAergic",
+      "cell_set_accession": "class_label:abc123",
+      "cell_fullname": "GABAergic",
+      "rationale_dois": [],
+      "parent_cell_set_accession": null,
+      "author_annotation_fields": {
+        "taxonomy_id": "TEST_CAS"
+      }
+    },
+    {
+      "labelset": "subclass_label",
+      "cell_label": "Sst",
+      "cell_set_accession": "TEST_CAS_444",
+      "cell_fullname": "Sst",
+      "rationale_dois": ["https://doi.org/10.1016/j.cell.2021.04.021"],
+      "parent_cell_set_accession": "class_label:abc123",
+      "author_annotation_fields": {
+        "cell_set_designation": "TEST 001-003",
+        "taxonomy_id": "TEST_CAS"
+      }
+    },
+    {
+      "labelset": "cluster_label",
+      "cell_label": "79_Sst",
+      "cell_set_accession": "TEST_CAS_79",
+      "cell_fullname": "79_Sst",
+      "rationale_dois": ["https://doi.org/10.1016/j.cell.2021.04.021"],
+      "parent_cell_set_accession": "TEST_CAS_444",
+      "author_annotation_fields": {
+        "cell_set_designation": "TEST 079",
+        "taxonomy_id": "TEST_CAS"
+      }
+    },
+    {
+      "labelset": "cluster_label",
+      "cell_label": "80_Sst",
+      "cell_set_accession": "TEST_CAS_80",
+      "cell_fullname": "80_Sst",
+      "rationale_dois": ["https://doi.org/10.1016/j.cell.2021.04.021"],
+      "parent_cell_set_accession": "TEST_CAS_444",
+      "author_annotation_fields": {
+        "cell_set_designation": "TEST 080",
+        "taxonomy_id": "TEST_CAS"
+      }
+    }
+  ]
+}

--- a/kb/draft/hippocampus/hippocampus_GABAergic_interneurons.yaml
+++ b/kb/draft/hippocampus/hippocampus_GABAergic_interneurons.yaml
@@ -14,6 +14,16 @@ notes: 'All nodes are CLASSICAL_MULTIMODAL. Species field left null — most evi
   confirmed per-node from primary sources. Marker ncbi_gene_ids left null — require NodeNormalization lookup.
 
   '
+annotation_transfer_datasets:
+- accession: GEO:GSE142546
+  publication: PMID:33398060
+  description: Que et al. 2021 — patch-seq of 88 morphologically identified PV-INs (basket, axo-axonic, bistratified) in mouse
+    hippocampal CA1, P10–P77
+  cell_types:
+  - pv_basket_cell_hippocampus
+  - axo_axonic_cell_hippocampus
+  - bistratified_cell_hippocampus
+  status: pending_retrieval
 nodes:
 - id: pv_basket_cell_hippocampus
   name: Parvalbumin-positive basket cell
@@ -1651,46 +1661,1331 @@ nodes:
   definition_basis: ATLAS_TRANSCRIPTOMIC
   taxonomy_id: CCN20230722
   cell_set_accession: CS20230722_CLUS_0732
+  precomputed_expression:
+    source: precomputed_stats_ABC_revision_230821.h5
+    level: cluster
+    genes:
+    - symbol: Calb2
+      ensembl_id: ENSMUSG00000003657
+      mean_expression: 0.29
+    - symbol: Cck
+      ensembl_id: ENSMUSG00000032532
+      mean_expression: 8.36
+    - symbol: Chrm2
+      ensembl_id: ENSMUSG00000045613
+      mean_expression: 7.73
+    - symbol: Chrna2
+      ensembl_id: ENSMUSG00000027577
+      mean_expression: 0.03
+    - symbol: Cnr1
+      ensembl_id: ENSMUSG00000044288
+      mean_expression: 2.22
+    - symbol: Gad1
+      ensembl_id: ENSMUSG00000070880
+      mean_expression: 10.05
+    - symbol: Gad2
+      ensembl_id: ENSMUSG00000026787
+      mean_expression: 8.81
+    - symbol: Id2
+      ensembl_id: ENSMUSG00000020644
+      mean_expression: 5.56
+    - symbol: Lamp5
+      ensembl_id: ENSMUSG00000025810
+      mean_expression: 6.97
+    - symbol: Nos1
+      ensembl_id: ENSMUSG00000029361
+      mean_expression: 2.88
+    - symbol: Npy
+      ensembl_id: ENSMUSG00000029819
+      mean_expression: 4.07
+    - symbol: Pnoc
+      ensembl_id: ENSMUSG00000045731
+      mean_expression: 0.61
+    - symbol: Pvalb
+      ensembl_id: ENSMUSG00000005716
+      mean_expression: 8.56
+    - symbol: Reln
+      ensembl_id: ENSMUSG00000042453
+      mean_expression: 1.3
+    - symbol: Slc17a8
+      ensembl_id: ENSMUSG00000019935
+      mean_expression: 0.57
+    - symbol: Sst
+      ensembl_id: ENSMUSG00000004366
+      mean_expression: 0.97
+    - symbol: Tac1
+      ensembl_id: ENSMUSG00000061762
+      mean_expression: 1.47
+    - symbol: Vip
+      ensembl_id: ENSMUSG00000019772
+      mean_expression: 0.47
 - id: CS20230722_CLUS_0739
   name: 0739 Pvalb Gaba_2
   definition_basis: ATLAS_TRANSCRIPTOMIC
   taxonomy_id: CCN20230722
   cell_set_accession: CS20230722_CLUS_0739
+  precomputed_expression:
+    source: precomputed_stats_ABC_revision_230821.h5
+    level: cluster
+    genes:
+    - symbol: Calb2
+      ensembl_id: ENSMUSG00000003657
+      mean_expression: 0.39
+    - symbol: Cck
+      ensembl_id: ENSMUSG00000032532
+      mean_expression: 7.56
+    - symbol: Chrm2
+      ensembl_id: ENSMUSG00000045613
+      mean_expression: 6.96
+    - symbol: Chrna2
+      ensembl_id: ENSMUSG00000027577
+      mean_expression: 0.43
+    - symbol: Cnr1
+      ensembl_id: ENSMUSG00000044288
+      mean_expression: 1.68
+    - symbol: Gad1
+      ensembl_id: ENSMUSG00000070880
+      mean_expression: 10.52
+    - symbol: Gad2
+      ensembl_id: ENSMUSG00000026787
+      mean_expression: 8.43
+    - symbol: Id2
+      ensembl_id: ENSMUSG00000020644
+      mean_expression: 3.43
+    - symbol: Lamp5
+      ensembl_id: ENSMUSG00000025810
+      mean_expression: 6.29
+    - symbol: Nos1
+      ensembl_id: ENSMUSG00000029361
+      mean_expression: 2.08
+    - symbol: Npy
+      ensembl_id: ENSMUSG00000029819
+      mean_expression: 1.33
+    - symbol: Pnoc
+      ensembl_id: ENSMUSG00000045731
+      mean_expression: 0.32
+    - symbol: Pvalb
+      ensembl_id: ENSMUSG00000005716
+      mean_expression: 10.63
+    - symbol: Reln
+      ensembl_id: ENSMUSG00000042453
+      mean_expression: 0.8
+    - symbol: Slc17a8
+      ensembl_id: ENSMUSG00000019935
+      mean_expression: 0.0
+    - symbol: Sst
+      ensembl_id: ENSMUSG00000004366
+      mean_expression: 1.51
+    - symbol: Tac1
+      ensembl_id: ENSMUSG00000061762
+      mean_expression: 3.69
+    - symbol: Vip
+      ensembl_id: ENSMUSG00000019772
+      mean_expression: 0.33
 - id: CS20230722_SUPT_0179
   name: 0179 Vip Gaba_7
   definition_basis: ATLAS_TRANSCRIPTOMIC
   taxonomy_id: CCN20230722
   cell_set_accession: CS20230722_SUPT_0179
+  precomputed_expression:
+    source: precomputed_stats_ABC_revision_230821.h5
+    level: supertype
+    genes:
+    - symbol: Calb2
+      ensembl_id: ENSMUSG00000003657
+      mean_expression: 6.78
+    - symbol: Cck
+      ensembl_id: ENSMUSG00000032532
+      mean_expression: 1.36
+    - symbol: Chrm2
+      ensembl_id: ENSMUSG00000045613
+      mean_expression: 0.27
+    - symbol: Chrna2
+      ensembl_id: ENSMUSG00000027577
+      mean_expression: 3.74
+    - symbol: Cnr1
+      ensembl_id: ENSMUSG00000044288
+      mean_expression: 10.58
+    - symbol: Gad1
+      ensembl_id: ENSMUSG00000070880
+      mean_expression: 9.29
+    - symbol: Gad2
+      ensembl_id: ENSMUSG00000026787
+      mean_expression: 9.59
+    - symbol: Id2
+      ensembl_id: ENSMUSG00000020644
+      mean_expression: 2.93
+    - symbol: Lamp5
+      ensembl_id: ENSMUSG00000025810
+      mean_expression: 6.16
+    - symbol: Nos1
+      ensembl_id: ENSMUSG00000029361
+      mean_expression: 6.9
+    - symbol: Npy
+      ensembl_id: ENSMUSG00000029819
+      mean_expression: 1.3
+    - symbol: Pnoc
+      ensembl_id: ENSMUSG00000045731
+      mean_expression: 4.57
+    - symbol: Pvalb
+      ensembl_id: ENSMUSG00000005716
+      mean_expression: 0.09
+    - symbol: Reln
+      ensembl_id: ENSMUSG00000042453
+      mean_expression: 4.33
+    - symbol: Slc17a8
+      ensembl_id: ENSMUSG00000019935
+      mean_expression: 0.42
+    - symbol: Sst
+      ensembl_id: ENSMUSG00000004366
+      mean_expression: 1.04
+    - symbol: Tac1
+      ensembl_id: ENSMUSG00000061762
+      mean_expression: 0.16
+    - symbol: Vip
+      ensembl_id: ENSMUSG00000019772
+      mean_expression: 6.82
+    child_cluster_expression:
+    - cluster_accession: CS20230722_CLUS_0649
+      n_cells: 1
+      expression:
+        Calb2: 7.47
+        Cck: 0.92
+        Chrna2: 4.38
+        Cnr1: 10.5
+        Gad1: 9.43
+        Gad2: 9.55
+        Id2: 1.58
+        Lamp5: 6.73
+        Chrm2: 0.16
+        Nos1: 8.32
+        Npy: 1.35
+        Pnoc: 4.3
+        Pvalb: 0.12
+        Reln: 4.93
+        Sst: 1.16
+        Tac1: 0.16
+        Slc17a8: 0.05
+        Vip: 9.17
+    - cluster_accession: CS20230722_CLUS_0650
+      n_cells: 1
+      expression:
+        Calb2: 5.96
+        Cck: 1.57
+        Chrna2: 4.33
+        Cnr1: 10.11
+        Gad1: 9.0
+        Gad2: 9.3
+        Id2: 3.5
+        Lamp5: 3.89
+        Chrm2: 0.14
+        Nos1: 3.38
+        Npy: 1.04
+        Pnoc: 6.43
+        Pvalb: 0.1
+        Reln: 4.0
+        Sst: 1.26
+        Tac1: 0.16
+        Slc17a8: 0.08
+        Vip: 4.84
+    - cluster_accession: CS20230722_CLUS_0651
+      n_cells: 1
+      expression:
+        Calb2: 6.9
+        Cck: 1.59
+        Chrna2: 2.51
+        Cnr1: 11.12
+        Gad1: 9.44
+        Gad2: 9.93
+        Id2: 3.71
+        Lamp5: 7.87
+        Chrm2: 0.51
+        Nos1: 9.01
+        Npy: 1.52
+        Pnoc: 2.98
+        Pvalb: 0.05
+        Reln: 4.07
+        Sst: 0.7
+        Tac1: 0.15
+        Slc17a8: 1.13
+        Vip: 6.45
 - id: CS20230722_SUPT_0193
   name: 0193 RHP-COA Ndnf Gaba_1
   definition_basis: ATLAS_TRANSCRIPTOMIC
   taxonomy_id: CCN20230722
   cell_set_accession: CS20230722_SUPT_0193
+  precomputed_expression:
+    source: precomputed_stats_ABC_revision_230821.h5
+    level: supertype
+    genes:
+    - symbol: Calb2
+      ensembl_id: ENSMUSG00000003657
+      mean_expression: 0.31
+    - symbol: Cck
+      ensembl_id: ENSMUSG00000032532
+      mean_expression: 6.33
+    - symbol: Chrm2
+      ensembl_id: ENSMUSG00000045613
+      mean_expression: 0.29
+    - symbol: Chrna2
+      ensembl_id: ENSMUSG00000027577
+      mean_expression: 0.48
+    - symbol: Cnr1
+      ensembl_id: ENSMUSG00000044288
+      mean_expression: 11.43
+    - symbol: Gad1
+      ensembl_id: ENSMUSG00000070880
+      mean_expression: 9.43
+    - symbol: Gad2
+      ensembl_id: ENSMUSG00000026787
+      mean_expression: 10.21
+    - symbol: Id2
+      ensembl_id: ENSMUSG00000020644
+      mean_expression: 4.88
+    - symbol: Lamp5
+      ensembl_id: ENSMUSG00000025810
+      mean_expression: 3.65
+    - symbol: Nos1
+      ensembl_id: ENSMUSG00000029361
+      mean_expression: 2.26
+    - symbol: Npy
+      ensembl_id: ENSMUSG00000029819
+      mean_expression: 2.61
+    - symbol: Pnoc
+      ensembl_id: ENSMUSG00000045731
+      mean_expression: 6.25
+    - symbol: Pvalb
+      ensembl_id: ENSMUSG00000005716
+      mean_expression: 0.27
+    - symbol: Reln
+      ensembl_id: ENSMUSG00000042453
+      mean_expression: 8.13
+    - symbol: Slc17a8
+      ensembl_id: ENSMUSG00000019935
+      mean_expression: 0.61
+    - symbol: Sst
+      ensembl_id: ENSMUSG00000004366
+      mean_expression: 1.51
+    - symbol: Tac1
+      ensembl_id: ENSMUSG00000061762
+      mean_expression: 0.1
+    - symbol: Vip
+      ensembl_id: ENSMUSG00000019772
+      mean_expression: 0.93
+    child_cluster_expression:
+    - cluster_accession: CS20230722_CLUS_0686
+      n_cells: 1
+      expression:
+        Calb2: 0.34
+        Cck: 8.92
+        Chrna2: 0.73
+        Cnr1: 11.81
+        Gad1: 9.41
+        Gad2: 10.33
+        Id2: 5.88
+        Lamp5: 1.59
+        Chrm2: 0.44
+        Nos1: 3.13
+        Npy: 3.01
+        Pnoc: 6.99
+        Pvalb: 0.35
+        Reln: 8.41
+        Sst: 1.48
+        Tac1: 0.21
+        Slc17a8: 0.09
+        Vip: 0.92
+    - cluster_accession: CS20230722_CLUS_0687
+      n_cells: 1
+      expression:
+        Calb2: 0.05
+        Cck: 8.67
+        Chrna2: 0.21
+        Cnr1: 11.68
+        Gad1: 9.56
+        Gad2: 10.44
+        Id2: 5.44
+        Lamp5: 5.19
+        Chrm2: 0.36
+        Nos1: 3.42
+        Npy: 1.86
+        Pnoc: 6.74
+        Pvalb: 0.41
+        Reln: 6.78
+        Sst: 1.11
+        Tac1: 0.14
+        Slc17a8: 1.14
+        Vip: 0.88
+    - cluster_accession: CS20230722_CLUS_0688
+      n_cells: 1
+      expression:
+        Calb2: 0.23
+        Cck: 2.13
+        Chrna2: 0.26
+        Cnr1: 10.84
+        Gad1: 9.56
+        Gad2: 10.27
+        Id2: 3.93
+        Lamp5: 4.87
+        Chrm2: 0.25
+        Nos1: 2.02
+        Npy: 1.65
+        Pnoc: 6.43
+        Pvalb: 0.26
+        Reln: 7.57
+        Sst: 1.71
+        Tac1: 0.0
+        Slc17a8: 1.02
+        Vip: 0.88
+    - cluster_accession: CS20230722_CLUS_0689
+      n_cells: 1
+      expression:
+        Calb2: 0.61
+        Cck: 5.62
+        Chrna2: 0.74
+        Cnr1: 11.41
+        Gad1: 9.2
+        Gad2: 9.82
+        Id2: 4.29
+        Lamp5: 2.94
+        Chrm2: 0.12
+        Nos1: 0.47
+        Npy: 3.91
+        Pnoc: 4.84
+        Pvalb: 0.04
+        Reln: 9.76
+        Sst: 1.74
+        Tac1: 0.05
+        Slc17a8: 0.21
+        Vip: 1.03
 - id: CS20230722_SUPT_0203
   name: 0203 Lamp5 Lhx6 Gaba_1
   definition_basis: ATLAS_TRANSCRIPTOMIC
   taxonomy_id: CCN20230722
   cell_set_accession: CS20230722_SUPT_0203
+  precomputed_expression:
+    source: precomputed_stats_ABC_revision_230821.h5
+    level: supertype
+    genes:
+    - symbol: Calb2
+      ensembl_id: ENSMUSG00000003657
+      mean_expression: 0.37
+    - symbol: Cck
+      ensembl_id: ENSMUSG00000032532
+      mean_expression: 6.59
+    - symbol: Chrm2
+      ensembl_id: ENSMUSG00000045613
+      mean_expression: 1.52
+    - symbol: Chrna2
+      ensembl_id: ENSMUSG00000027577
+      mean_expression: 0.46
+    - symbol: Cnr1
+      ensembl_id: ENSMUSG00000044288
+      mean_expression: 3.71
+    - symbol: Gad1
+      ensembl_id: ENSMUSG00000070880
+      mean_expression: 10.89
+    - symbol: Gad2
+      ensembl_id: ENSMUSG00000026787
+      mean_expression: 10.34
+    - symbol: Id2
+      ensembl_id: ENSMUSG00000020644
+      mean_expression: 9.35
+    - symbol: Lamp5
+      ensembl_id: ENSMUSG00000025810
+      mean_expression: 4.4
+    - symbol: Nos1
+      ensembl_id: ENSMUSG00000029361
+      mean_expression: 7.79
+    - symbol: Npy
+      ensembl_id: ENSMUSG00000029819
+      mean_expression: 4.62
+    - symbol: Pnoc
+      ensembl_id: ENSMUSG00000045731
+      mean_expression: 6.37
+    - symbol: Pvalb
+      ensembl_id: ENSMUSG00000005716
+      mean_expression: 0.43
+    - symbol: Reln
+      ensembl_id: ENSMUSG00000042453
+      mean_expression: 6.89
+    - symbol: Slc17a8
+      ensembl_id: ENSMUSG00000019935
+      mean_expression: 0.06
+    - symbol: Sst
+      ensembl_id: ENSMUSG00000004366
+      mean_expression: 1.52
+    - symbol: Tac1
+      ensembl_id: ENSMUSG00000061762
+      mean_expression: 2.64
+    - symbol: Vip
+      ensembl_id: ENSMUSG00000019772
+      mean_expression: 0.67
+    child_cluster_expression:
+    - cluster_accession: CS20230722_CLUS_0724
+      n_cells: 1
+      expression:
+        Calb2: 0.28
+        Cck: 6.85
+        Chrna2: 0.88
+        Cnr1: 3.74
+        Gad1: 11.15
+        Gad2: 11.37
+        Id2: 9.87
+        Lamp5: 4.13
+        Chrm2: 0.47
+        Nos1: 9.14
+        Npy: 6.66
+        Pnoc: 7.88
+        Pvalb: 0.23
+        Reln: 5.42
+        Sst: 1.18
+        Tac1: 0.38
+        Slc17a8: 0.06
+        Vip: 0.38
+    - cluster_accession: CS20230722_CLUS_0725
+      n_cells: 1
+      expression:
+        Calb2: 0.43
+        Cck: 8.13
+        Chrna2: 0.25
+        Cnr1: 2.0
+        Gad1: 10.75
+        Gad2: 9.98
+        Id2: 8.81
+        Lamp5: 5.04
+        Chrm2: 2.3
+        Nos1: 8.18
+        Npy: 7.24
+        Pnoc: 6.69
+        Pvalb: 0.27
+        Reln: 8.07
+        Sst: 1.05
+        Tac1: 0.57
+        Slc17a8: 0.13
+        Vip: 0.5
+    - cluster_accession: CS20230722_CLUS_0726
+      n_cells: 1
+      expression:
+        Calb2: 0.25
+        Cck: 5.37
+        Chrna2: 0.1
+        Cnr1: 2.02
+        Gad1: 11.25
+        Gad2: 10.68
+        Id2: 10.62
+        Lamp5: 2.03
+        Chrm2: 0.15
+        Nos1: 8.77
+        Npy: 7.79
+        Pnoc: 7.92
+        Pvalb: 0.45
+        Reln: 9.02
+        Sst: 1.38
+        Tac1: 0.46
+        Slc17a8: 0.1
+        Vip: 0.92
+    - cluster_accession: CS20230722_CLUS_0727
+      n_cells: 1
+      expression:
+        Calb2: 0.62
+        Cck: 2.56
+        Chrna2: 0.0
+        Cnr1: 2.01
+        Gad1: 10.64
+        Gad2: 9.8
+        Id2: 6.75
+        Lamp5: 1.87
+        Chrm2: 0.27
+        Nos1: 6.01
+        Npy: 1.97
+        Pnoc: 6.42
+        Pvalb: 0.55
+        Reln: 7.03
+        Sst: 3.03
+        Tac1: 8.28
+        Slc17a8: 0.0
+        Vip: 0.31
+    - cluster_accession: CS20230722_CLUS_0728
+      n_cells: 1
+      expression:
+        Calb2: 0.8
+        Cck: 9.48
+        Chrna2: 0.43
+        Cnr1: 4.26
+        Gad1: 10.68
+        Gad2: 8.9
+        Id2: 9.45
+        Lamp5: 5.84
+        Chrm2: 4.65
+        Nos1: 5.62
+        Npy: 2.19
+        Pnoc: 3.56
+        Pvalb: 1.4
+        Reln: 6.42
+        Sst: 1.22
+        Tac1: 7.48
+        Slc17a8: 0.0
+        Vip: 1.15
+    - cluster_accession: CS20230722_CLUS_0729
+      n_cells: 1
+      expression:
+        Calb2: 0.29
+        Cck: 5.6
+        Chrna2: 0.17
+        Cnr1: 4.18
+        Gad1: 10.82
+        Gad2: 10.4
+        Id2: 9.97
+        Lamp5: 4.3
+        Chrm2: 0.36
+        Nos1: 7.57
+        Npy: 2.64
+        Pnoc: 6.6
+        Pvalb: 0.07
+        Reln: 8.8
+        Sst: 1.67
+        Tac1: 1.97
+        Slc17a8: 0.16
+        Vip: 1.05
+    - cluster_accession: CS20230722_CLUS_0730
+      n_cells: 1
+      expression:
+        Calb2: 0.0
+        Cck: 6.89
+        Chrna2: 0.0
+        Cnr1: 4.56
+        Gad1: 10.99
+        Gad2: 10.56
+        Id2: 10.44
+        Lamp5: 7.19
+        Chrm2: 3.24
+        Nos1: 8.44
+        Npy: 4.12
+        Pnoc: 5.2
+        Pvalb: 0.39
+        Reln: 7.24
+        Sst: 1.39
+        Tac1: 1.53
+        Slc17a8: 0.0
+        Vip: 0.66
+    - cluster_accession: CS20230722_CLUS_0731
+      n_cells: 1
+      expression:
+        Calb2: 0.31
+        Cck: 7.82
+        Chrna2: 1.89
+        Cnr1: 6.94
+        Gad1: 10.83
+        Gad2: 11.04
+        Id2: 8.92
+        Lamp5: 4.77
+        Chrm2: 0.75
+        Nos1: 8.55
+        Npy: 4.35
+        Pnoc: 6.71
+        Pvalb: 0.07
+        Reln: 3.14
+        Sst: 1.24
+        Tac1: 0.47
+        Slc17a8: 0.03
+        Vip: 0.41
 - id: CS20230722_SUPT_0204
   name: 0204 Pvalb chandelier Gaba_1
   definition_basis: ATLAS_TRANSCRIPTOMIC
   taxonomy_id: CCN20230722
   cell_set_accession: CS20230722_SUPT_0204
+  precomputed_expression:
+    source: precomputed_stats_ABC_revision_230821.h5
+    level: supertype
+    genes:
+    - symbol: Calb2
+      ensembl_id: ENSMUSG00000003657
+      mean_expression: 0.3
+    - symbol: Cck
+      ensembl_id: ENSMUSG00000032532
+      mean_expression: 8.02
+    - symbol: Chrm2
+      ensembl_id: ENSMUSG00000045613
+      mean_expression: 4.76
+    - symbol: Chrna2
+      ensembl_id: ENSMUSG00000027577
+      mean_expression: 0.11
+    - symbol: Cnr1
+      ensembl_id: ENSMUSG00000044288
+      mean_expression: 1.35
+    - symbol: Gad1
+      ensembl_id: ENSMUSG00000070880
+      mean_expression: 10.11
+    - symbol: Gad2
+      ensembl_id: ENSMUSG00000026787
+      mean_expression: 8.75
+    - symbol: Id2
+      ensembl_id: ENSMUSG00000020644
+      mean_expression: 4.92
+    - symbol: Lamp5
+      ensembl_id: ENSMUSG00000025810
+      mean_expression: 4.42
+    - symbol: Nos1
+      ensembl_id: ENSMUSG00000029361
+      mean_expression: 1.91
+    - symbol: Npy
+      ensembl_id: ENSMUSG00000029819
+      mean_expression: 2.71
+    - symbol: Pnoc
+      ensembl_id: ENSMUSG00000045731
+      mean_expression: 0.53
+    - symbol: Pvalb
+      ensembl_id: ENSMUSG00000005716
+      mean_expression: 7.47
+    - symbol: Reln
+      ensembl_id: ENSMUSG00000042453
+      mean_expression: 0.82
+    - symbol: Slc17a8
+      ensembl_id: ENSMUSG00000019935
+      mean_expression: 0.28
+    - symbol: Sst
+      ensembl_id: ENSMUSG00000004366
+      mean_expression: 0.95
+    - symbol: Tac1
+      ensembl_id: ENSMUSG00000061762
+      mean_expression: 0.98
+    - symbol: Vip
+      ensembl_id: ENSMUSG00000019772
+      mean_expression: 0.37
+    child_cluster_expression:
+    - cluster_accession: CS20230722_CLUS_0732
+      n_cells: 1
+      expression:
+        Calb2: 0.29
+        Cck: 8.36
+        Chrna2: 0.03
+        Cnr1: 2.22
+        Gad1: 10.05
+        Gad2: 8.81
+        Id2: 5.56
+        Lamp5: 6.97
+        Chrm2: 7.73
+        Nos1: 2.88
+        Npy: 4.07
+        Pnoc: 0.61
+        Pvalb: 8.56
+        Reln: 1.3
+        Sst: 0.97
+        Tac1: 1.47
+        Slc17a8: 0.57
+        Vip: 0.47
+    - cluster_accession: CS20230722_CLUS_0733
+      n_cells: 1
+      expression:
+        Calb2: 0.32
+        Cck: 7.68
+        Chrna2: 0.19
+        Cnr1: 0.47
+        Gad1: 10.16
+        Gad2: 8.68
+        Id2: 4.29
+        Lamp5: 1.86
+        Chrm2: 1.79
+        Nos1: 0.93
+        Npy: 1.35
+        Pnoc: 0.45
+        Pvalb: 6.38
+        Reln: 0.34
+        Sst: 0.94
+        Tac1: 0.5
+        Slc17a8: 0.0
+        Vip: 0.27
 - id: CS20230722_SUPT_0206
   name: 0206 Pvalb Gaba_2
   definition_basis: ATLAS_TRANSCRIPTOMIC
   taxonomy_id: CCN20230722
   cell_set_accession: CS20230722_SUPT_0206
+  precomputed_expression:
+    source: precomputed_stats_ABC_revision_230821.h5
+    level: supertype
+    genes:
+    - symbol: Calb2
+      ensembl_id: ENSMUSG00000003657
+      mean_expression: 0.7
+    - symbol: Cck
+      ensembl_id: ENSMUSG00000032532
+      mean_expression: 5.4
+    - symbol: Chrm2
+      ensembl_id: ENSMUSG00000045613
+      mean_expression: 4.52
+    - symbol: Chrna2
+      ensembl_id: ENSMUSG00000027577
+      mean_expression: 0.47
+    - symbol: Cnr1
+      ensembl_id: ENSMUSG00000044288
+      mean_expression: 1.93
+    - symbol: Gad1
+      ensembl_id: ENSMUSG00000070880
+      mean_expression: 10.34
+    - symbol: Gad2
+      ensembl_id: ENSMUSG00000026787
+      mean_expression: 9.28
+    - symbol: Id2
+      ensembl_id: ENSMUSG00000020644
+      mean_expression: 3.11
+    - symbol: Lamp5
+      ensembl_id: ENSMUSG00000025810
+      mean_expression: 3.18
+    - symbol: Nos1
+      ensembl_id: ENSMUSG00000029361
+      mean_expression: 3.64
+    - symbol: Npy
+      ensembl_id: ENSMUSG00000029819
+      mean_expression: 2.87
+    - symbol: Pnoc
+      ensembl_id: ENSMUSG00000045731
+      mean_expression: 0.63
+    - symbol: Pvalb
+      ensembl_id: ENSMUSG00000005716
+      mean_expression: 8.74
+    - symbol: Reln
+      ensembl_id: ENSMUSG00000042453
+      mean_expression: 1.18
+    - symbol: Slc17a8
+      ensembl_id: ENSMUSG00000019935
+      mean_expression: 0.09
+    - symbol: Sst
+      ensembl_id: ENSMUSG00000004366
+      mean_expression: 2.72
+    - symbol: Tac1
+      ensembl_id: ENSMUSG00000061762
+      mean_expression: 5.36
+    - symbol: Vip
+      ensembl_id: ENSMUSG00000019772
+      mean_expression: 0.43
+    child_cluster_expression:
+    - cluster_accession: CS20230722_CLUS_0737
+      n_cells: 1
+      expression:
+        Calb2: 0.83
+        Cck: 5.21
+        Chrna2: 0.2
+        Cnr1: 2.37
+        Gad1: 10.32
+        Gad2: 9.78
+        Id2: 1.62
+        Lamp5: 2.97
+        Chrm2: 5.9
+        Nos1: 2.08
+        Npy: 5.53
+        Pnoc: 0.95
+        Pvalb: 8.27
+        Reln: 2.3
+        Sst: 4.39
+        Tac1: 7.26
+        Slc17a8: 0.27
+        Vip: 0.52
+    - cluster_accession: CS20230722_CLUS_0738
+      n_cells: 1
+      expression:
+        Calb2: 0.89
+        Cck: 3.44
+        Chrna2: 0.79
+        Cnr1: 1.75
+        Gad1: 10.19
+        Gad2: 9.62
+        Id2: 4.28
+        Lamp5: 0.27
+        Chrm2: 0.7
+        Nos1: 6.75
+        Npy: 1.75
+        Pnoc: 0.63
+        Pvalb: 7.32
+        Reln: 0.45
+        Sst: 2.25
+        Tac1: 5.12
+        Slc17a8: 0.0
+        Vip: 0.45
+    - cluster_accession: CS20230722_CLUS_0739
+      n_cells: 1
+      expression:
+        Calb2: 0.39
+        Cck: 7.56
+        Chrna2: 0.43
+        Cnr1: 1.68
+        Gad1: 10.52
+        Gad2: 8.43
+        Id2: 3.43
+        Lamp5: 6.29
+        Chrm2: 6.96
+        Nos1: 2.08
+        Npy: 1.33
+        Pnoc: 0.32
+        Pvalb: 10.63
+        Reln: 0.8
+        Sst: 1.51
+        Tac1: 3.69
+        Slc17a8: 0.0
+        Vip: 0.33
 - id: CS20230722_SUPT_0216
   name: 0216 Sst Gaba_3
   definition_basis: ATLAS_TRANSCRIPTOMIC
   taxonomy_id: CCN20230722
   cell_set_accession: CS20230722_SUPT_0216
+  precomputed_expression:
+    source: precomputed_stats_ABC_revision_230821.h5
+    level: supertype
+    genes:
+    - symbol: Calb2
+      ensembl_id: ENSMUSG00000003657
+      mean_expression: 1.28
+    - symbol: Cck
+      ensembl_id: ENSMUSG00000032532
+      mean_expression: 1.74
+    - symbol: Chrm2
+      ensembl_id: ENSMUSG00000045613
+      mean_expression: 2.51
+    - symbol: Chrna2
+      ensembl_id: ENSMUSG00000027577
+      mean_expression: 1.53
+    - symbol: Cnr1
+      ensembl_id: ENSMUSG00000044288
+      mean_expression: 7.75
+    - symbol: Gad1
+      ensembl_id: ENSMUSG00000070880
+      mean_expression: 8.92
+    - symbol: Gad2
+      ensembl_id: ENSMUSG00000026787
+      mean_expression: 10.26
+    - symbol: Id2
+      ensembl_id: ENSMUSG00000020644
+      mean_expression: 1.59
+    - symbol: Lamp5
+      ensembl_id: ENSMUSG00000025810
+      mean_expression: 0.62
+    - symbol: Nos1
+      ensembl_id: ENSMUSG00000029361
+      mean_expression: 2.94
+    - symbol: Npy
+      ensembl_id: ENSMUSG00000029819
+      mean_expression: 5.07
+    - symbol: Pnoc
+      ensembl_id: ENSMUSG00000045731
+      mean_expression: 3.69
+    - symbol: Pvalb
+      ensembl_id: ENSMUSG00000005716
+      mean_expression: 1.48
+    - symbol: Reln
+      ensembl_id: ENSMUSG00000042453
+      mean_expression: 7.9
+    - symbol: Slc17a8
+      ensembl_id: ENSMUSG00000019935
+      mean_expression: 0.29
+    - symbol: Sst
+      ensembl_id: ENSMUSG00000004366
+      mean_expression: 11.44
+    - symbol: Tac1
+      ensembl_id: ENSMUSG00000061762
+      mean_expression: 0.55
+    - symbol: Vip
+      ensembl_id: ENSMUSG00000019772
+      mean_expression: 0.42
+    child_cluster_expression:
+    - cluster_accession: CS20230722_CLUS_0767
+      n_cells: 1
+      expression:
+        Calb2: 1.0
+        Cck: 0.86
+        Chrna2: 0.56
+        Cnr1: 6.14
+        Gad1: 8.95
+        Gad2: 9.5
+        Id2: 1.5
+        Lamp5: 0.41
+        Chrm2: 6.11
+        Nos1: 0.87
+        Npy: 4.2
+        Pnoc: 3.49
+        Pvalb: 4.38
+        Reln: 9.17
+        Sst: 10.78
+        Tac1: 0.8
+        Slc17a8: 1.94
+        Vip: 0.67
+    - cluster_accession: CS20230722_CLUS_0768
+      n_cells: 1
+      expression:
+        Calb2: 2.3
+        Cck: 1.42
+        Chrna2: 3.11
+        Cnr1: 6.91
+        Gad1: 9.11
+        Gad2: 10.74
+        Id2: 2.88
+        Lamp5: 0.41
+        Chrm2: 0.67
+        Nos1: 0.76
+        Npy: 7.58
+        Pnoc: 2.51
+        Pvalb: 3.12
+        Reln: 10.65
+        Sst: 12.7
+        Tac1: 0.15
+        Slc17a8: 0.0
+        Vip: 0.31
+    - cluster_accession: CS20230722_CLUS_0769
+      n_cells: 1
+      expression:
+        Calb2: 0.29
+        Cck: 2.11
+        Chrna2: 1.26
+        Cnr1: 8.16
+        Gad1: 9.32
+        Gad2: 10.4
+        Id2: 1.23
+        Lamp5: 1.12
+        Chrm2: 2.71
+        Nos1: 4.07
+        Npy: 7.91
+        Pnoc: 3.23
+        Pvalb: 0.17
+        Reln: 4.99
+        Sst: 10.97
+        Tac1: 0.85
+        Slc17a8: 0.08
+        Vip: 0.25
+    - cluster_accession: CS20230722_CLUS_0770
+      n_cells: 1
+      expression:
+        Calb2: 0.84
+        Cck: 1.48
+        Chrna2: 3.62
+        Cnr1: 9.22
+        Gad1: 8.29
+        Gad2: 10.42
+        Id2: 0.68
+        Lamp5: 0.46
+        Chrm2: 4.39
+        Nos1: 3.65
+        Npy: 1.04
+        Pnoc: 6.98
+        Pvalb: 0.0
+        Reln: 8.82
+        Sst: 10.54
+        Tac1: 0.05
+        Slc17a8: 0.05
+        Vip: 0.16
+    - cluster_accession: CS20230722_CLUS_0771
+      n_cells: 1
+      expression:
+        Calb2: 3.53
+        Cck: 1.97
+        Chrna2: 2.48
+        Cnr1: 8.73
+        Gad1: 8.69
+        Gad2: 10.24
+        Id2: 0.95
+        Lamp5: 0.15
+        Chrm2: 2.0
+        Nos1: 1.67
+        Npy: 2.02
+        Pnoc: 3.72
+        Pvalb: 1.16
+        Reln: 9.59
+        Sst: 11.62
+        Tac1: 0.08
+        Slc17a8: 0.08
+        Vip: 0.87
+    - cluster_accession: CS20230722_CLUS_0772
+      n_cells: 1
+      expression:
+        Calb2: 0.81
+        Cck: 1.96
+        Chrna2: 0.53
+        Cnr1: 7.21
+        Gad1: 9.27
+        Gad2: 10.26
+        Id2: 0.91
+        Lamp5: 0.81
+        Chrm2: 1.34
+        Nos1: 1.09
+        Npy: 8.22
+        Pnoc: 1.65
+        Pvalb: 0.34
+        Reln: 10.13
+        Sst: 11.92
+        Tac1: 0.14
+        Slc17a8: 0.37
+        Vip: 0.35
+    - cluster_accession: CS20230722_CLUS_0773
+      n_cells: 1
+      expression:
+        Calb2: 1.21
+        Cck: 1.59
+        Chrna2: 0.28
+        Cnr1: 8.36
+        Gad1: 8.56
+        Gad2: 10.42
+        Id2: 0.53
+        Lamp5: 0.95
+        Chrm2: 0.73
+        Nos1: 3.61
+        Npy: 1.61
+        Pnoc: 4.4
+        Pvalb: 0.36
+        Reln: 9.24
+        Sst: 11.43
+        Tac1: 0.0
+        Slc17a8: 0.0
+        Vip: 0.27
+    - cluster_accession: CS20230722_CLUS_0774
+      n_cells: 1
+      expression:
+        Calb2: 0.88
+        Cck: 2.57
+        Chrna2: 1.01
+        Cnr1: 6.94
+        Gad1: 9.78
+        Gad2: 10.38
+        Id2: 2.1
+        Lamp5: 0.86
+        Chrm2: 2.45
+        Nos1: 5.1
+        Npy: 10.88
+        Pnoc: 0.0
+        Pvalb: 1.39
+        Reln: 4.92
+        Sst: 12.11
+        Tac1: 2.65
+        Slc17a8: 0.11
+        Vip: 0.23
+    - cluster_accession: CS20230722_CLUS_0775
+      n_cells: 1
+      expression:
+        Calb2: 0.65
+        Cck: 1.7
+        Chrna2: 0.91
+        Cnr1: 8.04
+        Gad1: 8.34
+        Gad2: 10.0
+        Id2: 3.54
+        Lamp5: 0.45
+        Chrm2: 2.17
+        Nos1: 5.65
+        Npy: 2.18
+        Pnoc: 7.2
+        Pvalb: 2.39
+        Reln: 3.6
+        Sst: 10.86
+        Tac1: 0.25
+        Slc17a8: 0.0
+        Vip: 0.67
 - id: CS20230722_SUPT_0219
   name: 0219 Sst Gaba_6
   definition_basis: ATLAS_TRANSCRIPTOMIC
   taxonomy_id: CCN20230722
   cell_set_accession: CS20230722_SUPT_0219
+  precomputed_expression:
+    source: precomputed_stats_ABC_revision_230821.h5
+    level: supertype
+    genes:
+    - symbol: Calb2
+      ensembl_id: ENSMUSG00000003657
+      mean_expression: 0.23
+    - symbol: Cck
+      ensembl_id: ENSMUSG00000032532
+      mean_expression: 1.48
+    - symbol: Chrm2
+      ensembl_id: ENSMUSG00000045613
+      mean_expression: 3.08
+    - symbol: Chrna2
+      ensembl_id: ENSMUSG00000027577
+      mean_expression: 0.52
+    - symbol: Cnr1
+      ensembl_id: ENSMUSG00000044288
+      mean_expression: 3.04
+    - symbol: Gad1
+      ensembl_id: ENSMUSG00000070880
+      mean_expression: 9.73
+    - symbol: Gad2
+      ensembl_id: ENSMUSG00000026787
+      mean_expression: 9.96
+    - symbol: Id2
+      ensembl_id: ENSMUSG00000020644
+      mean_expression: 3.92
+    - symbol: Lamp5
+      ensembl_id: ENSMUSG00000025810
+      mean_expression: 2.04
+    - symbol: Nos1
+      ensembl_id: ENSMUSG00000029361
+      mean_expression: 1.81
+    - symbol: Npy
+      ensembl_id: ENSMUSG00000029819
+      mean_expression: 7.18
+    - symbol: Pnoc
+      ensembl_id: ENSMUSG00000045731
+      mean_expression: 4.18
+    - symbol: Pvalb
+      ensembl_id: ENSMUSG00000005716
+      mean_expression: 1.68
+    - symbol: Reln
+      ensembl_id: ENSMUSG00000042453
+      mean_expression: 6.46
+    - symbol: Slc17a8
+      ensembl_id: ENSMUSG00000019935
+      mean_expression: 0.78
+    - symbol: Sst
+      ensembl_id: ENSMUSG00000004366
+      mean_expression: 10.17
+    - symbol: Tac1
+      ensembl_id: ENSMUSG00000061762
+      mean_expression: 2.43
+    - symbol: Vip
+      ensembl_id: ENSMUSG00000019772
+      mean_expression: 0.44
+    child_cluster_expression:
+    - cluster_accession: CS20230722_CLUS_0785
+      n_cells: 1
+      expression:
+        Calb2: 0.13
+        Cck: 1.54
+        Chrna2: 0.17
+        Cnr1: 0.84
+        Gad1: 8.99
+        Gad2: 10.25
+        Id2: 3.5
+        Lamp5: 1.34
+        Chrm2: 0.0
+        Nos1: 2.6
+        Npy: 7.54
+        Pnoc: 0.3
+        Pvalb: 0.3
+        Reln: 10.47
+        Sst: 10.99
+        Tac1: 0.0
+        Slc17a8: 0.0
+        Vip: 0.28
+    - cluster_accession: CS20230722_CLUS_0786
+      n_cells: 1
+      expression:
+        Calb2: 0.16
+        Cck: 1.15
+        Chrna2: 0.52
+        Cnr1: 2.84
+        Gad1: 9.3
+        Gad2: 9.91
+        Id2: 2.53
+        Lamp5: 0.2
+        Chrm2: 0.72
+        Nos1: 1.29
+        Npy: 8.02
+        Pnoc: 2.19
+        Pvalb: 0.19
+        Reln: 7.85
+        Sst: 11.23
+        Tac1: 0.4
+        Slc17a8: 0.08
+        Vip: 0.44
+    - cluster_accession: CS20230722_CLUS_0787
+      n_cells: 1
+      expression:
+        Calb2: 0.0
+        Cck: 1.83
+        Chrna2: 0.11
+        Cnr1: 4.68
+        Gad1: 9.59
+        Gad2: 9.81
+        Id2: 5.87
+        Lamp5: 5.21
+        Chrm2: 4.21
+        Nos1: 3.13
+        Npy: 2.51
+        Pnoc: 5.31
+        Pvalb: 0.73
+        Reln: 7.46
+        Sst: 9.05
+        Tac1: 0.14
+        Slc17a8: 1.28
+        Vip: 0.5
+    - cluster_accession: CS20230722_CLUS_0788
+      n_cells: 1
+      expression:
+        Calb2: 0.83
+        Cck: 1.54
+        Chrna2: 0.8
+        Cnr1: 4.31
+        Gad1: 9.72
+        Gad2: 10.5
+        Id2: 3.99
+        Lamp5: 0.56
+        Chrm2: 3.08
+        Nos1: 1.1
+        Npy: 7.66
+        Pnoc: 6.16
+        Pvalb: 1.38
+        Reln: 8.94
+        Sst: 10.5
+        Tac1: 1.68
+        Slc17a8: 0.44
+        Vip: 0.47
+    - cluster_accession: CS20230722_CLUS_0789
+      n_cells: 1
+      expression:
+        Calb2: 0.28
+        Cck: 0.97
+        Chrna2: 0.25
+        Cnr1: 2.01
+        Gad1: 10.01
+        Gad2: 9.76
+        Id2: 3.02
+        Lamp5: 0.89
+        Chrm2: 3.55
+        Nos1: 0.93
+        Npy: 8.44
+        Pnoc: 3.5
+        Pvalb: 0.3
+        Reln: 4.14
+        Sst: 11.07
+        Tac1: 2.08
+        Slc17a8: 0.18
+        Vip: 0.46
+    - cluster_accession: CS20230722_CLUS_0790
+      n_cells: 1
+      expression:
+        Calb2: 0.0
+        Cck: 1.41
+        Chrna2: 0.32
+        Cnr1: 1.21
+        Gad1: 10.55
+        Gad2: 9.69
+        Id2: 4.75
+        Lamp5: 3.83
+        Chrm2: 5.23
+        Nos1: 2.56
+        Npy: 7.52
+        Pnoc: 6.03
+        Pvalb: 3.38
+        Reln: 1.44
+        Sst: 10.7
+        Tac1: 4.43
+        Slc17a8: 1.43
+        Vip: 0.36
+    - cluster_accession: CS20230722_CLUS_0791
+      n_cells: 1
+      expression:
+        Calb2: 0.18
+        Cck: 1.89
+        Chrna2: 1.49
+        Cnr1: 5.36
+        Gad1: 9.93
+        Gad2: 9.77
+        Id2: 3.75
+        Lamp5: 2.24
+        Chrm2: 4.79
+        Nos1: 1.06
+        Npy: 8.6
+        Pnoc: 5.77
+        Pvalb: 5.48
+        Reln: 4.93
+        Sst: 7.68
+        Tac1: 8.27
+        Slc17a8: 2.05
+        Vip: 0.6
 edges:
 - id: edge_pv_basket_cell_hippocampus_to_CS20230722_SUPT_0206
   type_a: pv_basket_cell_hippocampus
@@ -1724,20 +3019,21 @@ edges:
       '
   - property: marker_Pvalb
     node_a_value: Pvalb — defining marker (immunohistochemistry, rat and mouse)
-    node_b_value: Pvalb subclass; Pvalb in MERFISH marker set of child cluster 0739
+    node_b_value: 'Pvalb subclass; Pvalb in MERFISH marker set of child cluster 0739; precomputed stats mean: 8.74'
     alignment: CONSISTENT
   - property: marker_Gad1
     node_a_value: Gad1 — defining marker
-    node_b_value: not present in supertype defining_markers; GABA nt_type consistent
+    node_b_value: 'not present in supertype defining_markers; GABA nt_type consistent; precomputed stats mean: 10.34'
     alignment: APPROXIMATE
   - property: marker_Gad2
     node_a_value: Gad2 — defining marker
-    node_b_value: not present in supertype defining_markers; GABA nt_type consistent
+    node_b_value: 'not present in supertype defining_markers; GABA nt_type consistent; precomputed stats mean: 9.28'
     alignment: APPROXIMATE
   - property: negative_marker_Cnr1
     node_a_value: Cnr1 — negative marker (absent)
-    node_b_value: not present in supertype markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in supertype markers; precomputed stats mean: 1.93'
+    alignment: CONSISTENT
+    notes: Cnr1 low/absent (1.93) in atlas type.
   caveats:
   - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
     description: 'Supertype spans hippocampus (CA1 SO, CA3 SO) and piriform area; not hippocampus-specific. Multiple PV+ morphological
@@ -1777,23 +3073,24 @@ edges:
     notes: Small CA1 pyramidal layer count; main hippocampal signal in SO.
   - property: marker_Pvalb
     node_a_value: Pvalb — defining marker
-    node_b_value: Pvalb in MERFISH markers
+    node_b_value: 'Pvalb in MERFISH markers; precomputed stats mean: 10.63'
     alignment: CONSISTENT
   - property: marker_Gad1
     node_a_value: Gad1 — defining marker
-    node_b_value: not in cluster defining_markers; GABA NT consistent
+    node_b_value: 'not in cluster defining_markers; GABA NT consistent; precomputed stats mean: 10.52'
     alignment: APPROXIMATE
   - property: marker_Gad2
     node_a_value: Gad2 — defining marker
-    node_b_value: not in cluster defining_markers; GABA NT consistent
+    node_b_value: 'not in cluster defining_markers; GABA NT consistent; precomputed stats mean: 8.43'
     alignment: APPROXIMATE
   - property: negative_marker_Cnr1
     node_a_value: Cnr1 — negative marker (absent)
-    node_b_value: not present in cluster markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in cluster markers; precomputed stats mean: 1.68'
+    alignment: CONSISTENT
+    notes: Cnr1 low/absent (1.68) in atlas type.
   - property: neuropeptide_Cck
     node_a_value: Cck not expected (Cnr1-negative PV cells)
-    node_b_value: Cck present (expression score 7.6)
+    node_b_value: 'Cck present (expression score 7.6); precomputed stats mean: 7.56'
     alignment: DISCORDANT
     notes: 'High Cck neuropeptide score is unexpected for a PV basket cell, which should be Cnr1/CB1R-negative. Could indicate
       cluster contains CCK-co-expressing PV cells, or that cluster boundaries do not align cleanly to classical types.
@@ -1838,21 +3135,21 @@ edges:
     notes: Perisomatic locations present but sparse. Supertype has distributed hippocampal signal.
   - property: marker_Cck
     node_a_value: Cck — defining marker
-    node_b_value: not present in supertype defining_markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in supertype defining_markers; precomputed stats mean: 1.36'
+    alignment: APPROXIMATE
     notes: Cck not listed in supertype markers; cannot confirm from metadata alone.
   - property: marker_Cnr1
     node_a_value: Cnr1 — defining marker
-    node_b_value: not present in supertype defining_markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in supertype defining_markers; precomputed stats mean: 10.58'
+    alignment: CONSISTENT
     notes: Cnr1/CB1R not present in atlas supertype metadata; key CCK basket marker unverifiable.
   - property: marker_Vglut3
     node_a_value: Vglut3 — defining marker (CCK basket cells)
-    node_b_value: not present in supertype defining_markers
+    node_b_value: 'not present in supertype defining_markers; precomputed stats mean: 0.42'
     alignment: NOT_ASSESSED
   - property: negative_marker_Pvalb
     node_a_value: Pvalb — negative marker (absent)
-    node_b_value: not present in supertype markers; Vip subclass
+    node_b_value: 'not present in supertype markers; Vip subclass; precomputed stats mean: 0.09'
     alignment: CONSISTENT
     notes: Absence of Pvalb consistent with CCK basket cell identity; Vip subclass is non-PV.
   caveats:
@@ -1902,7 +3199,7 @@ edges:
       '
   - property: marker_Pvalb
     node_a_value: Pvalb — defining marker
-    node_b_value: Pvalb in DEFINING_SCOPED markers; Pvalb subclass
+    node_b_value: 'Pvalb in DEFINING_SCOPED markers; Pvalb subclass; precomputed stats mean: 7.47'
     alignment: CONSISTENT
   - property: type_identity
     node_a_value: axo-axonic (chandelier) morphology — exclusive AIS targeting
@@ -1950,7 +3247,7 @@ edges:
       '
   - property: marker_Pvalb
     node_a_value: Pvalb — defining marker
-    node_b_value: Pvalb in MERFISH markers; Pvalb chandelier subclass
+    node_b_value: 'Pvalb in MERFISH markers; Pvalb chandelier subclass; precomputed stats mean: 8.56'
     alignment: CONSISTENT
   - property: type_identity
     node_a_value: axo-axonic (chandelier) morphology — exclusive AIS targeting
@@ -1996,7 +3293,7 @@ edges:
     notes: Dominant hippocampal signal in CA1 SO, not pyramidale. Bistratified cell soma classically in/near stratum pyramidale.
   - property: marker_Pvalb
     node_a_value: Pvalb — defining marker (co-expressed with Sst)
-    node_b_value: Sst subclass, not Pvalb; Pvalb not in supertype markers
+    node_b_value: 'Sst subclass, not Pvalb; Pvalb not in supertype markers; precomputed stats mean: 1.48'
     alignment: DISCORDANT
     notes: 'Bistratified cells co-express Pvalb and Sst (PMID:37467748). The Sst subclass placement is consistent with the
       Sst component but the Pvalb component is not captured. High transcriptomic similarity within Sst subclass may place
@@ -2005,16 +3302,16 @@ edges:
       '
   - property: marker_Sst
     node_a_value: Sst — defining marker
-    node_b_value: Sst subclass
+    node_b_value: 'Sst subclass; precomputed stats mean: 11.44'
     alignment: CONSISTENT
   - property: marker_Tac1
     node_a_value: Tac1 — defining marker (Sst;;Tac1 intersection targets bistratified cells)
-    node_b_value: Tac1 in DEFINING_SCOPED markers
+    node_b_value: 'Tac1 in DEFINING_SCOPED markers; precomputed stats mean: 0.55'
     alignment: CONSISTENT
     notes: Tac1 DEFINING_SCOPED in this supertype is directly consistent with bistratified cell identity.
   - property: neuropeptide_Sst
     node_a_value: Sst — neuropeptide
-    node_b_value: Sst subclass defining
+    node_b_value: 'Sst subclass defining; precomputed stats mean: 11.44'
     alignment: CONSISTENT
   caveats:
   - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
@@ -2055,11 +3352,12 @@ edges:
     alignment: CONSISTENT
   - property: marker_Sst
     node_a_value: Sst — defining marker
-    node_b_value: Sst subclass
+    node_b_value: 'Sst subclass; precomputed stats mean: 11.44'
     alignment: CONSISTENT
   - property: marker_Chrna2
     node_a_value: Chrna2 — defining marker
-    node_b_value: not in supertype defining_markers; scattered expression in Sst Gaba_3 per ABC Atlas
+    node_b_value: 'not in supertype defining_markers; scattered expression in Sst Gaba_3 per ABC Atlas; precomputed stats
+      mean: 1.53'
     alignment: APPROXIMATE
     notes: 'ABC Atlas HPF/GABA/Chrna2 filter retains Sst Gaba_3 (unlike Sst Gaba_6). Chrna2 expression is present but scattered
       across clusters within this supertype — consistent with partial OLM cell representation.
@@ -2067,16 +3365,16 @@ edges:
       '
   - property: marker_Reln
     node_a_value: Reln — defining marker (RT-PCR in OLM cells, PMID:31420995)
-    node_b_value: Reln in DEFINING markers of supertype
+    node_b_value: 'Reln in DEFINING markers of supertype; precomputed stats mean: 7.9'
     alignment: CONSISTENT
     notes: Reln as a defining supertype marker is consistent with OLM Reln expression.
   - property: neuropeptide_Sst
     node_a_value: Sst — neuropeptide
-    node_b_value: Sst subclass defining
+    node_b_value: 'Sst subclass defining; precomputed stats mean: 11.44'
     alignment: CONSISTENT
   - property: negative_marker_Pvalb
     node_a_value: Pvalb — low/absent
-    node_b_value: Sst subclass (not Pvalb subclass)
+    node_b_value: 'Sst subclass (not Pvalb subclass); precomputed stats mean: 1.48'
     alignment: CONSISTENT
   caveats:
   - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
@@ -2118,15 +3416,15 @@ edges:
     alignment: CONSISTENT
   - property: marker_Sst
     node_a_value: Sst — defining marker (IHC, mouse hippocampus)
-    node_b_value: Sst Gaba subclass — Sst is subclass-level marker
+    node_b_value: 'Sst Gaba subclass — Sst is subclass-level marker; precomputed stats mean: 11.44'
     alignment: CONSISTENT
   - property: neuropeptide_Sst
     node_a_value: Sst neuropeptide present
-    node_b_value: not present in supertype neuropeptide list (not assessed at this level)
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in supertype neuropeptide list (not assessed at this level); precomputed stats mean: 11.44'
+    alignment: CONSISTENT
   - property: marker_Reln
     node_a_value: not listed — not a HS defining marker
-    node_b_value: Reln — DEFINING marker of SUPT_0216
+    node_b_value: 'Reln — DEFINING marker of SUPT_0216; precomputed stats mean: 7.9'
     alignment: DISCORDANT
     notes: 'Reln is a known OLM marker (Chrna2::Reln coexpression confirmed). Its presence as a defining marker of this supertype
       is consistent with OLM but not expected for HS cells. May indicate SUPT_0216 predominantly captures OLM-like cells.
@@ -2186,7 +3484,7 @@ edges:
       '
   - property: marker_Nos1
     node_a_value: Nos1 (nNOS) — defining marker (IHC, mouse hippocampus)
-    node_b_value: not present in SUPT_0193 markers
+    node_b_value: 'not present in SUPT_0193 markers; precomputed stats mean: 2.26'
     alignment: DISCORDANT
     notes: 'Classical NGC node uses Nos1 as a defining marker, but this reflects the MGE-derived nNOS+ NGC majority. CGE-derived
       NGCs (the lineage represented here) are nNOS-. The discordance is lineage-specific, not a global mismatch.
@@ -2194,7 +3492,7 @@ edges:
       '
   - property: marker_Lamp5
     node_a_value: Lamp5 — defining marker (transcript, hippocampus)
-    node_b_value: not listed in SUPT_0193 markers
+    node_b_value: 'not listed in SUPT_0193 markers; precomputed stats mean: 3.65'
     alignment: DISCORDANT
     notes: 'Lamp5 is listed as DEFINING_SCOPED in SUPT_0203 (MGE Lamp5 Lhx6), not in this Ndnf CGE supertype. However, NGFC.C
       annotation is Lhx6-/Lamp5+/Id2+/Ndnf+ — Lamp5 and Ndnf coexpression expected in this lineage.
@@ -2202,20 +3500,21 @@ edges:
       '
   - property: marker_Npy
     node_a_value: Npy — defining marker (IHC, mouse hippocampus)
-    node_b_value: not present in SUPT_0193 markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in SUPT_0193 markers; precomputed stats mean: 2.61'
+    alignment: CONSISTENT
   - property: negative_marker_Sst
     node_a_value: Sst — negative marker
-    node_b_value: Sst not in SUPT_0193 markers
+    node_b_value: 'Sst not in SUPT_0193 markers; precomputed stats mean: 1.51'
     alignment: CONSISTENT
   - property: negative_marker_Pvalb
     node_a_value: Pvalb — negative marker
-    node_b_value: Pvalb not in SUPT_0193 markers
+    node_b_value: 'Pvalb not in SUPT_0193 markers; precomputed stats mean: 0.27'
     alignment: CONSISTENT
   - property: negative_marker_Calb2
     node_a_value: Calb2 — negative marker
-    node_b_value: not assessed from metadata
-    alignment: NOT_ASSESSED
+    node_b_value: 'not assessed from metadata; precomputed stats mean: 0.31'
+    alignment: CONSISTENT
+    notes: Calb2 low/absent (0.31) in atlas type.
   caveats:
   - caveat_type: OTHER
     description: 'SUPT_0193 subclass is RHP-COA Ndnf Gaba, which spans retrohippocampal and cortical amygdala regions in addition
@@ -2259,31 +3558,31 @@ edges:
       '
   - property: marker_Lamp5
     node_a_value: Lamp5 — defining marker (transcript)
-    node_b_value: Lamp5 — DEFINING_SCOPED marker of SUPT_0203
+    node_b_value: 'Lamp5 — DEFINING_SCOPED marker of SUPT_0203; precomputed stats mean: 4.4'
     alignment: CONSISTENT
   - property: marker_Nos1
     node_a_value: Nos1 (nNOS) — defining marker (IHC)
-    node_b_value: not present in SUPT_0203 markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in SUPT_0203 markers; precomputed stats mean: 7.79'
+    alignment: CONSISTENT
     notes: 'MGE-derived nNOS+ NGCs (NGFC.M) should express Nos1. Its absence from the atlas supertype defining markers is
       unexpected and may indicate this supertype does not correspond to the nNOS+ NGC population.
 
       '
   - property: marker_Id2
     node_a_value: Id2 — defining marker (transcript)
-    node_b_value: not present in SUPT_0203 markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in SUPT_0203 markers; precomputed stats mean: 9.35'
+    alignment: CONSISTENT
   - property: marker_Npy
     node_a_value: Npy — defining marker (IHC)
-    node_b_value: not present in SUPT_0203 markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in SUPT_0203 markers; precomputed stats mean: 4.62'
+    alignment: CONSISTENT
   - property: negative_marker_Sst
     node_a_value: Sst — negative marker
-    node_b_value: Sst not listed in SUPT_0203 markers
+    node_b_value: 'Sst not listed in SUPT_0203 markers; precomputed stats mean: 1.52'
     alignment: CONSISTENT
   - property: negative_marker_Pvalb
     node_a_value: Pvalb — negative marker
-    node_b_value: Pvalb not listed in SUPT_0203 markers
+    node_b_value: 'Pvalb not listed in SUPT_0203 markers; precomputed stats mean: 0.43'
     alignment: CONSISTENT
   caveats:
   - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
@@ -2327,36 +3626,37 @@ edges:
       '
   - property: marker_Lamp5
     node_a_value: Lamp5 — defining marker (transcript)
-    node_b_value: Lamp5 — DEFINING_SCOPED marker of SUPT_0203
+    node_b_value: 'Lamp5 — DEFINING_SCOPED marker of SUPT_0203; precomputed stats mean: 4.4'
     alignment: CONSISTENT
   - property: marker_Nos1
     node_a_value: Nos1 (nNOS) — defining marker (IHC and transcript)
-    node_b_value: not present in SUPT_0203 markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in SUPT_0203 markers; precomputed stats mean: 7.79'
+    alignment: CONSISTENT
     notes: 'Nos1 expected for Ivy cells (Bhatt 2023: Grin3a expressed in both IvyC Lamp5+/Lhx6+ and NGC.M subsets). Absence
       from atlas markers does not rule out expression — may not be a defining marker at this resolution.
 
       '
   - property: marker_Npy
     node_a_value: Npy — defining marker (IHC)
-    node_b_value: not present in SUPT_0203 markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in SUPT_0203 markers; precomputed stats mean: 4.62'
+    alignment: CONSISTENT
   - property: neuropeptide_Npy
     node_a_value: Npy neuropeptide present
-    node_b_value: not present in supertype neuropeptide list
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in supertype neuropeptide list; precomputed stats mean: 4.62'
+    alignment: CONSISTENT
   - property: negative_marker_Sst
     node_a_value: Sst — negative marker
-    node_b_value: Sst not listed in SUPT_0203 markers
+    node_b_value: 'Sst not listed in SUPT_0203 markers; precomputed stats mean: 1.52'
     alignment: CONSISTENT
   - property: negative_marker_Pvalb
     node_a_value: Pvalb — negative marker
-    node_b_value: Pvalb not listed in SUPT_0203 markers
+    node_b_value: 'Pvalb not listed in SUPT_0203 markers; precomputed stats mean: 0.43'
     alignment: CONSISTENT
   - property: negative_marker_Calb2
     node_a_value: Calb2 — negative marker
-    node_b_value: not assessed from metadata
-    alignment: NOT_ASSESSED
+    node_b_value: 'not assessed from metadata; precomputed stats mean: 0.37'
+    alignment: CONSISTENT
+    notes: Calb2 low/absent (0.37) in atlas type.
   caveats:
   - caveat_type: OTHER
     description: 'Ivy cells and nNOS+ NGCs (NGFC.M) are reported to share completely overlapping developmental, electrophysiological,
@@ -2409,20 +3709,20 @@ edges:
     notes: SLM is listed in the classical node but not a top-count location in this supertype.
   - property: marker_Vip
     node_a_value: Vip — defining marker (IHC/transgenic, hippocampus)
-    node_b_value: Vip — DEFINING marker of SUPT_0179
+    node_b_value: 'Vip — DEFINING marker of SUPT_0179; precomputed stats mean: 6.82'
     alignment: CONSISTENT
   - property: marker_Calb2
     node_a_value: Calb2 (calretinin) — defining marker (IHC, hippocampus)
-    node_b_value: not present in SUPT_0179 markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in SUPT_0179 markers; precomputed stats mean: 6.78'
+    alignment: CONSISTENT
     notes: 'IS-1 and IS-3 subtypes express calretinin (Calb2). Absence from atlas defining markers does not rule out expression
       — may not be a defining marker at supertype resolution.
 
       '
   - property: neuropeptide_Vip
     node_a_value: Vip neuropeptide present
-    node_b_value: not assessed from supertype metadata
-    alignment: NOT_ASSESSED
+    node_b_value: 'not assessed from supertype metadata; precomputed stats mean: 6.82'
+    alignment: CONSISTENT
   caveats:
   - caveat_type: OTHER
     description: 'The classical IS interneuron node is heterogeneous (IS-1/2/3 subtypes). IS-1 cells are VIP-negative (CR+
@@ -2468,12 +3768,12 @@ edges:
       '
   - property: marker_Sst
     node_a_value: Sst — defining marker
-    node_b_value: Sst — DEFINING marker of SUPT_0219 (via Sst Gaba subclass)
+    node_b_value: 'Sst — DEFINING marker of SUPT_0219 (via Sst Gaba subclass); precomputed stats mean: 10.17'
     alignment: CONSISTENT
   - property: marker_Nos1
     node_a_value: Nos1 — defining marker (intersectional genetics, Sst;;Nos1 strategy)
-    node_b_value: not listed in SUPT_0219 markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not listed in SUPT_0219 markers; precomputed stats mean: 1.81'
+    alignment: APPROXIMATE
     notes: 'Nos1 is critical for the Sst;;Nos1 intersectional identification of O-O cells. Its absence from atlas defining
       markers does not confirm absence of expression — may reflect different marker selection criteria.
 
@@ -2529,16 +3829,16 @@ edges:
     alignment: CONSISTENT
   - property: marker_Pvalb
     node_a_value: Pvalb — defining marker
-    node_b_value: Pvalb Gaba subclass (Pvalb implicit)
+    node_b_value: 'Pvalb Gaba subclass (Pvalb implicit); precomputed stats mean: 8.74'
     alignment: CONSISTENT
   - property: marker_M2R
     node_a_value: M2R (Chrm2) — defining marker
-    node_b_value: not present in supertype defining markers
-    alignment: NOT_ASSESSED
+    node_b_value: 'not present in supertype defining markers; precomputed stats mean: 4.52'
+    alignment: CONSISTENT
     notes: Chrm2 not represented in SUPT_0206 marker list; cannot confirm or exclude.
   - property: negative_marker_Sst
     node_a_value: Sst — negative marker
-    node_b_value: Sst absent from Pvalb Gaba_2 defining markers
+    node_b_value: 'Sst absent from Pvalb Gaba_2 defining markers; precomputed stats mean: 2.72'
     alignment: CONSISTENT
   caveats:
   - caveat_type: AMBIGUOUS_MAPPING
@@ -2589,7 +3889,7 @@ edges:
       '
   - property: marker_Vip
     node_a_value: Vip — defining marker
-    node_b_value: Vip — DEFINING marker in SUPT_0179
+    node_b_value: 'Vip — DEFINING marker in SUPT_0179; precomputed stats mean: 6.82'
     alignment: CONSISTENT
   caveats:
   - caveat_type: AMBIGUOUS_MAPPING
@@ -2632,7 +3932,8 @@ edges:
     alignment: CONSISTENT
   - property: marker_Sst
     node_a_value: Sst — defining marker
-    node_b_value: Sst Gaba subclass (Sst implicit); Reln, Rbp4, Npffr1 are scoped defining markers
+    node_b_value: 'Sst Gaba subclass (Sst implicit); Reln, Rbp4, Npffr1 are scoped defining markers; precomputed stats mean:
+      11.44'
     alignment: CONSISTENT
   caveats:
   - caveat_type: AMBIGUOUS_MAPPING
@@ -2681,7 +3982,7 @@ edges:
       '
   - property: marker_Sst
     node_a_value: Sst — defining marker
-    node_b_value: Sst — DEFINING marker in SUPT_0219
+    node_b_value: 'Sst — DEFINING marker in SUPT_0219; precomputed stats mean: 10.17'
     alignment: CONSISTENT
   caveats:
   - caveat_type: DISCORDANT_ANATOMY
@@ -2731,7 +4032,7 @@ edges:
       '
   - property: marker_Sst
     node_a_value: Sst — defining marker (SST-Cre labelling)
-    node_b_value: Sst — DEFINING marker in SUPT_0219
+    node_b_value: 'Sst — DEFINING marker in SUPT_0219; precomputed stats mean: 10.17'
     alignment: CONSISTENT
   caveats:
   - caveat_type: ELECTROPHYSIOLOGY_ONLY_DEFINITION

--- a/kb/draft/hippocampus/hippocampus_GABAergic_interneurons.yaml
+++ b/kb/draft/hippocampus/hippocampus_GABAergic_interneurons.yaml
@@ -2991,7 +2991,7 @@ edges:
   type_a: pv_basket_cell_hippocampus
   type_b: CS20230722_SUPT_0206
   relationship: PARTIAL_OVERLAP
-  confidence: LOW
+  confidence: MODERATE
   evidence:
   - evidence_type: ATLAS_METADATA
     supports: PARTIAL
@@ -3004,6 +3004,10 @@ edges:
       bistratified) that share high transcriptomic similarity and may not be separable at supertype level.
 
       '
+  - evidence_type: ATLAS_METADATA
+    supports: SUPPORT
+    explanation: 'Precomputed stats cross-check: all 3 defining markers confirmed (Pvalb=8.74, Gad1=10.34, Gad2=9.28) and
+      negative marker Cnr1 absent (1.93). Strong quantitative support for PV basket identity in this supertype.'
   property_comparisons:
   - property: nt_type
     node_a_value: GABAergic
@@ -3049,7 +3053,7 @@ edges:
   type_a: pv_basket_cell_hippocampus
   type_b: CS20230722_CLUS_0739
   relationship: PARTIAL_OVERLAP
-  confidence: LOW
+  confidence: MODERATE
   evidence:
   - evidence_type: ATLAS_METADATA
     supports: PARTIAL
@@ -3061,6 +3065,10 @@ edges:
       as parent supertype.
 
       '
+  - evidence_type: ATLAS_METADATA
+    supports: SUPPORT
+    explanation: 'Precomputed stats cross-check: Pvalb=10.63, Gad1=10.52, Gad2=8.43, Cnr1=1.68 (absent). Strongest Pvalb expression
+      among SUPT_0206 child clusters.'
   property_comparisons:
   - property: nt_type
     node_a_value: GABAergic
@@ -3329,7 +3337,7 @@ edges:
   type_a: olm_cell_ca1
   type_b: CS20230722_SUPT_0216
   relationship: PARTIAL_OVERLAP
-  confidence: LOW
+  confidence: MODERATE
   evidence:
   - evidence_type: ATLAS_METADATA
     supports: PARTIAL
@@ -3341,6 +3349,10 @@ edges:
       here.
 
       '
+  - evidence_type: ATLAS_METADATA
+    supports: SUPPORT
+    explanation: 'Precomputed stats cross-check: Sst=11.44, Reln=7.90, Chrna2=1.53 (low but present), Pvalb=1.48 (absent).
+      All 3 neuropeptides confirmed (Sst=11.44, Npy=5.07, Pnoc=3.69). Multiple independent marker confirmations.'
   property_comparisons:
   - property: nt_type
     node_a_value: GABAergic
@@ -3453,7 +3465,7 @@ edges:
   type_a: neurogliaform_cell_hippocampus
   type_b: CS20230722_SUPT_0193
   relationship: PARTIAL_OVERLAP
-  confidence: LOW
+  confidence: MODERATE
   evidence:
   - evidence_type: ATLAS_METADATA
     supports: PARTIAL
@@ -3465,6 +3477,10 @@ edges:
       RHP-COA Ndnf not hippocampus-specific.
 
       '
+  - evidence_type: ATLAS_METADATA
+    supports: SUPPORT
+    explanation: 'Precomputed stats cross-check: all 4 defining markers confirmed (Nos1=2.26, Npy=2.61, Lamp5=3.65, Id2=4.88)
+      and all 3 negative markers absent (Pvalb=0.27, Sst=1.51, Calb2=0.31). Comprehensive marker match.'
   property_comparisons:
   - property: nt_type
     node_a_value: GABAergic
@@ -3531,8 +3547,8 @@ edges:
 - id: edge_neurogliaform_cell_hippocampus_to_CS20230722_SUPT_0203
   type_a: neurogliaform_cell_hippocampus
   type_b: CS20230722_SUPT_0203
-  relationship: UNCERTAIN
-  confidence: UNCERTAIN
+  relationship: PARTIAL_OVERLAP
+  confidence: LOW
   evidence:
   - evidence_type: ATLAS_METADATA
     supports: PARTIAL
@@ -3543,6 +3559,11 @@ edges:
       doubt on this supertype as an NGC hippocampal candidate.
 
       '
+  - evidence_type: ATLAS_METADATA
+    supports: SUPPORT
+    explanation: 'Precomputed stats cross-check: all 4 defining markers confirmed at higher levels than SUPT_0193 (Nos1=7.79,
+      Npy=4.62, Lamp5=4.40, Id2=9.35), all 3 negative markers absent. Stronger Nos1 expression suggests MGE-derived nNOS+
+      NGC subtype identity. Upgraded from UNCERTAIN.'
   property_comparisons:
   - property: nt_type
     node_a_value: GABAergic
@@ -3600,7 +3621,7 @@ edges:
   type_a: ivy_cell_hippocampus
   type_b: CS20230722_SUPT_0203
   relationship: PARTIAL_OVERLAP
-  confidence: LOW
+  confidence: MODERATE
   evidence:
   - evidence_type: ATLAS_METADATA
     supports: PARTIAL
@@ -3611,6 +3632,11 @@ edges:
       pyramidale — Ivy cell preferred location in CA1 SP is absent.
 
       '
+  - evidence_type: ATLAS_METADATA
+    supports: SUPPORT
+    explanation: 'Precomputed stats cross-check: all 3 defining markers confirmed (Nos1=7.79, Npy=4.62, Lamp5=4.40) and all
+      3 negative markers absent (Pvalb=0.43, Sst=1.52, Calb2=0.37). Strong marker support for Ivy cell identity in Lamp5 Lhx6
+      supertype.'
   property_comparisons:
   - property: nt_type
     node_a_value: GABAergic
@@ -3677,7 +3703,7 @@ edges:
   type_a: is_interneuron_hippocampus
   type_b: CS20230722_SUPT_0179
   relationship: PARTIAL_OVERLAP
-  confidence: LOW
+  confidence: MODERATE
   evidence:
   - evidence_type: ATLAS_METADATA
     supports: PARTIAL
@@ -3689,6 +3715,10 @@ edges:
       IS literature.
 
       '
+  - evidence_type: ATLAS_METADATA
+    supports: SUPPORT
+    explanation: 'Precomputed stats cross-check: both defining markers strongly confirmed (Calb2=6.78, Vip=6.82). Vip neuropeptide
+      also confirmed (6.82).'
   property_comparisons:
   - property: nt_type
     node_a_value: GABAergic
@@ -3753,6 +3783,10 @@ edges:
       making this a PLAUSIBLE but unconfirmed assignment.
 
       '
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Precomputed stats cross-check: Sst=10.17 strongly confirmed, but Nos1=1.81 is low. O-O cells are defined
+      by Sst+Nos1 co-expression; weak Nos1 in SUPT_0219 suggests this may not be the primary O-O supertype.'
   property_comparisons:
   - property: nt_type
     node_a_value: GABAergic
@@ -3818,6 +3852,11 @@ edges:
       SUPT_0206 likely contains multiple PV+ interneuron types including PV basket cells, making overlap partial.
 
       '
+  - evidence_type: ATLAS_METADATA
+    supports: PARTIAL
+    explanation: 'Precomputed stats cross-check: defining markers confirmed (Pvalb=8.74, Chrm2/M2R=4.52), but negative marker
+      Sst expressed at 2.72. Low-level Sst in a Pvalb supertype is not unexpected (some Pvalb interneurons co-express Sst
+      at low levels) but weakens the negative marker constraint.'
   property_comparisons:
   - property: nt_type
     node_a_value: GABAergic
@@ -3858,6 +3897,10 @@ edges:
       been independently confirmed.
 
       '
+  - caveat_type: MARKER_NOT_SPECIFIC
+    description: Negative marker Sst shows low expression (2.72) in SUPT_0206. Classical trilaminar cells are defined as Sst-negative,
+      but low-level Sst co-expression in Pvalb types is known. Does not disqualify the mapping but reduces confidence in Sst
+      as a discriminating marker.
 - id: edge_vip_basket_cell_hippocampus_to_CS20230722_SUPT_0179
   type_a: vip_basket_cell_hippocampus
   type_b: CS20230722_SUPT_0179

--- a/kb/draft/hippocampus/wmb_to_ctx_annotation_transfer.yaml
+++ b/kb/draft/hippocampus/wmb_to_ctx_annotation_transfer.yaml
@@ -1,0 +1,1997 @@
+name: WMBv1 → CTX-HPF cross-taxonomy annotation transfer (hippocampus GABA)
+description: Cross-taxonomy annotation transfer edges linking WMBv1 (CCN20230722) clusters to CTX-HPF (CS202106160, Yao et
+  al. 2021) clusters. Derived from vendor-provided CTX_* fields in WMB metadata. These are 1:1 deterministic assignments (no
+  F1 scores). Scoped to hippocampus GABA stratum oriens clusters (49 edges). Name discrepancies between WMB-side labels and
+  authoritative CTX labels are preserved in name_in_source for audit.
+brain_region:
+  id: UBERON:0005370
+  label: stratum oriens of hippocampal formation
+  name_in_source: stratum oriens
+source_atlas: WMBv1 (CCN20230722)
+target_atlas: CTX-HPF (CS202106160)
+species:
+  id: NCBITaxon:10090
+  label: Mus musculus
+  name_in_source: Mus musculus
+creation_date: '2026-04-22'
+nodes:
+- id: ctx_cs202106160_102
+  name: 102_Sst HPF
+  cell_set_accession: CS202106160_102
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+- id: ctx_cs202106160_103
+  name: 103_Sst HPF
+  cell_set_accession: CS202106160_103
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+- id: ctx_cs202106160_104
+  name: 104_Sst HPF
+  cell_set_accession: CS202106160_104
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+- id: ctx_cs202106160_105
+  name: 105_Sst HPF
+  cell_set_accession: CS202106160_105
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+- id: ctx_cs202106160_110
+  name: 110_Pvalb
+  cell_set_accession: CS202106160_110
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+- id: ctx_cs202106160_114
+  name: 114_Pvalb
+  cell_set_accession: CS202106160_114
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+- id: ctx_cs202106160_21
+  name: 21_Sncg
+  cell_set_accession: CS202106160_21
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+- id: ctx_cs202106160_25
+  name: 25_Sncg
+  cell_set_accession: CS202106160_25
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+- id: ctx_cs202106160_26
+  name: 26_Ntng1 HPF
+  cell_set_accession: CS202106160_26
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+- id: ctx_cs202106160_29
+  name: 29_Ntng1 HPF
+  cell_set_accession: CS202106160_29
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+- id: ctx_cs202106160_30
+  name: 30_Ntng1 HPF
+  cell_set_accession: CS202106160_30
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+- id: ctx_cs202106160_34
+  name: 34_Sncg
+  cell_set_accession: CS202106160_34
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+- id: ctx_cs202106160_4
+  name: 4_Meis2 HPF
+  cell_set_accession: CS202106160_4
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+- id: ctx_cs202106160_49
+  name: 49_Vip
+  cell_set_accession: CS202106160_49
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+- id: ctx_cs202106160_5
+  name: 5_Lamp5 Lhx6
+  cell_set_accession: CS202106160_5
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+- id: ctx_cs202106160_55
+  name: 55_Vip HPF
+  cell_set_accession: CS202106160_55
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+- id: ctx_cs202106160_56
+  name: 56_Vip HPF
+  cell_set_accession: CS202106160_56
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+- id: ctx_cs202106160_59
+  name: 59_Vip Igfbp6
+  cell_set_accession: CS202106160_59
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+- id: ctx_cs202106160_6
+  name: 6_Lamp5 Lhx6
+  cell_set_accession: CS202106160_6
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+- id: ctx_cs202106160_60
+  name: 60_Vip Igfbp6
+  cell_set_accession: CS202106160_60
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+- id: ctx_cs202106160_61
+  name: 61_Vip Igfbp6
+  cell_set_accession: CS202106160_61
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+- id: ctx_cs202106160_7
+  name: 7_Lamp5 Lhx6
+  cell_set_accession: CS202106160_7
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+- id: ctx_cs202106160_77
+  name: 77_Sst HPF
+  cell_set_accession: CS202106160_77
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+- id: ctx_cs202106160_78
+  name: 78_Sst HPF
+  cell_set_accession: CS202106160_78
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+- id: ctx_cs202106160_79
+  name: 79_Sst
+  cell_set_accession: CS202106160_79
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+- id: ctx_cs202106160_8
+  name: 8_Lamp5 Lhx6
+  cell_set_accession: CS202106160_8
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+- id: ctx_cs202106160_80
+  name: 80_Sst
+  cell_set_accession: CS202106160_80
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+- id: ctx_cs202106160_87
+  name: 87_Sst
+  cell_set_accession: CS202106160_87
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+- id: ctx_cs202106160_9
+  name: 9_Lamp5 Lhx6
+  cell_set_accession: CS202106160_9
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+- id: wmb_cs20230722_clus_0649
+  name: 0649 Vip Gaba_7
+  cell_set_accession: CS20230722_CLUS_0649
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0650
+  name: 0650 Vip Gaba_7
+  cell_set_accession: CS20230722_CLUS_0650
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0651
+  name: 0651 Vip Gaba_7
+  cell_set_accession: CS20230722_CLUS_0651
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0654
+  name: 0654 Vip Gaba_9
+  cell_set_accession: CS20230722_CLUS_0654
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0655
+  name: 0655 Vip Gaba_9
+  cell_set_accession: CS20230722_CLUS_0655
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0656
+  name: 0656 Vip Gaba_9
+  cell_set_accession: CS20230722_CLUS_0656
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0657
+  name: 0657 Vip Gaba_9
+  cell_set_accession: CS20230722_CLUS_0657
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0658
+  name: 0658 Vip Gaba_10
+  cell_set_accession: CS20230722_CLUS_0658
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0659
+  name: 0659 Vip Gaba_10
+  cell_set_accession: CS20230722_CLUS_0659
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0679
+  name: 0679 Sncg Gaba_5
+  cell_set_accession: CS20230722_CLUS_0679
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0680
+  name: 0680 Sncg Gaba_5
+  cell_set_accession: CS20230722_CLUS_0680
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0681
+  name: 0681 Sncg Gaba_5
+  cell_set_accession: CS20230722_CLUS_0681
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0697
+  name: 0697 RHP-COA Ndnf Gaba_4
+  cell_set_accession: CS20230722_CLUS_0697
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0698
+  name: 0698 RHP-COA Ndnf Gaba_4
+  cell_set_accession: CS20230722_CLUS_0698
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0699
+  name: 0699 RHP-COA Ndnf Gaba_5
+  cell_set_accession: CS20230722_CLUS_0699
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0700
+  name: 0700 RHP-COA Ndnf Gaba_5
+  cell_set_accession: CS20230722_CLUS_0700
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0701
+  name: 0701 RHP-COA Ndnf Gaba_5
+  cell_set_accession: CS20230722_CLUS_0701
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0702
+  name: 0702 RHP-COA Ndnf Gaba_5
+  cell_set_accession: CS20230722_CLUS_0702
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0703
+  name: 0703 RHP-COA Ndnf Gaba_5
+  cell_set_accession: CS20230722_CLUS_0703
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0704
+  name: 0704 RHP-COA Ndnf Gaba_6
+  cell_set_accession: CS20230722_CLUS_0704
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0705
+  name: 0705 RHP-COA Ndnf Gaba_6
+  cell_set_accession: CS20230722_CLUS_0705
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0724
+  name: 0724 Lamp5 Lhx6 Gaba_1
+  cell_set_accession: CS20230722_CLUS_0724
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0725
+  name: 0725 Lamp5 Lhx6 Gaba_1
+  cell_set_accession: CS20230722_CLUS_0725
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0726
+  name: 0726 Lamp5 Lhx6 Gaba_1
+  cell_set_accession: CS20230722_CLUS_0726
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0727
+  name: 0727 Lamp5 Lhx6 Gaba_1
+  cell_set_accession: CS20230722_CLUS_0727
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0728
+  name: 0728 Lamp5 Lhx6 Gaba_1
+  cell_set_accession: CS20230722_CLUS_0728
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0729
+  name: 0729 Lamp5 Lhx6 Gaba_1
+  cell_set_accession: CS20230722_CLUS_0729
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0730
+  name: 0730 Lamp5 Lhx6 Gaba_1
+  cell_set_accession: CS20230722_CLUS_0730
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0731
+  name: 0731 Lamp5 Lhx6 Gaba_1
+  cell_set_accession: CS20230722_CLUS_0731
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0737
+  name: 0737 Pvalb Gaba_2
+  cell_set_accession: CS20230722_CLUS_0737
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0738
+  name: 0738 Pvalb Gaba_2
+  cell_set_accession: CS20230722_CLUS_0738
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0739
+  name: 0739 Pvalb Gaba_2
+  cell_set_accession: CS20230722_CLUS_0739
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0755
+  name: 0755 Pvalb Gaba_9
+  cell_set_accession: CS20230722_CLUS_0755
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0767
+  name: 0767 Sst Gaba_3
+  cell_set_accession: CS20230722_CLUS_0767
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0768
+  name: 0768 Sst Gaba_3
+  cell_set_accession: CS20230722_CLUS_0768
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0769
+  name: 0769 Sst Gaba_3
+  cell_set_accession: CS20230722_CLUS_0769
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0770
+  name: 0770 Sst Gaba_3
+  cell_set_accession: CS20230722_CLUS_0770
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0771
+  name: 0771 Sst Gaba_3
+  cell_set_accession: CS20230722_CLUS_0771
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0772
+  name: 0772 Sst Gaba_3
+  cell_set_accession: CS20230722_CLUS_0772
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0773
+  name: 0773 Sst Gaba_3
+  cell_set_accession: CS20230722_CLUS_0773
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0774
+  name: 0774 Sst Gaba_3
+  cell_set_accession: CS20230722_CLUS_0774
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0775
+  name: 0775 Sst Gaba_3
+  cell_set_accession: CS20230722_CLUS_0775
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0785
+  name: 0785 Sst Gaba_6
+  cell_set_accession: CS20230722_CLUS_0785
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0786
+  name: 0786 Sst Gaba_6
+  cell_set_accession: CS20230722_CLUS_0786
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0787
+  name: 0787 Sst Gaba_6
+  cell_set_accession: CS20230722_CLUS_0787
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0788
+  name: 0788 Sst Gaba_6
+  cell_set_accession: CS20230722_CLUS_0788
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0789
+  name: 0789 Sst Gaba_6
+  cell_set_accession: CS20230722_CLUS_0789
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0790
+  name: 0790 Sst Gaba_6
+  cell_set_accession: CS20230722_CLUS_0790
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+- id: wmb_cs20230722_clus_0791
+  name: 0791 Sst Gaba_6
+  cell_set_accession: CS20230722_CLUS_0791
+  taxonomy_id: CCN20230722
+  taxonomy_level: CLUSTER
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+edges:
+- id: edge_wmb_cs20230722_clus_0649_to_ctx_cs202106160_49
+  type_a: wmb_cs20230722_clus_0649
+  type_b: ctx_cs202106160_49
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0649 Vip Gaba_7 (CS20230722_CLUS_0649) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 49_Vip (CS202106160_49). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0649 Vip Gaba_7
+    source_cell_set_accession: CS20230722_CLUS_0649
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 49_Vip
+      best_target_accession: CS202106160_49
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Vip
+      best_target_accession: subclass_label:a547e761cb
+    name_in_source: 49_Vip_4
+- id: edge_wmb_cs20230722_clus_0650_to_ctx_cs202106160_56
+  type_a: wmb_cs20230722_clus_0650
+  type_b: ctx_cs202106160_56
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0650 Vip Gaba_7 (CS20230722_CLUS_0650) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 56_Vip HPF (CS202106160_56). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0650 Vip Gaba_7
+    source_cell_set_accession: CS20230722_CLUS_0650
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 56_Vip HPF
+      best_target_accession: CS202106160_56
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Vip
+      best_target_accession: subclass_label:a547e761cb
+    name_in_source: 56_Vip_3
+- id: edge_wmb_cs20230722_clus_0651_to_ctx_cs202106160_55
+  type_a: wmb_cs20230722_clus_0651
+  type_b: ctx_cs202106160_55
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0651 Vip Gaba_7 (CS20230722_CLUS_0651) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 55_Vip HPF (CS202106160_55). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0651 Vip Gaba_7
+    source_cell_set_accession: CS20230722_CLUS_0651
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 55_Vip HPF
+      best_target_accession: CS202106160_55
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Vip
+      best_target_accession: subclass_label:a547e761cb
+    name_in_source: 55_Vip
+- id: edge_wmb_cs20230722_clus_0654_to_ctx_cs202106160_56
+  type_a: wmb_cs20230722_clus_0654
+  type_b: ctx_cs202106160_56
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0654 Vip Gaba_9 (CS20230722_CLUS_0654) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 56_Vip HPF (CS202106160_56). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0654 Vip Gaba_9
+    source_cell_set_accession: CS20230722_CLUS_0654
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 56_Vip HPF
+      best_target_accession: CS202106160_56
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Vip
+      best_target_accession: subclass_label:a547e761cb
+    name_in_source: 56_Vip_2
+- id: edge_wmb_cs20230722_clus_0655_to_ctx_cs202106160_56
+  type_a: wmb_cs20230722_clus_0655
+  type_b: ctx_cs202106160_56
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0655 Vip Gaba_9 (CS20230722_CLUS_0655) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 56_Vip HPF (CS202106160_56). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0655 Vip Gaba_9
+    source_cell_set_accession: CS20230722_CLUS_0655
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 56_Vip HPF
+      best_target_accession: CS202106160_56
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Vip
+      best_target_accession: subclass_label:a547e761cb
+    name_in_source: 56_Vip_4
+- id: edge_wmb_cs20230722_clus_0656_to_ctx_cs202106160_60
+  type_a: wmb_cs20230722_clus_0656
+  type_b: ctx_cs202106160_60
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0656 Vip Gaba_9 (CS20230722_CLUS_0656) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 60_Vip Igfbp6 (CS202106160_60). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0656 Vip Gaba_9
+    source_cell_set_accession: CS20230722_CLUS_0656
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 60_Vip Igfbp6
+      best_target_accession: CS202106160_60
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Vip
+      best_target_accession: subclass_label:a547e761cb
+    name_in_source: 60_Vip_3
+- id: edge_wmb_cs20230722_clus_0657_to_ctx_cs202106160_61
+  type_a: wmb_cs20230722_clus_0657
+  type_b: ctx_cs202106160_61
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0657 Vip Gaba_9 (CS20230722_CLUS_0657) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 61_Vip Igfbp6 (CS202106160_61). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0657 Vip Gaba_9
+    source_cell_set_accession: CS20230722_CLUS_0657
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 61_Vip Igfbp6
+      best_target_accession: CS202106160_61
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Vip
+      best_target_accession: subclass_label:a547e761cb
+    name_in_source: 61_Vip_2
+- id: edge_wmb_cs20230722_clus_0658_to_ctx_cs202106160_59
+  type_a: wmb_cs20230722_clus_0658
+  type_b: ctx_cs202106160_59
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0658 Vip Gaba_10 (CS20230722_CLUS_0658) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 59_Vip Igfbp6 (CS202106160_59). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0658 Vip Gaba_10
+    source_cell_set_accession: CS20230722_CLUS_0658
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 59_Vip Igfbp6
+      best_target_accession: CS202106160_59
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Vip
+      best_target_accession: subclass_label:a547e761cb
+    name_in_source: 59_Vip_3
+- id: edge_wmb_cs20230722_clus_0659_to_ctx_cs202106160_59
+  type_a: wmb_cs20230722_clus_0659
+  type_b: ctx_cs202106160_59
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0659 Vip Gaba_10 (CS20230722_CLUS_0659) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 59_Vip Igfbp6 (CS202106160_59). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0659 Vip Gaba_10
+    source_cell_set_accession: CS20230722_CLUS_0659
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 59_Vip Igfbp6
+      best_target_accession: CS202106160_59
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Vip
+      best_target_accession: subclass_label:a547e761cb
+    name_in_source: 59_Vip_4
+- id: edge_wmb_cs20230722_clus_0679_to_ctx_cs202106160_25
+  type_a: wmb_cs20230722_clus_0679
+  type_b: ctx_cs202106160_25
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0679 Sncg Gaba_5 (CS20230722_CLUS_0679) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 25_Sncg (CS202106160_25). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0679 Sncg Gaba_5
+    source_cell_set_accession: CS20230722_CLUS_0679
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 25_Sncg
+      best_target_accession: CS202106160_25
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sncg
+      best_target_accession: subclass_label:86d5f48b05
+    name_in_source: 25_Sncg_1
+- id: edge_wmb_cs20230722_clus_0680_to_ctx_cs202106160_21
+  type_a: wmb_cs20230722_clus_0680
+  type_b: ctx_cs202106160_21
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0680 Sncg Gaba_5 (CS20230722_CLUS_0680) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 21_Sncg (CS202106160_21). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0680 Sncg Gaba_5
+    source_cell_set_accession: CS20230722_CLUS_0680
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 21_Sncg
+      best_target_accession: CS202106160_21
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sncg
+      best_target_accession: subclass_label:86d5f48b05
+- id: edge_wmb_cs20230722_clus_0681_to_ctx_cs202106160_34
+  type_a: wmb_cs20230722_clus_0681
+  type_b: ctx_cs202106160_34
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0681 Sncg Gaba_5 (CS20230722_CLUS_0681) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 34_Sncg (CS202106160_34). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0681 Sncg Gaba_5
+    source_cell_set_accession: CS20230722_CLUS_0681
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 34_Sncg
+      best_target_accession: CS202106160_34
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sncg
+      best_target_accession: subclass_label:86d5f48b05
+- id: edge_wmb_cs20230722_clus_0697_to_ctx_cs202106160_30
+  type_a: wmb_cs20230722_clus_0697
+  type_b: ctx_cs202106160_30
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0697 RHP-COA Ndnf Gaba_4 (CS20230722_CLUS_0697) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 30_Ntng1 HPF (CS202106160_30). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0697 RHP-COA Ndnf Gaba_4
+    source_cell_set_accession: CS20230722_CLUS_0697
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 30_Ntng1 HPF
+      best_target_accession: CS202106160_30
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sncg
+      best_target_accession: subclass_label:86d5f48b05
+    name_in_source: 30_Ndnf HPF
+- id: edge_wmb_cs20230722_clus_0698_to_ctx_cs202106160_29
+  type_a: wmb_cs20230722_clus_0698
+  type_b: ctx_cs202106160_29
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0698 RHP-COA Ndnf Gaba_4 (CS20230722_CLUS_0698) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 29_Ntng1 HPF (CS202106160_29). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0698 RHP-COA Ndnf Gaba_4
+    source_cell_set_accession: CS20230722_CLUS_0698
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 29_Ntng1 HPF
+      best_target_accession: CS202106160_29
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sncg
+      best_target_accession: subclass_label:86d5f48b05
+    name_in_source: 29_Ndnf HPF_2
+- id: edge_wmb_cs20230722_clus_0699_to_ctx_cs202106160_29
+  type_a: wmb_cs20230722_clus_0699
+  type_b: ctx_cs202106160_29
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0699 RHP-COA Ndnf Gaba_5 (CS20230722_CLUS_0699) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 29_Ntng1 HPF (CS202106160_29). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0699 RHP-COA Ndnf Gaba_5
+    source_cell_set_accession: CS20230722_CLUS_0699
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 29_Ntng1 HPF
+      best_target_accession: CS202106160_29
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sncg
+      best_target_accession: subclass_label:86d5f48b05
+    name_in_source: 29_Ndnf HPF_4
+- id: edge_wmb_cs20230722_clus_0700_to_ctx_cs202106160_26
+  type_a: wmb_cs20230722_clus_0700
+  type_b: ctx_cs202106160_26
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0700 RHP-COA Ndnf Gaba_5 (CS20230722_CLUS_0700) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 26_Ntng1 HPF (CS202106160_26). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0700 RHP-COA Ndnf Gaba_5
+    source_cell_set_accession: CS20230722_CLUS_0700
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 26_Ntng1 HPF
+      best_target_accession: CS202106160_26
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sncg
+      best_target_accession: subclass_label:86d5f48b05
+    name_in_source: 26_Ndnf HPF_3
+- id: edge_wmb_cs20230722_clus_0701_to_ctx_cs202106160_26
+  type_a: wmb_cs20230722_clus_0701
+  type_b: ctx_cs202106160_26
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0701 RHP-COA Ndnf Gaba_5 (CS20230722_CLUS_0701) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 26_Ntng1 HPF (CS202106160_26). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0701 RHP-COA Ndnf Gaba_5
+    source_cell_set_accession: CS20230722_CLUS_0701
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 26_Ntng1 HPF
+      best_target_accession: CS202106160_26
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sncg
+      best_target_accession: subclass_label:86d5f48b05
+    name_in_source: 26_Ndnf HPF_1
+- id: edge_wmb_cs20230722_clus_0702_to_ctx_cs202106160_25
+  type_a: wmb_cs20230722_clus_0702
+  type_b: ctx_cs202106160_25
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0702 RHP-COA Ndnf Gaba_5 (CS20230722_CLUS_0702) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 25_Sncg (CS202106160_25). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0702 RHP-COA Ndnf Gaba_5
+    source_cell_set_accession: CS20230722_CLUS_0702
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 25_Sncg
+      best_target_accession: CS202106160_25
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sncg
+      best_target_accession: subclass_label:86d5f48b05
+    name_in_source: 25_Sncg_2
+- id: edge_wmb_cs20230722_clus_0703_to_ctx_cs202106160_26
+  type_a: wmb_cs20230722_clus_0703
+  type_b: ctx_cs202106160_26
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0703 RHP-COA Ndnf Gaba_5 (CS20230722_CLUS_0703) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 26_Ntng1 HPF (CS202106160_26). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0703 RHP-COA Ndnf Gaba_5
+    source_cell_set_accession: CS20230722_CLUS_0703
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 26_Ntng1 HPF
+      best_target_accession: CS202106160_26
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sncg
+      best_target_accession: subclass_label:86d5f48b05
+    name_in_source: 26_Ndnf HPF_2
+- id: edge_wmb_cs20230722_clus_0704_to_ctx_cs202106160_4
+  type_a: wmb_cs20230722_clus_0704
+  type_b: ctx_cs202106160_4
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0704 RHP-COA Ndnf Gaba_6 (CS20230722_CLUS_0704) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 4_Meis2 HPF (CS202106160_4). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0704 RHP-COA Ndnf Gaba_6
+    source_cell_set_accession: CS20230722_CLUS_0704
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 4_Meis2 HPF
+      best_target_accession: CS202106160_4
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sncg
+      best_target_accession: subclass_label:86d5f48b05
+    name_in_source: 4_Meis2 HPF_1
+- id: edge_wmb_cs20230722_clus_0705_to_ctx_cs202106160_4
+  type_a: wmb_cs20230722_clus_0705
+  type_b: ctx_cs202106160_4
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0705 RHP-COA Ndnf Gaba_6 (CS20230722_CLUS_0705) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 4_Meis2 HPF (CS202106160_4). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0705 RHP-COA Ndnf Gaba_6
+    source_cell_set_accession: CS20230722_CLUS_0705
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 4_Meis2 HPF
+      best_target_accession: CS202106160_4
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sncg
+      best_target_accession: subclass_label:86d5f48b05
+    name_in_source: 4_Meis2 HPF_2
+- id: edge_wmb_cs20230722_clus_0724_to_ctx_cs202106160_6
+  type_a: wmb_cs20230722_clus_0724
+  type_b: ctx_cs202106160_6
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0724 Lamp5 Lhx6 Gaba_1 (CS20230722_CLUS_0724) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 6_Lamp5 Lhx6 (CS202106160_6). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0724 Lamp5 Lhx6 Gaba_1
+    source_cell_set_accession: CS20230722_CLUS_0724
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 6_Lamp5 Lhx6
+      best_target_accession: CS202106160_6
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Lamp5
+      best_target_accession: subclass_label:e40986e2c0
+- id: edge_wmb_cs20230722_clus_0725_to_ctx_cs202106160_7
+  type_a: wmb_cs20230722_clus_0725
+  type_b: ctx_cs202106160_7
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0725 Lamp5 Lhx6 Gaba_1 (CS20230722_CLUS_0725) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 7_Lamp5 Lhx6 (CS202106160_7). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0725 Lamp5 Lhx6 Gaba_1
+    source_cell_set_accession: CS20230722_CLUS_0725
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 7_Lamp5 Lhx6
+      best_target_accession: CS202106160_7
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Lamp5
+      best_target_accession: subclass_label:e40986e2c0
+    name_in_source: 7_Lamp5 Lhx6_1
+- id: edge_wmb_cs20230722_clus_0726_to_ctx_cs202106160_7
+  type_a: wmb_cs20230722_clus_0726
+  type_b: ctx_cs202106160_7
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0726 Lamp5 Lhx6 Gaba_1 (CS20230722_CLUS_0726) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 7_Lamp5 Lhx6 (CS202106160_7). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0726 Lamp5 Lhx6 Gaba_1
+    source_cell_set_accession: CS20230722_CLUS_0726
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 7_Lamp5 Lhx6
+      best_target_accession: CS202106160_7
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Lamp5
+      best_target_accession: subclass_label:e40986e2c0
+    name_in_source: 7_Lamp5 Lhx6_2
+- id: edge_wmb_cs20230722_clus_0727_to_ctx_cs202106160_8
+  type_a: wmb_cs20230722_clus_0727
+  type_b: ctx_cs202106160_8
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0727 Lamp5 Lhx6 Gaba_1 (CS20230722_CLUS_0727) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 8_Lamp5 Lhx6 (CS202106160_8). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0727 Lamp5 Lhx6 Gaba_1
+    source_cell_set_accession: CS20230722_CLUS_0727
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 8_Lamp5 Lhx6
+      best_target_accession: CS202106160_8
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Lamp5
+      best_target_accession: subclass_label:e40986e2c0
+    name_in_source: 8_Lamp5 Lhx6_2
+- id: edge_wmb_cs20230722_clus_0728_to_ctx_cs202106160_9
+  type_a: wmb_cs20230722_clus_0728
+  type_b: ctx_cs202106160_9
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0728 Lamp5 Lhx6 Gaba_1 (CS20230722_CLUS_0728) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 9_Lamp5 Lhx6 (CS202106160_9). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0728 Lamp5 Lhx6 Gaba_1
+    source_cell_set_accession: CS20230722_CLUS_0728
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 9_Lamp5 Lhx6
+      best_target_accession: CS202106160_9
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Lamp5
+      best_target_accession: subclass_label:e40986e2c0
+- id: edge_wmb_cs20230722_clus_0729_to_ctx_cs202106160_8
+  type_a: wmb_cs20230722_clus_0729
+  type_b: ctx_cs202106160_8
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0729 Lamp5 Lhx6 Gaba_1 (CS20230722_CLUS_0729) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 8_Lamp5 Lhx6 (CS202106160_8). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0729 Lamp5 Lhx6 Gaba_1
+    source_cell_set_accession: CS20230722_CLUS_0729
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 8_Lamp5 Lhx6
+      best_target_accession: CS202106160_8
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Lamp5
+      best_target_accession: subclass_label:e40986e2c0
+    name_in_source: 8_Lamp5 Lhx6_1
+- id: edge_wmb_cs20230722_clus_0730_to_ctx_cs202106160_5
+  type_a: wmb_cs20230722_clus_0730
+  type_b: ctx_cs202106160_5
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0730 Lamp5 Lhx6 Gaba_1 (CS20230722_CLUS_0730) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 5_Lamp5 Lhx6 (CS202106160_5). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0730 Lamp5 Lhx6 Gaba_1
+    source_cell_set_accession: CS20230722_CLUS_0730
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 5_Lamp5 Lhx6
+      best_target_accession: CS202106160_5
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Lamp5
+      best_target_accession: subclass_label:e40986e2c0
+    name_in_source: 5_Lamp5 Lhx6_1
+- id: edge_wmb_cs20230722_clus_0731_to_ctx_cs202106160_5
+  type_a: wmb_cs20230722_clus_0731
+  type_b: ctx_cs202106160_5
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0731 Lamp5 Lhx6 Gaba_1 (CS20230722_CLUS_0731) carries a 1:1 deterministic annotation transfer
+      to CTX-HPF cluster 5_Lamp5 Lhx6 (CS202106160_5). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0731 Lamp5 Lhx6 Gaba_1
+    source_cell_set_accession: CS20230722_CLUS_0731
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 5_Lamp5 Lhx6
+      best_target_accession: CS202106160_5
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Lamp5
+      best_target_accession: subclass_label:e40986e2c0
+    name_in_source: 5_Lamp5 Lhx6_2
+- id: edge_wmb_cs20230722_clus_0737_to_ctx_cs202106160_114
+  type_a: wmb_cs20230722_clus_0737
+  type_b: ctx_cs202106160_114
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0737 Pvalb Gaba_2 (CS20230722_CLUS_0737) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 114_Pvalb (CS202106160_114). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0737 Pvalb Gaba_2
+    source_cell_set_accession: CS20230722_CLUS_0737
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 114_Pvalb
+      best_target_accession: CS202106160_114
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Pvalb
+      best_target_accession: CS202106160_463
+    name_in_source: 114_Pvalb_7
+- id: edge_wmb_cs20230722_clus_0738_to_ctx_cs202106160_114
+  type_a: wmb_cs20230722_clus_0738
+  type_b: ctx_cs202106160_114
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0738 Pvalb Gaba_2 (CS20230722_CLUS_0738) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 114_Pvalb (CS202106160_114). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0738 Pvalb Gaba_2
+    source_cell_set_accession: CS20230722_CLUS_0738
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 114_Pvalb
+      best_target_accession: CS202106160_114
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Pvalb
+      best_target_accession: CS202106160_463
+    name_in_source: 114_Pvalb_8
+- id: edge_wmb_cs20230722_clus_0739_to_ctx_cs202106160_114
+  type_a: wmb_cs20230722_clus_0739
+  type_b: ctx_cs202106160_114
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0739 Pvalb Gaba_2 (CS20230722_CLUS_0739) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 114_Pvalb (CS202106160_114). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0739 Pvalb Gaba_2
+    source_cell_set_accession: CS20230722_CLUS_0739
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 114_Pvalb
+      best_target_accession: CS202106160_114
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Pvalb
+      best_target_accession: CS202106160_463
+    name_in_source: 114_Pvalb_9
+- id: edge_wmb_cs20230722_clus_0755_to_ctx_cs202106160_110
+  type_a: wmb_cs20230722_clus_0755
+  type_b: ctx_cs202106160_110
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0755 Pvalb Gaba_9 (CS20230722_CLUS_0755) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 110_Pvalb (CS202106160_110). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0755 Pvalb Gaba_9
+    source_cell_set_accession: CS20230722_CLUS_0755
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 110_Pvalb
+      best_target_accession: CS202106160_110
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Pvalb
+      best_target_accession: CS202106160_463
+- id: edge_wmb_cs20230722_clus_0767_to_ctx_cs202106160_78
+  type_a: wmb_cs20230722_clus_0767
+  type_b: ctx_cs202106160_78
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0767 Sst Gaba_3 (CS20230722_CLUS_0767) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 78_Sst HPF (CS202106160_78). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0767 Sst Gaba_3
+    source_cell_set_accession: CS20230722_CLUS_0767
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 78_Sst HPF
+      best_target_accession: CS202106160_78
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 78_Sst_1
+- id: edge_wmb_cs20230722_clus_0768_to_ctx_cs202106160_78
+  type_a: wmb_cs20230722_clus_0768
+  type_b: ctx_cs202106160_78
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0768 Sst Gaba_3 (CS20230722_CLUS_0768) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 78_Sst HPF (CS202106160_78). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0768 Sst Gaba_3
+    source_cell_set_accession: CS20230722_CLUS_0768
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 78_Sst HPF
+      best_target_accession: CS202106160_78
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 78_Sst_2
+- id: edge_wmb_cs20230722_clus_0769_to_ctx_cs202106160_80
+  type_a: wmb_cs20230722_clus_0769
+  type_b: ctx_cs202106160_80
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0769 Sst Gaba_3 (CS20230722_CLUS_0769) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 80_Sst (CS202106160_80). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0769 Sst Gaba_3
+    source_cell_set_accession: CS20230722_CLUS_0769
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 80_Sst
+      best_target_accession: CS202106160_80
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 80_Sst_1
+- id: edge_wmb_cs20230722_clus_0770_to_ctx_cs202106160_80
+  type_a: wmb_cs20230722_clus_0770
+  type_b: ctx_cs202106160_80
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0770 Sst Gaba_3 (CS20230722_CLUS_0770) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 80_Sst (CS202106160_80). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0770 Sst Gaba_3
+    source_cell_set_accession: CS20230722_CLUS_0770
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 80_Sst
+      best_target_accession: CS202106160_80
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 80_Sst_2
+- id: edge_wmb_cs20230722_clus_0771_to_ctx_cs202106160_79
+  type_a: wmb_cs20230722_clus_0771
+  type_b: ctx_cs202106160_79
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0771 Sst Gaba_3 (CS20230722_CLUS_0771) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 79_Sst (CS202106160_79). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0771 Sst Gaba_3
+    source_cell_set_accession: CS20230722_CLUS_0771
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 79_Sst
+      best_target_accession: CS202106160_79
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+- id: edge_wmb_cs20230722_clus_0772_to_ctx_cs202106160_78
+  type_a: wmb_cs20230722_clus_0772
+  type_b: ctx_cs202106160_78
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0772 Sst Gaba_3 (CS20230722_CLUS_0772) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 78_Sst HPF (CS202106160_78). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0772 Sst Gaba_3
+    source_cell_set_accession: CS20230722_CLUS_0772
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 78_Sst HPF
+      best_target_accession: CS202106160_78
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 78_Sst_3
+- id: edge_wmb_cs20230722_clus_0773_to_ctx_cs202106160_80
+  type_a: wmb_cs20230722_clus_0773
+  type_b: ctx_cs202106160_80
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0773 Sst Gaba_3 (CS20230722_CLUS_0773) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 80_Sst (CS202106160_80). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0773 Sst Gaba_3
+    source_cell_set_accession: CS20230722_CLUS_0773
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 80_Sst
+      best_target_accession: CS202106160_80
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 80_Sst_3
+- id: edge_wmb_cs20230722_clus_0774_to_ctx_cs202106160_87
+  type_a: wmb_cs20230722_clus_0774
+  type_b: ctx_cs202106160_87
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0774 Sst Gaba_3 (CS20230722_CLUS_0774) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 87_Sst (CS202106160_87). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0774 Sst Gaba_3
+    source_cell_set_accession: CS20230722_CLUS_0774
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 87_Sst
+      best_target_accession: CS202106160_87
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 87_Sst_5
+- id: edge_wmb_cs20230722_clus_0775_to_ctx_cs202106160_77
+  type_a: wmb_cs20230722_clus_0775
+  type_b: ctx_cs202106160_77
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0775 Sst Gaba_3 (CS20230722_CLUS_0775) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 77_Sst HPF (CS202106160_77). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0775 Sst Gaba_3
+    source_cell_set_accession: CS20230722_CLUS_0775
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 77_Sst HPF
+      best_target_accession: CS202106160_77
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 77_Sst
+- id: edge_wmb_cs20230722_clus_0785_to_ctx_cs202106160_104
+  type_a: wmb_cs20230722_clus_0785
+  type_b: ctx_cs202106160_104
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0785 Sst Gaba_6 (CS20230722_CLUS_0785) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 104_Sst HPF (CS202106160_104). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0785 Sst Gaba_6
+    source_cell_set_accession: CS20230722_CLUS_0785
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 104_Sst HPF
+      best_target_accession: CS202106160_104
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 104_Sst_2
+- id: edge_wmb_cs20230722_clus_0786_to_ctx_cs202106160_104
+  type_a: wmb_cs20230722_clus_0786
+  type_b: ctx_cs202106160_104
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0786 Sst Gaba_6 (CS20230722_CLUS_0786) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 104_Sst HPF (CS202106160_104). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0786 Sst Gaba_6
+    source_cell_set_accession: CS20230722_CLUS_0786
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 104_Sst HPF
+      best_target_accession: CS202106160_104
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 104_Sst_3
+- id: edge_wmb_cs20230722_clus_0787_to_ctx_cs202106160_102
+  type_a: wmb_cs20230722_clus_0787
+  type_b: ctx_cs202106160_102
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0787 Sst Gaba_6 (CS20230722_CLUS_0787) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 102_Sst HPF (CS202106160_102). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0787 Sst Gaba_6
+    source_cell_set_accession: CS20230722_CLUS_0787
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 102_Sst HPF
+      best_target_accession: CS202106160_102
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 102_Sst_1
+- id: edge_wmb_cs20230722_clus_0788_to_ctx_cs202106160_103
+  type_a: wmb_cs20230722_clus_0788
+  type_b: ctx_cs202106160_103
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0788 Sst Gaba_6 (CS20230722_CLUS_0788) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 103_Sst HPF (CS202106160_103). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0788 Sst Gaba_6
+    source_cell_set_accession: CS20230722_CLUS_0788
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 103_Sst HPF
+      best_target_accession: CS202106160_103
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 103_Sst_1
+- id: edge_wmb_cs20230722_clus_0789_to_ctx_cs202106160_105
+  type_a: wmb_cs20230722_clus_0789
+  type_b: ctx_cs202106160_105
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0789 Sst Gaba_6 (CS20230722_CLUS_0789) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 105_Sst HPF (CS202106160_105). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0789 Sst Gaba_6
+    source_cell_set_accession: CS20230722_CLUS_0789
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 105_Sst HPF
+      best_target_accession: CS202106160_105
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 105_Sst
+- id: edge_wmb_cs20230722_clus_0790_to_ctx_cs202106160_102
+  type_a: wmb_cs20230722_clus_0790
+  type_b: ctx_cs202106160_102
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0790 Sst Gaba_6 (CS20230722_CLUS_0790) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 102_Sst HPF (CS202106160_102). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0790 Sst Gaba_6
+    source_cell_set_accession: CS20230722_CLUS_0790
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 102_Sst HPF
+      best_target_accession: CS202106160_102
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 102_Sst_2
+- id: edge_wmb_cs20230722_clus_0791_to_ctx_cs202106160_103
+  type_a: wmb_cs20230722_clus_0791
+  type_b: ctx_cs202106160_103
+  relationship: OVERLAPS
+  confidence: LOW
+  evidence:
+  - evidence_type: ANNOTATION_TRANSFER
+    supports: SUPPORT
+    explanation: WMB cluster 0791 Sst Gaba_6 (CS20230722_CLUS_0791) carries a 1:1 deterministic annotation transfer to CTX-HPF
+      cluster 103_Sst HPF (CS202106160_103). Cross-taxonomy assignment from WMB metadata (Yao et al. 2021).
+    target_atlas: CTX-HPF (CS202106160)
+    method: deterministic annotation transfer (1:1, vendor-provided)
+    source_dataset_accession: CCN20230722
+    source_cluster_label: 0791 Sst Gaba_6
+    source_cell_set_accession: CS20230722_CLUS_0791
+    best_mapping_level: CLUSTER
+    best_mapping_rank: 0
+    metrics_by_level:
+    - taxonomy_level: CLUSTER
+      taxonomy_rank: 0
+      best_target_name: 103_Sst HPF
+      best_target_accession: CS202106160_103
+    - taxonomy_level: SUBCLASS
+      taxonomy_rank: 1
+      best_target_name: Sst
+      best_target_accession: CS202106160_444
+    name_in_source: 103_Sst_2

--- a/kb/taxonomy/CCN20230722/class.yaml
+++ b/kb/taxonomy/CCN20230722/class.yaml
@@ -51,6 +51,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_09
   name: 09 CNU-LGE GABA
   cell_set_accession: CS20230722_CLAS_09
@@ -85,6 +86,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_04
   name: 04 DG-IMN Glut
   cell_set_accession: CS20230722_CLAS_04
@@ -134,6 +136,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_05
   name: 05 OB-IMN GABA
   cell_set_accession: CS20230722_CLAS_05
@@ -188,6 +191,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_06
   name: 06 CTX-CGE GABA
   cell_set_accession: CS20230722_CLAS_06
@@ -217,6 +221,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_07
   name: 07 CTX-MGE GABA
   cell_set_accession: CS20230722_CLAS_07
@@ -246,6 +251,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_01
   name: 01 IT-ET Glut
   cell_set_accession: CS20230722_CLAS_01
@@ -270,6 +276,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_02
   name: 02 NP-CT-L6b Glut
   cell_set_accession: CS20230722_CLAS_02
@@ -299,6 +306,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_03
   name: 03 OB-CR Glut
   cell_set_accession: CS20230722_CLAS_03
@@ -343,6 +351,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_19
   name: 19 MB Glut
   cell_set_accession: CS20230722_CLAS_19
@@ -387,6 +396,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_10
   name: 10 LSX GABA
   cell_set_accession: CS20230722_CLAS_10
@@ -421,6 +431,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_15
   name: 15 HY Gnrh1 Glut
   cell_set_accession: CS20230722_CLAS_15
@@ -460,6 +471,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_16
   name: 16 HY MM Glut
   cell_set_accession: CS20230722_CLAS_16
@@ -504,6 +516,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_17
   name: 17 MH-LH Glut
   cell_set_accession: CS20230722_CLAS_17
@@ -533,6 +546,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_18
   name: 18 TH Glut
   cell_set_accession: CS20230722_CLAS_18
@@ -582,6 +596,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_11
   name: 11 CNU-HYa GABA
   cell_set_accession: CS20230722_CLAS_11
@@ -631,6 +646,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_12
   name: 12 HY GABA
   cell_set_accession: CS20230722_CLAS_12
@@ -680,6 +696,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_13
   name: 13 CNU-HYa Glut
   cell_set_accession: CS20230722_CLAS_13
@@ -714,6 +731,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_14
   name: 14 HY Glut
   cell_set_accession: CS20230722_CLAS_14
@@ -758,6 +776,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_20
   name: 20 MB GABA
   cell_set_accession: CS20230722_CLAS_20
@@ -807,6 +826,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_21
   name: 21 MB Dopa
   cell_set_accession: CS20230722_CLAS_21
@@ -851,6 +871,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_26
   name: 26 P GABA
   cell_set_accession: CS20230722_CLAS_26
@@ -895,6 +916,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_27
   name: 27 MY GABA
   cell_set_accession: CS20230722_CLAS_27
@@ -934,6 +956,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_28
   name: 28 CB GABA
   cell_set_accession: CS20230722_CLAS_28
@@ -952,6 +975,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_29
   name: 29 CB Glut
   cell_set_accession: CS20230722_CLAS_29
@@ -970,6 +994,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_22
   name: 22 MB-HB Sero
   cell_set_accession: CS20230722_CLAS_22
@@ -1019,6 +1044,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_23
   name: 23 P Glut
   cell_set_accession: CS20230722_CLAS_23
@@ -1058,6 +1084,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_24
   name: 24 MY Glut
   cell_set_accession: CS20230722_CLAS_24
@@ -1097,6 +1124,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_25
   name: 25 Pineal Glut
   cell_set_accession: CS20230722_CLAS_25
@@ -1121,6 +1149,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_30
   name: 30 Astro-Epen
   cell_set_accession: CS20230722_CLAS_30
@@ -1164,6 +1193,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_31
   name: 31 OPC-Oligo
   cell_set_accession: CS20230722_CLAS_31
@@ -1176,6 +1206,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_32
   name: 32 OEC
   cell_set_accession: CS20230722_CLAS_32
@@ -1210,6 +1241,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_33
   name: 33 Vascular
   cell_set_accession: CS20230722_CLAS_33
@@ -1222,6 +1254,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3
 - id: WMB:CS20230722_CLAS_34
   name: 34 Immune
   cell_set_accession: CS20230722_CLAS_34
@@ -1246,3 +1279,4 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 3

--- a/kb/taxonomy/CCN20230722/field_mapping.json
+++ b/kb/taxonomy/CCN20230722/field_mapping.json
@@ -56,7 +56,7 @@
       {"source": "wmb.properties.np_markers",                         "target": "np_markers",                 "confidence": "HIGH", "notes": "Raw string e.g. 'Cck:8.7,Npy:4.9'"},
       {"source": "wmb.properties.neighborhood",                       "target": "neighborhood",               "confidence": "MODERATE"},
       {"source": "wmb.properties.Light",                              "target": "circadian_ratio",            "confidence": "MODERATE", "notes": "Light phase fraction; stored only when skewed (>0.7 or <0.3) — small number of types where useful for identification"},
-      {"source": "wmb.properties.CCN20230722_sex_bias",               "target": "sex_bias",                   "confidence": "MODERATE", "notes": "'sex-dominant' flag; raw Male/Female fractions dropped"},
+      {"source": "wmb.properties.Male / wmb.properties.Female",       "target": "male_female_ratio",          "confidence": "HIGH", "notes": "Computed: round(Male/Female, 2). Null when either fraction is 0 or absent. >1 = male-biased, <1 = female-biased."},
       {"source": "wmb.properties.rationale[0]",                       "target": "rationale",                  "confidence": "HIGH", "notes": "Prose CL mapping justification; list — take first element"},
       {"source": "wmb.properties.rationale_dois",                     "target": "rationale_dois",             "confidence": "HIGH", "notes": "List of DOI URLs supporting rationale"},
       {"source": "wmb.properties.marker_gene_evidence",               "target": "marker_gene_evidence",       "confidence": "HIGH", "notes": "Gene list supporting CL assignment; very sparse"}
@@ -84,7 +84,7 @@
     "wmb.properties.CCF_broad_freq, CCF_acronym_freq (deprecated CCF mapping)",
     "wmb.properties.v2_size, v3_size, multiome_size, CTX_size (cell counts superseded by anat[])",
     "wmb.properties.CTX_* (cross-taxonomy CTX references)",
-    "wmb.properties.Male, Female (raw sex fractions; CCN20230722_sex_bias flag preserved instead)",
+    "wmb.properties.CCN20230722_sex_bias (categorical 'sex-dominant' flag; superseded by male_female_ratio computed from Male/Female fractions)",
     "wmb.properties.Dark (complementary to Light; circadian_ratio captures the relevant signal)",
     "wmb.properties.neurotransmitter_rationale (same content as nt_markers; redundant)",
     "wmb.properties.nt_type_combo_label (same as nt_type_label in most cases)",

--- a/kb/taxonomy/CCN20230722/subclass.yaml
+++ b/kb/taxonomy/CCN20230722/subclass.yaml
@@ -35,6 +35,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_331
   name: 331 Peri NN
   cell_set_accession: CS20230722_SUBC_331
@@ -70,6 +71,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_334
   name: 334 Microglia NN
   cell_set_accession: CS20230722_SUBC_334
@@ -107,6 +109,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_335
   name: 335 BAM NN
   cell_set_accession: CS20230722_SUBC_335
@@ -173,6 +176,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_332
   name: 332 SMC NN
   cell_set_accession: CS20230722_SUBC_332
@@ -204,6 +208,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_333
   name: 333 Endo NN
   cell_set_accession: CS20230722_SUBC_333
@@ -239,6 +244,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_338
   name: 338 Lymphoid NN
   cell_set_accession: CS20230722_SUBC_338
@@ -270,6 +276,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_336
   name: 336 Monocytes NN
   cell_set_accession: CS20230722_SUBC_336
@@ -305,6 +312,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_337
   name: 337 DC NN
   cell_set_accession: CS20230722_SUBC_337
@@ -334,6 +342,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_320
   name: 320 Astro-OLF NN
   cell_set_accession: CS20230722_SUBC_320
@@ -369,6 +378,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_323
   name: 323 Ependymal NN
   cell_set_accession: CS20230722_SUBC_323
@@ -402,6 +412,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_324
   name: 324 Hypendymal NN
   cell_set_accession: CS20230722_SUBC_324
@@ -454,6 +465,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_321
   name: 321 Astroependymal NN
   cell_set_accession: CS20230722_SUBC_321
@@ -505,6 +517,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_322
   name: 322 Tanycyte NN
   cell_set_accession: CS20230722_SUBC_322
@@ -562,6 +575,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_327
   name: 327 Oligo NN
   cell_set_accession: CS20230722_SUBC_327
@@ -593,6 +607,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_328
   name: 328 OEC NN
   cell_set_accession: CS20230722_SUBC_328
@@ -640,6 +655,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_325
   name: 325 CHOR NN
   cell_set_accession: CS20230722_SUBC_325
@@ -697,6 +713,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_326
   name: 326 OPC NN
   cell_set_accession: CS20230722_SUBC_326
@@ -726,6 +743,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_329
   name: 329 ABC NN
   cell_set_accession: CS20230722_SUBC_329
@@ -755,6 +773,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_312
   name: 312 CBX MLI Cdh22 Gaba
   cell_set_accession: CS20230722_SUBC_312
@@ -823,6 +842,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_313
   name: 313 CBX Purkinje Gaba
   cell_set_accession: CS20230722_SUBC_313
@@ -878,6 +898,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_310
   name: 310 CBX Golgi Gly-Gaba
   cell_set_accession: CS20230722_SUBC_310
@@ -939,6 +960,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_311
   name: 311 CBX MLI Megf11 Gaba
   cell_set_accession: CS20230722_SUBC_311
@@ -978,6 +1000,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_316
   name: 316 Bergmann NN
   cell_set_accession: CS20230722_SUBC_316
@@ -1040,6 +1063,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_317
   name: 317 Astro-CB NN
   cell_set_accession: CS20230722_SUBC_317
@@ -1108,6 +1132,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_314
   name: 314 CB Granule Glut
   cell_set_accession: CS20230722_SUBC_314
@@ -1174,6 +1199,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_315
   name: 315 DCO UBC Glut
   cell_set_accession: CS20230722_SUBC_315
@@ -1235,6 +1261,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_318
   name: 318 Astro-NT NN
   cell_set_accession: CS20230722_SUBC_318
@@ -1310,6 +1337,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_319
   name: 319 Astro-TE NN
   cell_set_accession: CS20230722_SUBC_319
@@ -1351,6 +1379,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_301
   name: 301 MV Nr4a2 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_301
@@ -1421,6 +1450,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_302
   name: 302 MV Xdh Gly-Gaba
   cell_set_accession: CS20230722_SUBC_302
@@ -1469,6 +1499,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_300
   name: 300 PARN-MDRNd-NTS Gbx2 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_300
@@ -1537,6 +1568,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_305
   name: 305 SPVI-SPVC Sall3 Nfib Gly-Gaba
   cell_set_accession: CS20230722_SUBC_305
@@ -1593,6 +1625,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_306
   name: 306 SPVI-SPVC Sall3 Lhx1 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_306
@@ -1640,6 +1673,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_303
   name: 303 IRN Dmbx1 Pax2 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_303
@@ -1702,6 +1736,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_304
   name: 304 NTS-PARN Neurod2 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_304
@@ -1770,6 +1805,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_309
   name: 309 CB PLI Gly-Gaba
   cell_set_accession: CS20230722_SUBC_309
@@ -1817,6 +1853,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_307
   name: 307 RO-RPA Pkd2l1 Gaba
   cell_set_accession: CS20230722_SUBC_307
@@ -1888,6 +1925,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_308
   name: 308 DCO Il22 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_308
@@ -1948,6 +1986,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_055
   name: 055 STR Lhx8 Gaba
   cell_set_accession: CS20230722_SUBC_055
@@ -1993,6 +2032,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_056
   name: 056 Sst Chodl Gaba
   cell_set_accession: CS20230722_SUBC_056
@@ -2046,6 +2086,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_053
   name: 053 Sst Gaba
   cell_set_accession: CS20230722_SUBC_053
@@ -2096,6 +2137,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_054
   name: 054 STR Prox1 Lhx6 Gaba
   cell_set_accession: CS20230722_SUBC_054
@@ -2136,6 +2178,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_059
   name: 059 GPe-SI Sox6 Cyp26b1 Gaba
   cell_set_accession: CS20230722_SUBC_059
@@ -2183,6 +2226,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_057
   name: 057 NDB-SI-MA-STRv Lhx8 Gaba
   cell_set_accession: CS20230722_SUBC_057
@@ -2250,6 +2294,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_058
   name: 058 PAL-STR Gaba-Chol
   cell_set_accession: CS20230722_SUBC_058
@@ -2307,6 +2352,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_051
   name: 051 Pvalb chandelier Gaba
   cell_set_accession: CS20230722_SUBC_051
@@ -2354,6 +2400,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_052
   name: 052 Pvalb Gaba
   cell_set_accession: CS20230722_SUBC_052
@@ -2407,6 +2454,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_050
   name: 050 Lamp5 Lhx6 Gaba
   cell_set_accession: CS20230722_SUBC_050
@@ -2460,6 +2508,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_044
   name: 044 OB Dopa-Gaba
   cell_set_accession: CS20230722_SUBC_044
@@ -2510,6 +2559,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_045
   name: 045 OB-STR-CTX Inh IMN
   cell_set_accession: CS20230722_SUBC_045
@@ -2584,6 +2634,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_042
   name: 042 OB-out Frmd7 Gaba
   cell_set_accession: CS20230722_SUBC_042
@@ -2636,6 +2687,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_043
   name: 043 OB-mi Frmd7 Gaba
   cell_set_accession: CS20230722_SUBC_043
@@ -2688,6 +2740,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_048
   name: 048 RHP-COA Ndnf Gaba
   cell_set_accession: CS20230722_SUBC_048
@@ -2762,6 +2815,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_049
   name: 049 Lamp5 Gaba
   cell_set_accession: CS20230722_SUBC_049
@@ -2809,6 +2863,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_046
   name: 046 Vip Gaba
   cell_set_accession: CS20230722_SUBC_046
@@ -2850,6 +2905,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_047
   name: 047 Sncg Gaba
   cell_set_accession: CS20230722_SUBC_047
@@ -2901,6 +2957,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_040
   name: 040 OB Trdn Gaba
   cell_set_accession: CS20230722_SUBC_040
@@ -2960,6 +3017,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_041
   name: 041 OB-in Frmd7 Gaba
   cell_set_accession: CS20230722_SUBC_041
@@ -3028,6 +3086,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_033
   name: 033 NP SUB Glut
   cell_set_accession: CS20230722_SUBC_033
@@ -3075,6 +3134,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_034
   name: 034 NP PPP Glut
   cell_set_accession: CS20230722_SUBC_034
@@ -3127,6 +3187,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_031
   name: 031 CT SUB Glut
   cell_set_accession: CS20230722_SUBC_031
@@ -3185,6 +3246,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_032
   name: 032 L5 NP CTX Glut
   cell_set_accession: CS20230722_SUBC_032
@@ -3244,6 +3306,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_037
   name: 037 DG Glut
   cell_set_accession: CS20230722_SUBC_037
@@ -3317,6 +3380,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_038
   name: 038 DG-PIR Ex IMN
   cell_set_accession: CS20230722_SUBC_038
@@ -3380,6 +3444,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_035
   name: 035 OB Eomes Ms4a15 Glut
   cell_set_accession: CS20230722_SUBC_035
@@ -3433,6 +3498,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_036
   name: 036 HPF CR Glut
   cell_set_accession: CS20230722_SUBC_036
@@ -3477,6 +3543,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_030
   name: 030 L6 CT CTX Glut
   cell_set_accession: CS20230722_SUBC_030
@@ -3549,6 +3616,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_039
   name: 039 OB Meis2 Thsd7b Gaba
   cell_set_accession: CS20230722_SUBC_039
@@ -3610,6 +3678,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_022
   name: 022 L5 ET CTX Glut
   cell_set_accession: CS20230722_SUBC_022
@@ -3670,6 +3739,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_023
   name: 023 SUB-ProS Glut
   cell_set_accession: CS20230722_SUBC_023
@@ -3726,6 +3796,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_020
   name: 020 L2/3 IT RSP Glut
   cell_set_accession: CS20230722_SUBC_020
@@ -3787,6 +3858,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_021
   name: 021 L4 RSP-ACA Glut
   cell_set_accession: CS20230722_SUBC_021
@@ -3827,6 +3899,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_026
   name: 026 NLOT Rho Glut
   cell_set_accession: CS20230722_SUBC_026
@@ -3875,6 +3948,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_027
   name: 027 L6b EPd Glut
   cell_set_accession: CS20230722_SUBC_027
@@ -3932,6 +4006,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_024
   name: 024 L5 PPP Glut
   cell_set_accession: CS20230722_SUBC_024
@@ -3977,6 +4052,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_025
   name: 025 CA2-FC-IG Glut
   cell_set_accession: CS20230722_SUBC_025
@@ -4048,6 +4124,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_028
   name: 028 L6b/CT ENT Glut
   cell_set_accession: CS20230722_SUBC_028
@@ -4113,6 +4190,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_029
   name: 029 L6b CTX Glut
   cell_set_accession: CS20230722_SUBC_029
@@ -4158,6 +4236,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_011
   name: 011 L2 IT ENT-po Glut
   cell_set_accession: CS20230722_SUBC_011
@@ -4229,6 +4308,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_012
   name: 012 MEA Slc17a7 Glut
   cell_set_accession: CS20230722_SUBC_012
@@ -4281,6 +4361,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_010
   name: 010 IT AON-TT-DP Glut
   cell_set_accession: CS20230722_SUBC_010
@@ -4342,6 +4423,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_015
   name: 015 ENTmv-PA-COAp Glut
   cell_set_accession: CS20230722_SUBC_015
@@ -4406,6 +4488,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_016
   name: 016 CA1-ProS Glut
   cell_set_accession: CS20230722_SUBC_016
@@ -4461,6 +4544,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_013
   name: 013 COAp Grxcr2 Glut
   cell_set_accession: CS20230722_SUBC_013
@@ -4526,6 +4610,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_014
   name: 014 LA-BLA-BMA-PA Glut
   cell_set_accession: CS20230722_SUBC_014
@@ -4591,6 +4676,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_019
   name: 019 L2/3 IT PPP Glut
   cell_set_accession: CS20230722_SUBC_019
@@ -4662,6 +4748,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_017
   name: 017 CA3 Glut
   cell_set_accession: CS20230722_SUBC_017
@@ -4724,6 +4811,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_018
   name: 018 L2 IT PPP-APr Glut
   cell_set_accession: CS20230722_SUBC_018
@@ -4784,6 +4872,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_001
   name: 001 CLA-EPd-CTX Car3 Glut
   cell_set_accession: CS20230722_SUBC_001
@@ -4828,6 +4917,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_004
   name: 004 L6 IT CTX Glut
   cell_set_accession: CS20230722_SUBC_004
@@ -4891,6 +4981,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_005
   name: 005 L5 IT CTX Glut
   cell_set_accession: CS20230722_SUBC_005
@@ -4965,6 +5056,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_002
   name: 002 IT EP-CLA Glut
   cell_set_accession: CS20230722_SUBC_002
@@ -5027,6 +5119,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_003
   name: 003 L5/6 IT TPE-ENT Glut
   cell_set_accession: CS20230722_SUBC_003
@@ -5091,6 +5184,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_008
   name: 008 L2/3 IT ENT Glut
   cell_set_accession: CS20230722_SUBC_008
@@ -5172,6 +5266,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_009
   name: 009 L2/3 IT PIR-ENTl Glut
   cell_set_accession: CS20230722_SUBC_009
@@ -5232,6 +5327,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_006
   name: 006 L4/5 IT CTX Glut
   cell_set_accession: CS20230722_SUBC_006
@@ -5296,6 +5392,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_007
   name: 007 L2/3 IT CTX Glut
   cell_set_accession: CS20230722_SUBC_007
@@ -5358,6 +5455,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_099
   name: 099 SBPV-PVa Six6 Satb2 Gaba
   cell_set_accession: CS20230722_SUBC_099
@@ -5439,6 +5537,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_097
   name: 097 PVHd-SBPV Six3 Prox1 Gaba
   cell_set_accession: CS20230722_SUBC_097
@@ -5497,6 +5596,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_098
   name: 098 AHN-SBPV-PVHd Pdrm12 Gaba
   cell_set_accession: CS20230722_SUBC_098
@@ -5553,6 +5653,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_091
   name: 091 ARH-PVi Six6 Dopa-Gaba
   cell_set_accession: CS20230722_SUBC_091
@@ -5606,6 +5707,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_092
   name: 092 TMv-PMv Tbx3 Hist-Gaba
   cell_set_accession: CS20230722_SUBC_092
@@ -5659,6 +5761,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_090
   name: 090 BST-MPN Six3 Nrgn Gaba
   cell_set_accession: CS20230722_SUBC_090
@@ -5725,6 +5828,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_095
   name: 095 DMH Prdm13 Gaba
   cell_set_accession: CS20230722_SUBC_095
@@ -5767,6 +5871,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_096
   name: 096 PVHd Gsc Gaba
   cell_set_accession: CS20230722_SUBC_096
@@ -5815,6 +5920,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_093
   name: 093 RT-ZI Gnb3 Gaba
   cell_set_accession: CS20230722_SUBC_093
@@ -5850,6 +5956,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_094
   name: 094 SCH Six6 Cdc14a Gaba
   cell_set_accession: CS20230722_SUBC_094
@@ -5906,6 +6013,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_088
   name: 088 BST Tac2 Gaba
   cell_set_accession: CS20230722_SUBC_088
@@ -5979,6 +6087,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_089
   name: 089 PVR Six3 Sox3 Gaba
   cell_set_accession: CS20230722_SUBC_089
@@ -6050,6 +6159,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_086
   name: 086 MPO-ADP Lhx8 Gaba
   cell_set_accession: CS20230722_SUBC_086
@@ -6116,6 +6226,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_087
   name: 087 MPN-MPO-LPO Lhx6 Zfhx3 Gaba
   cell_set_accession: CS20230722_SUBC_087
@@ -6178,6 +6289,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_080
   name: 080 CEA-AAA-BST Six3 Sp9 Gaba
   cell_set_accession: CS20230722_SUBC_080
@@ -6262,6 +6374,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_081
   name: 081 ACB-BST-FS D1 Gaba
   cell_set_accession: CS20230722_SUBC_081
@@ -6327,6 +6440,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_084
   name: 084 BST-SI-AAA Six3 Slc22a3 Gaba
   cell_set_accession: CS20230722_SUBC_084
@@ -6404,6 +6518,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_085
   name: 085 SI-MPO-LPO Lhx8 Gaba
   cell_set_accession: CS20230722_SUBC_085
@@ -6466,6 +6581,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_082
   name: 082 CEA-BST Ebf1 Pdyn Gaba
   cell_set_accession: CS20230722_SUBC_082
@@ -6536,6 +6652,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_083
   name: 083 CEA-BST Rai14 Pdyn Crh Gaba
   cell_set_accession: CS20230722_SUBC_083
@@ -6592,6 +6709,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_077
   name: 077 CEA-BST Gal Avp Gaba
   cell_set_accession: CS20230722_SUBC_077
@@ -6632,6 +6750,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_078
   name: 078 SI-MA-ACB Ebf1 Bnc2 Gaba
   cell_set_accession: CS20230722_SUBC_078
@@ -6684,6 +6803,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_075
   name: 075 MEA-BST Lhx6 Nr2e1 Gaba
   cell_set_accession: CS20230722_SUBC_075
@@ -6731,6 +6851,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_076
   name: 076 MEA-BST Lhx6 Nfib Gaba
   cell_set_accession: CS20230722_SUBC_076
@@ -6780,6 +6901,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_079
   name: 079 CEA-BST Six3 Cyp26b1 Gaba
   cell_set_accession: CS20230722_SUBC_079
@@ -6842,6 +6964,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_070
   name: 070 LSX Prdm12 Slit2 Gaba
   cell_set_accession: CS20230722_SUBC_070
@@ -6895,6 +7018,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_073
   name: 073 MEA-BST Sox6 Gaba
   cell_set_accession: CS20230722_SUBC_073
@@ -6957,6 +7081,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_074
   name: 074 MEA-BST Lhx6 Sp9 Gaba
   cell_set_accession: CS20230722_SUBC_074
@@ -7013,6 +7138,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_071
   name: 071 LSX Prdm12 Zeb2 Gaba
   cell_set_accession: CS20230722_SUBC_071
@@ -7059,6 +7185,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_072
   name: 072 LSX Sall3 Lmo1 Gaba
   cell_set_accession: CS20230722_SUBC_072
@@ -7110,6 +7237,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_066
   name: 066 NDB-SI-ant Prdm12 Gaba
   cell_set_accession: CS20230722_SUBC_066
@@ -7178,6 +7306,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_067
   name: 067 LSX Sall3 Pax6 Gaba
   cell_set_accession: CS20230722_SUBC_067
@@ -7230,6 +7359,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_064
   name: 064 STR-PAL Chst9 Gaba
   cell_set_accession: CS20230722_SUBC_064
@@ -7284,6 +7414,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_065
   name: 065 IA Mgp Gaba
   cell_set_accession: CS20230722_SUBC_065
@@ -7354,6 +7485,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_068
   name: 068 LSX Otx2 Gaba
   cell_set_accession: CS20230722_SUBC_068
@@ -7396,6 +7528,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_069
   name: 069 LSX Nkx2-1 Gaba
   cell_set_accession: CS20230722_SUBC_069
@@ -7444,6 +7577,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_062
   name: 062 STR D2 Gaba
   cell_set_accession: CS20230722_SUBC_062
@@ -7483,6 +7617,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_063
   name: 063 STR D1 Sema5a Gaba
   cell_set_accession: CS20230722_SUBC_063
@@ -7552,6 +7687,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_060
   name: 060 OT D3 Folh1 Gaba
   cell_set_accession: CS20230722_SUBC_060
@@ -7605,6 +7741,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_061
   name: 061 STR D1 Gaba
   cell_set_accession: CS20230722_SUBC_061
@@ -7642,6 +7779,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_297
   name: 297 CU-ECU Pax2 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_297
@@ -7700,6 +7838,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_298
   name: 298 PRP Gata3 Slc6a5 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_298
@@ -7750,6 +7889,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_295
   name: 295 CBN Dmbx1 Gaba
   cell_set_accession: CS20230722_SUBC_295
@@ -7800,6 +7940,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_296
   name: 296 RPA Pax6 Hoxb5 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_296
@@ -7852,6 +7993,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_299
   name: 299 MARN-PPY Ngfr Gly-Gaba
   cell_set_accession: CS20230722_SUBC_299
@@ -7910,6 +8052,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_290
   name: 290 MY Prox1 Lmo7 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_290
@@ -7982,6 +8125,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_293
   name: 293 PAS-MV Ebf2 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_293
@@ -8045,6 +8189,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_294
   name: 294 MV Pax6 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_294
@@ -8102,6 +8247,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_291
   name: 291 NTS-MDRNd Prox1 Zic1 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_291
@@ -8151,6 +8297,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_292
   name: 292 MV Nkx6-1 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_292
@@ -8196,6 +8343,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_286
   name: 286 PPY-PGRNl Vip Glyc-Gaba
   cell_set_accession: CS20230722_SUBC_286
@@ -8261,6 +8409,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_287
   name: 287 MV-SPIV-PRP Dmbx1 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_287
@@ -8310,6 +8459,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_284
   name: 284 GRN-IRN-MDRNd Ikzf1 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_284
@@ -8348,6 +8498,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_285
   name: 285 MY Lhx1 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_285
@@ -8424,6 +8575,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_288
   name: 288 MDRN Hoxb5 Ebf2 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_288
@@ -8486,6 +8638,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_289
   name: 289 MDRNd Prox1 Pax6 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_289
@@ -8546,6 +8699,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_282
   name: 282 POR Spp1 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_282
@@ -8599,6 +8753,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_283
   name: 283 PRP Otp Gly-Gaba
   cell_set_accession: CS20230722_SUBC_283
@@ -8671,6 +8826,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_280
   name: 280 NLL-po Pax7 Gaba
   cell_set_accession: CS20230722_SUBC_280
@@ -8721,6 +8877,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_281
   name: 281 POR Gata3 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_281
@@ -8769,6 +8926,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_275
   name: 275 PDTg Otp Olig3 Gaba
   cell_set_accession: CS20230722_SUBC_275
@@ -8798,6 +8956,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_276
   name: 276 LDT-PCG St18 Gaba
   cell_set_accession: CS20230722_SUBC_276
@@ -8856,6 +9015,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_273
   name: 273 PDTg-PCG Pax6 Gaba
   cell_set_accession: CS20230722_SUBC_273
@@ -8903,6 +9063,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_274
   name: 274 PDTg Otp Shroom3 Gaba
   cell_set_accession: CS20230722_SUBC_274
@@ -8940,6 +9101,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_279
   name: 279 PSV Pax2 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_279
@@ -8991,6 +9153,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_277
   name: 277 DTN-LDT-IPN Otp Pax3 Gaba
   cell_set_accession: CS20230722_SUBC_277
@@ -9051,6 +9214,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_278
   name: 278 NLL Gata3 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_278
@@ -9112,6 +9276,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_271
   name: 271 NI-RPO Gata3 Nr4a2 Gaba
   cell_set_accession: CS20230722_SUBC_271
@@ -9189,6 +9354,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_272
   name: 272 LDT-PCG-CS Gata3 Lhx1 Gaba
   cell_set_accession: CS20230722_SUBC_272
@@ -9266,6 +9432,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_270
   name: 270 LDT-DTN Gata3 Nfix Gaba
   cell_set_accession: CS20230722_SUBC_270
@@ -9344,6 +9511,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_264
   name: 264 PRNc Otp Gly-Gaba
   cell_set_accession: CS20230722_SUBC_264
@@ -9398,6 +9566,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_265
   name: 265 PB Sst Gly-Gaba
   cell_set_accession: CS20230722_SUBC_265
@@ -9455,6 +9624,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_262
   name: 262 Pineal Crx Glut
   cell_set_accession: CS20230722_SUBC_262
@@ -9484,6 +9654,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_263
   name: 263 CS-RPO Meis2 Gaba
   cell_set_accession: CS20230722_SUBC_263
@@ -9537,6 +9708,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_268
   name: 268 CS-PRNr-DR En1 Sox2 Gaba
   cell_set_accession: CS20230722_SUBC_268
@@ -9598,6 +9770,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_269
   name: 269 LDT Fgf7 Gaba
   cell_set_accession: CS20230722_SUBC_269
@@ -9653,6 +9826,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_266
   name: 266 PRNc Prox1 Brs3 Gly-Gaba
   cell_set_accession: CS20230722_SUBC_266
@@ -9705,6 +9879,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_267
   name: 267 CS-PRNr-PCG Tmem163 Otp Gaba
   cell_set_accession: CS20230722_SUBC_267
@@ -9771,6 +9946,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_260
   name: 260 MDRNv Crp Glut
   cell_set_accession: CS20230722_SUBC_260
@@ -9834,6 +10010,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_261
   name: 261 HB Calcb Chol
   cell_set_accession: CS20230722_SUBC_261
@@ -9886,6 +10063,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_253
   name: 253 IO Fgl2 Glut
   cell_set_accession: CS20230722_SUBC_253
@@ -9931,6 +10109,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_254
   name: 254 VCO Mafa Meis2 Glut
   cell_set_accession: CS20230722_SUBC_254
@@ -9984,6 +10163,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_251
   name: 251 NTS Dbh Glut
   cell_set_accession: CS20230722_SUBC_251
@@ -10032,6 +10212,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_252
   name: 252 DMX VII Tbx20 Chol
   cell_set_accession: CS20230722_SUBC_252
@@ -10086,6 +10267,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_257
   name: 257 SPVC Ccdc172 Glut
   cell_set_accession: CS20230722_SUBC_257
@@ -10131,6 +10313,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_258
   name: 258 SPVC Nmu Glut
   cell_set_accession: CS20230722_SUBC_258
@@ -10176,6 +10359,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_255
   name: 255 SPVO Mafa Meis2 Glut
   cell_set_accession: CS20230722_SUBC_255
@@ -10233,6 +10417,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_256
   name: 256 SPVC Mafa Glut
   cell_set_accession: CS20230722_SUBC_256
@@ -10278,6 +10463,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_250
   name: 250 CBN Neurod2 Pvalb Glut
   cell_set_accession: CS20230722_SUBC_250
@@ -10346,6 +10532,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_259
   name: 259 MDRNd Bves Glut
   cell_set_accession: CS20230722_SUBC_259
@@ -10402,6 +10589,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_242
   name: 242 PGRNd Dmbx1 Glut
   cell_set_accession: CS20230722_SUBC_242
@@ -10460,6 +10648,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_243
   name: 243 PGRN-PARN-MDRN Hoxb5 Glut
   cell_set_accession: CS20230722_SUBC_243
@@ -10540,6 +10729,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_240
   name: 240 MDRNv Lhx4 Qrfprl Glut
   cell_set_accession: CS20230722_SUBC_240
@@ -10590,6 +10780,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_241
   name: 241 NTS Mbnl3 Glut
   cell_set_accession: CS20230722_SUBC_241
@@ -10632,6 +10823,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_246
   name: 246 CU-ECU-SPVI Foxb1 Glut
   cell_set_accession: CS20230722_SUBC_246
@@ -10684,6 +10876,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_247
   name: 247 MV-SPIV Phox2b Ebf3 Lbx1 Glut
   cell_set_accession: CS20230722_SUBC_247
@@ -10737,6 +10930,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_244
   name: 244 MV-SPIV Slc6a2 Glut
   cell_set_accession: CS20230722_SUBC_244
@@ -10794,6 +10988,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_245
   name: 245 SPVI-SPVC Tlx3 Ebf3 Glut
   cell_set_accession: CS20230722_SUBC_245
@@ -10857,6 +11052,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_248
   name: 248 MV-SPIV Zic4 Neurod2 Glut
   cell_set_accession: CS20230722_SUBC_248
@@ -10917,6 +11113,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_249
   name: 249 NTS Aldh1a2 Glut
   cell_set_accession: CS20230722_SUBC_249
@@ -10957,6 +11154,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_231
   name: 231 IPN-LDT Vsx2 Nkx6-1 Glut
   cell_set_accession: CS20230722_SUBC_231
@@ -11009,6 +11207,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_232
   name: 232 LDT Vsx2 Nkx6-1 Nfib Glut
   cell_set_accession: CS20230722_SUBC_232
@@ -11051,6 +11250,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_230
   name: 230 PRNr Otp Nfib Glut
   cell_set_accession: CS20230722_SUBC_230
@@ -11108,6 +11308,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_235
   name: 235 PG-TRN-LRN Fat2 Glut
   cell_set_accession: CS20230722_SUBC_235
@@ -11153,6 +11354,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_236
   name: 236 IRN Vip Glut
   cell_set_accession: CS20230722_SUBC_236
@@ -11198,6 +11400,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_233
   name: 233 NLL-SOC Spp1 Glut
   cell_set_accession: CS20230722_SUBC_233
@@ -11253,6 +11456,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_234
   name: 234 MEV Ppp1r1c Glut
   cell_set_accession: CS20230722_SUBC_234
@@ -11309,6 +11513,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_239
   name: 239 MARN-GRN Pyy Glut
   cell_set_accession: CS20230722_SUBC_239
@@ -11350,6 +11555,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_237
   name: 237 PRP-NI-PRNc-GRN Otp Glut
   cell_set_accession: CS20230722_SUBC_237
@@ -11422,6 +11628,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_238
   name: 238 NTS Phox2b Glut
   cell_set_accession: CS20230722_SUBC_238
@@ -11484,6 +11691,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_220
   name: 220 PB Pax5 Glut
   cell_set_accession: CS20230722_SUBC_220
@@ -11538,6 +11746,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_221
   name: 221 LDT-PCG Vsx2 Lhx4 Glut
   cell_set_accession: CS20230722_SUBC_221
@@ -11603,6 +11812,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_224
   name: 224 PCG-PRNr Vsx2 Nkx6-1 Glut
   cell_set_accession: CS20230722_SUBC_224
@@ -11676,6 +11886,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_225
   name: 225 PRNc-NI-SG-RPO Vsx2 Nr4a2 Glut
   cell_set_accession: CS20230722_SUBC_225
@@ -11731,6 +11942,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_222
   name: 222 PB Evx2 Glut
   cell_set_accession: CS20230722_SUBC_222
@@ -11799,6 +12011,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_223
   name: 223 B-PB Nr4a2 Glut
   cell_set_accession: CS20230722_SUBC_223
@@ -11863,6 +12076,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_228
   name: 228 PSV Pvalb Lhx2 Glut
   cell_set_accession: CS20230722_SUBC_228
@@ -11912,6 +12126,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_229
   name: 229 PB-NTS Phox2b Ebf3 Lmx1b Glut
   cell_set_accession: CS20230722_SUBC_229
@@ -11969,6 +12184,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_226
   name: 226 PRNc-PARN Tlx1 Glut
   cell_set_accession: CS20230722_SUBC_226
@@ -12030,6 +12246,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_227
   name: 227 PB-PSV Phox2b Glut
   cell_set_accession: CS20230722_SUBC_227
@@ -12097,6 +12314,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_210
   name: 210 PRT Mecom Gaba
   cell_set_accession: CS20230722_SUBC_210
@@ -12145,6 +12363,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_213
   name: 213 SCsg Gabrr2 Gaba
   cell_set_accession: CS20230722_SUBC_213
@@ -12196,6 +12415,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_214
   name: 214 IPN Otp Crisp1 Gaba
   cell_set_accession: CS20230722_SUBC_214
@@ -12261,6 +12481,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_211
   name: 211 SC Tnnt1 Gli3 Gaba
   cell_set_accession: CS20230722_SUBC_211
@@ -12318,6 +12539,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_212
   name: 212 SCs Lef1 Gli3 Gaba
   cell_set_accession: CS20230722_SUBC_212
@@ -12371,6 +12593,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_217
   name: 217 PB Lmx1a Glut
   cell_set_accession: CS20230722_SUBC_217
@@ -12419,6 +12642,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_218
   name: 218 PSV Lmx1a Trpv6 Glut
   cell_set_accession: CS20230722_SUBC_218
@@ -12483,6 +12707,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_215
   name: 215 SNc-VTA-RAmb Foxa1 Dopa
   cell_set_accession: CS20230722_SUBC_215
@@ -12536,6 +12761,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_216
   name: 216 MB-MY Tph2 Glut-Sero
   cell_set_accession: CS20230722_SUBC_216
@@ -12594,6 +12820,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_219
   name: 219 PB-SUT Tlx3 Lhx2 Glut
   cell_set_accession: CS20230722_SUBC_219
@@ -12636,6 +12863,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_202
   name: 202 PRT Tcf7l2 Gaba
   cell_set_accession: CS20230722_SUBC_202
@@ -12683,6 +12911,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_203
   name: 203 LGv-SPFp-SPFm Nkx2-2 Tcf7l2 Gaba
   cell_set_accession: CS20230722_SUBC_203
@@ -12740,6 +12969,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_200
   name: 200 PAG-ND-PCG Onecut1 Gaba
   cell_set_accession: CS20230722_SUBC_200
@@ -12797,6 +13027,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_201
   name: 201 PAG-RN Nkx2-2 Otx1 Gaba
   cell_set_accession: CS20230722_SUBC_201
@@ -12853,6 +13084,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_206
   name: 206 SCm-PAG Cdh23 Gaba
   cell_set_accession: CS20230722_SUBC_206
@@ -12916,6 +13148,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_207
   name: 207 SCs Dmbx1 Gaba
   cell_set_accession: CS20230722_SUBC_207
@@ -12978,6 +13211,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_204
   name: 204 SC Otx2 Gcnt4 Gaba
   cell_set_accession: CS20230722_SUBC_204
@@ -13030,6 +13264,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_205
   name: 205 SC-PAG Lef1 Emx2 Gaba
   cell_set_accession: CS20230722_SUBC_205
@@ -13093,6 +13328,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_208
   name: 208 SC Lef1 Otx2 Gaba
   cell_set_accession: CS20230722_SUBC_208
@@ -13159,6 +13395,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_209
   name: 209 SCs Pax7 Nfia Gaba
   cell_set_accession: CS20230722_SUBC_209
@@ -13216,6 +13453,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_176
   name: 176 SCig Foxb1 Glut
   cell_set_accession: CS20230722_SUBC_176
@@ -13268,6 +13506,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_177
   name: 177 SCig-an-PPT Foxb1 Glut
   cell_set_accession: CS20230722_SUBC_177
@@ -13323,6 +13562,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_174
   name: 174 PAG Pou4f2 Mesi2 Glut
   cell_set_accession: CS20230722_SUBC_174
@@ -13371,6 +13611,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_175
   name: 175 SC Bnc2 Glut
   cell_set_accession: CS20230722_SUBC_175
@@ -13436,6 +13677,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_178
   name: 178 SCig Foxb1 Otx2 Glut
   cell_set_accession: CS20230722_SUBC_178
@@ -13484,6 +13726,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_179
   name: 179 SCdg-PAG Tfap2b Glut
   cell_set_accession: CS20230722_SUBC_179
@@ -13538,6 +13781,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_172
   name: 172 PAG Pou4f1 Ebf2 Glut
   cell_set_accession: CS20230722_SUBC_172
@@ -13583,6 +13827,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_173
   name: 173 PAG Pou4f2 Glut
   cell_set_accession: CS20230722_SUBC_173
@@ -13652,6 +13897,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_170
   name: 170 PAG-MRN Tfap2b Glut
   cell_set_accession: CS20230722_SUBC_170
@@ -13701,6 +13947,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_171
   name: 171 PAG Pou4f1 Bnc2 Glut
   cell_set_accession: CS20230722_SUBC_171
@@ -13757,6 +14004,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_165
   name: 165 PAG-MRN Pou3f1 Glut
   cell_set_accession: CS20230722_SUBC_165
@@ -13815,6 +14063,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_166
   name: 166 MRN Pou3f1 C1ql4 Glut
   cell_set_accession: CS20230722_SUBC_166
@@ -13878,6 +14127,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_163
   name: 163 APN C1ql2 Glut
   cell_set_accession: CS20230722_SUBC_163
@@ -13920,6 +14170,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_164
   name: 164 APN C1ql4 Glut
   cell_set_accession: CS20230722_SUBC_164
@@ -13967,6 +14218,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_169
   name: 169 PAG-SC Pou4f1 Zic1 Glut
   cell_set_accession: CS20230722_SUBC_169
@@ -14047,6 +14299,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_167
   name: 167 PRC-PAG Tcf7l2 Irx2 Glut
   cell_set_accession: CS20230722_SUBC_167
@@ -14117,6 +14370,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_168
   name: 168 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut
   cell_set_accession: CS20230722_SUBC_168
@@ -14177,6 +14431,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_161
   name: 161 PAG Pou4f3 Glut
   cell_set_accession: CS20230722_SUBC_161
@@ -14224,6 +14479,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_162
   name: 162 CUN Evx2 Lhx2 Glut
   cell_set_accession: CS20230722_SUBC_162
@@ -14287,6 +14543,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_160
   name: 160 PAG-SC Neurod2 Meis2 Glut
   cell_set_accession: CS20230722_SUBC_160
@@ -14344,6 +14601,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_154
   name: 154 PF Fzd5 Glut
   cell_set_accession: CS20230722_SUBC_154
@@ -14394,6 +14652,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_155
   name: 155 PRC-PAG Pax6 Glut
   cell_set_accession: CS20230722_SUBC_155
@@ -14451,6 +14710,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_152
   name: 152 RE-Xi Nox4 Glut
   cell_set_accession: CS20230722_SUBC_152
@@ -14512,6 +14772,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_153
   name: 153 MG-POL-SGN Nts Glut
   cell_set_accession: CS20230722_SUBC_153
@@ -14586,6 +14847,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_158
   name: 158 MRN-PAG Nkx6-1 Glut
   cell_set_accession: CS20230722_SUBC_158
@@ -14629,6 +14891,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_159
   name: 159 IF-RL-CLI-PAG Foxa1 Glut
   cell_set_accession: CS20230722_SUBC_159
@@ -14685,6 +14948,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_156
   name: 156 MB-ant-ve Dmrta2 Glut
   cell_set_accession: CS20230722_SUBC_156
@@ -14750,6 +15014,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_157
   name: 157 RN Spp1 Glut
   cell_set_accession: CS20230722_SUBC_157
@@ -14795,6 +15060,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_150
   name: 150 CM-IAD-CL-PCN Sema5b Glut
   cell_set_accession: CS20230722_SUBC_150
@@ -14859,6 +15125,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_151
   name: 151 TH Prkcd Grin2c Glut
   cell_set_accession: CS20230722_SUBC_151
@@ -14925,6 +15192,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_143
   name: 143 MM-ant Foxb1 Glut
   cell_set_accession: CS20230722_SUBC_143
@@ -14994,6 +15262,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_144
   name: 144 MM Foxb1 Glut
   cell_set_accession: CS20230722_SUBC_144
@@ -15042,6 +15311,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_141
   name: 141 PH-SUM Foxa1 Glut
   cell_set_accession: CS20230722_SUBC_141
@@ -15104,6 +15374,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_142
   name: 142 HY Gnrh1 Glut
   cell_set_accession: CS20230722_SUBC_142
@@ -15150,6 +15421,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_147
   name: 147 AD Serpinb7 Glut
   cell_set_accession: CS20230722_SUBC_147
@@ -15192,6 +15464,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_148
   name: 148 AV Col27a1 Glut
   cell_set_accession: CS20230722_SUBC_148
@@ -15236,6 +15509,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_145
   name: 145 MH Tac2 Glut
   cell_set_accession: CS20230722_SUBC_145
@@ -15271,6 +15545,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_146
   name: 146 LH Pou4f1 Sox1 Glut
   cell_set_accession: CS20230722_SUBC_146
@@ -15318,6 +15593,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_140
   name: 140 PMd-LHA Foxb1 Glut
   cell_set_accession: CS20230722_SUBC_140
@@ -15366,6 +15642,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_149
   name: 149 PVT-PT Ntrk1 Glut
   cell_set_accession: CS20230722_SUBC_149
@@ -15418,6 +15695,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_132
   name: 132 AHN-RCH-LHA Otp Fezf1 Glut
   cell_set_accession: CS20230722_SUBC_132
@@ -15465,6 +15743,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_133
   name: 133 PVH-SO-PVa Otp Glut
   cell_set_accession: CS20230722_SUBC_133
@@ -15522,6 +15801,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_130
   name: 130 LHA Pmch Glut
   cell_set_accession: CS20230722_SUBC_130
@@ -15570,6 +15850,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_131
   name: 131 LHA-AHN-PVH Otp Trh Glut
   cell_set_accession: CS20230722_SUBC_131
@@ -15628,6 +15909,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_136
   name: 136 PMv-TMv Pitx2 Glut
   cell_set_accession: CS20230722_SUBC_136
@@ -15694,6 +15976,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_137
   name: 137 PH-an Pitx2 Glut
   cell_set_accession: CS20230722_SUBC_137
@@ -15742,6 +16025,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_134
   name: 134 PH-ant-LHA Otp Bsx Glut
   cell_set_accession: CS20230722_SUBC_134
@@ -15794,6 +16078,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_135
   name: 135 STN-PSTN Pitx2 Glut
   cell_set_accession: CS20230722_SUBC_135
@@ -15844,6 +16129,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_138
   name: 138 PH Pitx2 Glut
   cell_set_accession: CS20230722_SUBC_138
@@ -15897,6 +16183,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_139
   name: 139 PH-LHA Foxb1 Glut
   cell_set_accession: CS20230722_SUBC_139
@@ -15946,6 +16233,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_121
   name: 121 MEA-BST Otp Zic2 Glut
   cell_set_accession: CS20230722_SUBC_121
@@ -15995,6 +16283,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_122
   name: 122 LHA-MEA Otp Glut
   cell_set_accession: CS20230722_SUBC_122
@@ -16047,6 +16336,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_120
   name: 120 MEA Otp Foxp2 Glut
   cell_set_accession: CS20230722_SUBC_120
@@ -16099,6 +16389,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_125
   name: 125 DMH Hmx2 Glut
   cell_set_accession: CS20230722_SUBC_125
@@ -16151,6 +16442,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_126
   name: 126 ARH-PVp Tbx3 Glut
   cell_set_accession: CS20230722_SUBC_126
@@ -16200,6 +16492,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_123
   name: 123 DMH Nkx2-4 Glut
   cell_set_accession: CS20230722_SUBC_123
@@ -16245,6 +16538,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_124
   name: 124 MPN-MPO-PVpo Hmx2 Glut
   cell_set_accession: CS20230722_SUBC_124
@@ -16304,6 +16598,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_129
   name: 129 VMH Nr5a1 Glut
   cell_set_accession: CS20230722_SUBC_129
@@ -16352,6 +16647,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_127
   name: 127 DMH-LHA Vgll2 Glut
   cell_set_accession: CS20230722_SUBC_127
@@ -16398,6 +16694,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_128
   name: 128 VMH Fezf1 Glut
   cell_set_accession: CS20230722_SUBC_128
@@ -16445,6 +16742,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_110
   name: 110 BST-po Iigp1 Glut
   cell_set_accession: CS20230722_SUBC_110
@@ -16495,6 +16793,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_111
   name: 111 TRS-BAC Sln Glut
   cell_set_accession: CS20230722_SUBC_111
@@ -16548,6 +16847,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_114
   name: 114 COAa-PAA-MEA Barhl2 Glut
   cell_set_accession: CS20230722_SUBC_114
@@ -16611,6 +16911,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_115
   name: 115 MS-SF Bsx Glut
   cell_set_accession: CS20230722_SUBC_115
@@ -16671,6 +16972,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_112
   name: 112 GPi Tbr1 Cngb3 Gaba-Glut
   cell_set_accession: CS20230722_SUBC_112
@@ -16724,6 +17026,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_113
   name: 113 MEA-COA-BMA Ccdc42 Glut
   cell_set_accession: CS20230722_SUBC_113
@@ -16792,6 +17095,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_118
   name: 118 ADP-MPO Trp73 Glut
   cell_set_accession: CS20230722_SUBC_118
@@ -16847,6 +17151,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_119
   name: 119 SI-MA-LPO-LHA Skor1 Glut
   cell_set_accession: CS20230722_SUBC_119
@@ -16906,6 +17211,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_116
   name: 116 AVPV-MEPO-SFO Tbr1 Glut
   cell_set_accession: CS20230722_SUBC_116
@@ -16962,6 +17268,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_117
   name: 117 LHA Barhl2 Glut
   cell_set_accession: CS20230722_SUBC_117
@@ -17019,6 +17326,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_100
   name: 100 AHN Onecut3 Gaba
   cell_set_accession: CS20230722_SUBC_100
@@ -17071,6 +17379,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_103
   name: 103 PVHd-DMH Lhx6 Gaba
   cell_set_accession: CS20230722_SUBC_103
@@ -17128,6 +17437,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_104
   name: 104 TU-ARH Otp Six6 Gaba
   cell_set_accession: CS20230722_SUBC_104
@@ -17176,6 +17486,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_101
   name: 101 ZI Pax6 Gaba
   cell_set_accession: CS20230722_SUBC_101
@@ -17226,6 +17537,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_102
   name: 102 DMH-LHA Gsx1 Gaba
   cell_set_accession: CS20230722_SUBC_102
@@ -17278,6 +17590,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_107
   name: 107 DMH Hmx2 Gaba
   cell_set_accession: CS20230722_SUBC_107
@@ -17334,6 +17647,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_108
   name: 108 ARH-PVp Tbx3 Gaba
   cell_set_accession: CS20230722_SUBC_108
@@ -17385,6 +17699,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_105
   name: 105 TMd-DMH Foxd2 Gaba
   cell_set_accession: CS20230722_SUBC_105
@@ -17438,6 +17753,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_106
   name: 106 PVpo-VMPO-MPN Hmx2 Gaba
   cell_set_accession: CS20230722_SUBC_106
@@ -17504,6 +17820,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_109
   name: 109 LGv-ZI Otx2 Gaba
   cell_set_accession: CS20230722_SUBC_109
@@ -17560,6 +17877,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_198
   name: 198 IC Six3 En2 Gaba
   cell_set_accession: CS20230722_SUBC_198
@@ -17630,6 +17948,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_199
   name: 199 PAG-MRN-RN Foxa2 Gaba
   cell_set_accession: CS20230722_SUBC_199
@@ -17680,6 +17999,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_196
   name: 196 PAG-PPN Pax5 Sox21 Gaba
   cell_set_accession: CS20230722_SUBC_196
@@ -17736,6 +18056,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_197
   name: 197 SNr Six3 Gaba
   cell_set_accession: CS20230722_SUBC_197
@@ -17794,6 +18115,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_190
   name: 190 ND-INC Foxd2 Glut
   cell_set_accession: CS20230722_SUBC_190
@@ -17842,6 +18164,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_191
   name: 191 PAG-MRN Rln3 Gaba
   cell_set_accession: CS20230722_SUBC_191
@@ -17885,6 +18208,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_194
   name: 194 MRN-VTN-PPN Pax5 Cdh23 Gaba
   cell_set_accession: CS20230722_SUBC_194
@@ -17948,6 +18272,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_195
   name: 195 SNr-VTA Pax5 Npas1 Gaba
   cell_set_accession: CS20230722_SUBC_195
@@ -18005,6 +18330,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_192
   name: 192 PPN-CUN-PCG Otp En1 Gaba
   cell_set_accession: CS20230722_SUBC_192
@@ -18058,6 +18384,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_193
   name: 193 MRN-PPN-CUN Pax8 Gaba
   cell_set_accession: CS20230722_SUBC_193
@@ -18124,6 +18451,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_187
   name: 187 SCsg Pde5a Glut
   cell_set_accession: CS20230722_SUBC_187
@@ -18178,6 +18506,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_188
   name: 188 SCop Sln Glut
   cell_set_accession: CS20230722_SUBC_188
@@ -18227,6 +18556,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_185
   name: 185 SCig Tfap2b Chrnb3 Glut
   cell_set_accession: CS20230722_SUBC_185
@@ -18284,6 +18614,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_186
   name: 186 SCop Pou4f2 Neurod2 Glut
   cell_set_accession: CS20230722_SUBC_186
@@ -18348,6 +18679,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_189
   name: 189 PAG Ucn Glut
   cell_set_accession: CS20230722_SUBC_189
@@ -18399,6 +18731,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_180
   name: 180 SCiw Pitx2 Glut
   cell_set_accession: CS20230722_SUBC_180
@@ -18447,6 +18780,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_183
   name: 183 PBG Mtnr1a Glut-Chol
   cell_set_accession: CS20230722_SUBC_183
@@ -18490,6 +18824,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_184
   name: 184 PAG Tcf24 Glut
   cell_set_accession: CS20230722_SUBC_184
@@ -18543,6 +18878,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_181
   name: 181 IC Tfap2d Maf Glut
   cell_set_accession: CS20230722_SUBC_181
@@ -18599,6 +18935,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2
 - id: WMB:CS20230722_SUBC_182
   name: 182 CUN-PPN Evx2 Meis2 Glut
   cell_set_accession: CS20230722_SUBC_182
@@ -18660,3 +18997,4 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 2

--- a/kb/taxonomy/CCN20230722/supertype.yaml
+++ b/kb/taxonomy/CCN20230722/supertype.yaml
@@ -78,6 +78,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1091
   name: 1091 MY Lhx1 Gly-Gaba_3
   cell_set_accession: CS20230722_SUPT_1091
@@ -142,6 +143,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1092
   name: 1092 MY Lhx1 Gly-Gaba_4
   cell_set_accession: CS20230722_SUPT_1092
@@ -188,6 +190,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1093
   name: 1093 MY Lhx1 Gly-Gaba_5
   cell_set_accession: CS20230722_SUPT_1093
@@ -256,6 +259,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1094
   name: 1094 MY Lhx1 Gly-Gaba_6
   cell_set_accession: CS20230722_SUPT_1094
@@ -310,6 +314,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1095
   name: 1095 MY Lhx1 Gly-Gaba_7
   cell_set_accession: CS20230722_SUPT_1095
@@ -366,6 +371,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1096
   name: 1096 MY Lhx1 Gly-Gaba_8
   cell_set_accession: CS20230722_SUPT_1096
@@ -421,6 +427,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1097
   name: 1097 MY Lhx1 Gly-Gaba_9
   cell_set_accession: CS20230722_SUPT_1097
@@ -482,6 +489,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1098
   name: 1098 PPY-PGRNl Vip Glyc-Gaba_1
   cell_set_accession: CS20230722_SUPT_1098
@@ -546,6 +554,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1099
   name: 1099 MV-SPIV-PRP Dmbx1 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1099
@@ -590,6 +599,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1080
   name: 1080 NLL-po Pax7 Gaba_1
   cell_set_accession: CS20230722_SUPT_1080
@@ -631,6 +641,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1081
   name: 1081 POR Gata3 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1081
@@ -676,6 +687,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1082
   name: 1082 POR Spp1 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1082
@@ -726,6 +738,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1083
   name: 1083 PRP Otp Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1083
@@ -788,6 +801,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1084
   name: 1084 PRP Otp Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1084
@@ -835,6 +849,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1085
   name: 1085 PRP Otp Gly-Gaba_3
   cell_set_accession: CS20230722_SUPT_1085
@@ -903,6 +918,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1086
   name: 1086 PRP Otp Gly-Gaba_4
   cell_set_accession: CS20230722_SUPT_1086
@@ -972,6 +988,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1087
   name: 1087 PRP Otp Gly-Gaba_5
   cell_set_accession: CS20230722_SUPT_1087
@@ -1036,6 +1053,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1088
   name: 1088 GRN-IRN-MDRNd Ikzf1 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1088
@@ -1071,6 +1089,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1089
   name: 1089 MY Lhx1 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1089
@@ -1136,6 +1155,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1110
   name: 1110 PAS-MV Ebf2 Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1110
@@ -1185,6 +1205,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1111
   name: 1111 PAS-MV Ebf2 Gly-Gaba_3
   cell_set_accession: CS20230722_SUPT_1111
@@ -1243,6 +1264,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1112
   name: 1112 PAS-MV Ebf2 Gly-Gaba_4
   cell_set_accession: CS20230722_SUPT_1112
@@ -1288,6 +1310,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1113
   name: 1113 MV Pax6 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1113
@@ -1328,6 +1351,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1103
   name: 1103 MDRNd Prox1 Pax6 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1103
@@ -1387,6 +1411,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1104
   name: 1104 MY Prox1 Lmo7 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1104
@@ -1450,6 +1475,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1105
   name: 1105 NTS-MDRNd Prox1 Zic1 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1105
@@ -1525,6 +1551,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1106
   name: 1106 NTS-MDRNd Prox1 Zic1 Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1106
@@ -1565,6 +1592,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1107
   name: 1107 MV Nkx6-1 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1107
@@ -1605,6 +1633,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1108
   name: 1108 MV Nkx6-1 Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1108
@@ -1640,6 +1669,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1109
   name: 1109 PAS-MV Ebf2 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1109
@@ -1686,6 +1716,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1100
   name: 1100 MV-SPIV-PRP Dmbx1 Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1100
@@ -1734,6 +1765,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1101
   name: 1101 MV-SPIV-PRP Dmbx1 Gly-Gaba_3
   cell_set_accession: CS20230722_SUPT_1101
@@ -1779,6 +1811,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1102
   name: 1102 MDRN Hoxb5 Ebf2 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1102
@@ -1842,6 +1875,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1150
   name: 1150 CBX MLI Megf11 Gaba_2
   cell_set_accession: CS20230722_SUPT_1150
@@ -1885,6 +1919,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1151
   name: 1151 CBX MLI Cdh22 Gaba_1
   cell_set_accession: CS20230722_SUPT_1151
@@ -1942,6 +1977,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1152
   name: 1152 CBX Purkinje Gaba_1
   cell_set_accession: CS20230722_SUPT_1152
@@ -1966,6 +2002,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1153
   name: 1153 CBX Purkinje Gaba_2
   cell_set_accession: CS20230722_SUPT_1153
@@ -1988,6 +2025,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1154
   name: 1154 CB Granule Glut_1
   cell_set_accession: CS20230722_SUPT_1154
@@ -2010,6 +2048,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1155
   name: 1155 CB Granule Glut_2
   cell_set_accession: CS20230722_SUPT_1155
@@ -2034,6 +2073,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1156
   name: 1156 DCO UBC Glut_1
   cell_set_accession: CS20230722_SUPT_1156
@@ -2056,6 +2096,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1157
   name: 1157 Bergmann NN_1
   cell_set_accession: CS20230722_SUPT_1157
@@ -2111,6 +2152,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1147
   name: 1147 CB PLI Gly-Gaba_4
   cell_set_accession: CS20230722_SUPT_1147
@@ -2164,6 +2206,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1148
   name: 1148 CBX Golgi Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1148
@@ -2188,6 +2231,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1149
   name: 1149 CBX MLI Megf11 Gaba_1
   cell_set_accession: CS20230722_SUPT_1149
@@ -2216,6 +2260,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1140
   name: 1140 RO-RPA Pkd2l1 Gaba_1
   cell_set_accession: CS20230722_SUPT_1140
@@ -2284,6 +2329,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1141
   name: 1141 DCO Il22 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1141
@@ -2308,6 +2354,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1142
   name: 1142 DCO Il22 Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1142
@@ -2351,6 +2398,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1143
   name: 1143 DCO Il22 Gly-Gaba_3
   cell_set_accession: CS20230722_SUPT_1143
@@ -2375,6 +2423,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1144
   name: 1144 CB PLI Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1144
@@ -2430,6 +2479,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1145
   name: 1145 CB PLI Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1145
@@ -2462,6 +2512,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1146
   name: 1146 CB PLI Gly-Gaba_3
   cell_set_accession: CS20230722_SUPT_1146
@@ -2509,6 +2560,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1136
   name: 1136 SPVI-SPVC Sall3 Nfib Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1136
@@ -2570,6 +2622,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1137
   name: 1137 SPVI-SPVC Sall3 Nfib Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1137
@@ -2616,6 +2669,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1138
   name: 1138 SPVI-SPVC Sall3 Lhx1 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1138
@@ -2665,6 +2719,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1139
   name: 1139 SPVI-SPVC Sall3 Lhx1 Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1139
@@ -2707,6 +2762,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1130
   name: 1130 NTS-PARN Neurod2 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1130
@@ -2756,6 +2812,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1131
   name: 1131 NTS-PARN Neurod2 Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1131
@@ -2809,6 +2866,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1132
   name: 1132 NTS-PARN Neurod2 Gly-Gaba_3
   cell_set_accession: CS20230722_SUPT_1132
@@ -2869,6 +2927,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1133
   name: 1133 NTS-PARN Neurod2 Gly-Gaba_4
   cell_set_accession: CS20230722_SUPT_1133
@@ -2919,6 +2978,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1134
   name: 1134 NTS-PARN Neurod2 Gly-Gaba_5
   cell_set_accession: CS20230722_SUPT_1134
@@ -2982,6 +3042,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1135
   name: 1135 NTS-PARN Neurod2 Gly-Gaba_6
   cell_set_accession: CS20230722_SUPT_1135
@@ -3040,6 +3101,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1125
   name: 1125 PARN-MDRNd-NTS Gbx2 Gly-Gaba_6
   cell_set_accession: CS20230722_SUPT_1125
@@ -3094,6 +3156,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1126
   name: 1126 PARN-MDRNd-NTS Gbx2 Gly-Gaba_7
   cell_set_accession: CS20230722_SUPT_1126
@@ -3143,6 +3206,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1127
   name: 1127 MV Nr4a2 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1127
@@ -3208,6 +3272,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1128
   name: 1128 MV Xdh Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1128
@@ -3251,6 +3316,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1129
   name: 1129 IRN Dmbx1 Pax2 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1129
@@ -3310,6 +3376,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1120
   name: 1120 PARN-MDRNd-NTS Gbx2 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1120
@@ -3370,6 +3437,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1121
   name: 1121 PARN-MDRNd-NTS Gbx2 Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1121
@@ -3430,6 +3498,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1122
   name: 1122 PARN-MDRNd-NTS Gbx2 Gly-Gaba_3
   cell_set_accession: CS20230722_SUPT_1122
@@ -3487,6 +3556,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1123
   name: 1123 PARN-MDRNd-NTS Gbx2 Gly-Gaba_4
   cell_set_accession: CS20230722_SUPT_1123
@@ -3543,6 +3613,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1124
   name: 1124 PARN-MDRNd-NTS Gbx2 Gly-Gaba_5
   cell_set_accession: CS20230722_SUPT_1124
@@ -3595,6 +3666,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1114
   name: 1114 MV Pax6 Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1114
@@ -3645,6 +3717,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1115
   name: 1115 CBN Dmbx1 Gaba_1
   cell_set_accession: CS20230722_SUPT_1115
@@ -3690,6 +3763,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1116
   name: 1116 RPA Pax6 Hoxb5 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1116
@@ -3741,6 +3815,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1117
   name: 1117 CU-ECU Pax2 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1117
@@ -3792,6 +3867,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1118
   name: 1118 PRP Gata3 Slc6a5 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1118
@@ -3839,6 +3915,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1119
   name: 1119 MARN-PPY Ngfr Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1119
@@ -3894,6 +3971,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1190
   name: 1190 VLMC NN_4
   cell_set_accession: CS20230722_SUPT_1190
@@ -3929,6 +4007,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1191
   name: 1191 Peri NN_1
   cell_set_accession: CS20230722_SUPT_1191
@@ -3957,6 +4036,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1192
   name: 1192 SMC NN_1
   cell_set_accession: CS20230722_SUPT_1192
@@ -3979,6 +4059,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1193
   name: 1193 Endo NN_1
   cell_set_accession: CS20230722_SUPT_1193
@@ -4005,6 +4086,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1194
   name: 1194 Microglia NN_1
   cell_set_accession: CS20230722_SUPT_1194
@@ -4035,6 +4117,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1195
   name: 1195 BAM NN_1
   cell_set_accession: CS20230722_SUPT_1195
@@ -4088,6 +4171,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1196
   name: 1196 Monocytes NN_1
   cell_set_accession: CS20230722_SUPT_1196
@@ -4116,6 +4200,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1197
   name: 1197 DC NN_1
   cell_set_accession: CS20230722_SUPT_1197
@@ -4140,6 +4225,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1198
   name: 1198 B cells NN_1
   cell_set_accession: CS20230722_SUPT_1198
@@ -4162,6 +4248,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1199
   name: 1199 ILC NN_2
   cell_set_accession: CS20230722_SUPT_1199
@@ -4195,6 +4282,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1180
   name: 1180 OPC NN_2
   cell_set_accession: CS20230722_SUPT_1180
@@ -4243,6 +4331,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1181
   name: 1181 COP NN_1
   cell_set_accession: CS20230722_SUPT_1181
@@ -4277,6 +4366,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1182
   name: 1182 NFOL NN_2
   cell_set_accession: CS20230722_SUPT_1182
@@ -4313,6 +4403,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1183
   name: 1183 MFOL NN_3
   cell_set_accession: CS20230722_SUPT_1183
@@ -4345,6 +4436,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1184
   name: 1184 MOL NN_4
   cell_set_accession: CS20230722_SUPT_1184
@@ -4375,6 +4467,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1185
   name: 1185 OEC NN_1
   cell_set_accession: CS20230722_SUPT_1185
@@ -4399,6 +4492,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1186
   name: 1186 ABC NN_1
   cell_set_accession: CS20230722_SUPT_1186
@@ -4421,6 +4515,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1187
   name: 1187 VLMC NN_1
   cell_set_accession: CS20230722_SUPT_1187
@@ -4443,6 +4538,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1188
   name: 1188 VLMC NN_2
   cell_set_accession: CS20230722_SUPT_1188
@@ -4510,6 +4606,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1189
   name: 1189 VLMC NN_3
   cell_set_accession: CS20230722_SUPT_1189
@@ -4563,6 +4660,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1170
   name: 1170 Astroependymal NN_2
   cell_set_accession: CS20230722_SUPT_1170
@@ -4599,6 +4697,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1171
   name: 1171 Astroependymal NN_3
   cell_set_accession: CS20230722_SUPT_1171
@@ -4634,6 +4733,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1172
   name: 1172 Tanycyte NN_1
   cell_set_accession: CS20230722_SUPT_1172
@@ -4682,6 +4782,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1173
   name: 1173 Tanycyte NN_2
   cell_set_accession: CS20230722_SUPT_1173
@@ -4724,6 +4825,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1174
   name: 1174 Tanycyte NN_3
   cell_set_accession: CS20230722_SUPT_1174
@@ -4760,6 +4862,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1175
   name: 1175 Ependymal NN_1
   cell_set_accession: CS20230722_SUPT_1175
@@ -4808,6 +4911,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1176
   name: 1176 Ependymal NN_2
   cell_set_accession: CS20230722_SUPT_1176
@@ -4872,6 +4976,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1177
   name: 1177 Hypendymal NN_1
   cell_set_accession: CS20230722_SUPT_1177
@@ -4917,6 +5022,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1178
   name: 1178 CHOR NN_1
   cell_set_accession: CS20230722_SUPT_1178
@@ -4937,6 +5043,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1179
   name: 1179 OPC NN_1
   cell_set_accession: CS20230722_SUPT_1179
@@ -5007,6 +5114,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1169
   name: 1169 Astroependymal NN_1
   cell_set_accession: CS20230722_SUPT_1169
@@ -5049,6 +5157,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1160
   name: 1160 Astro-NT NN_2
   cell_set_accession: CS20230722_SUPT_1160
@@ -5110,6 +5219,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1161
   name: 1161 Astro-TE NN_1
   cell_set_accession: CS20230722_SUPT_1161
@@ -5132,6 +5242,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1162
   name: 1162 Astro-TE NN_2
   cell_set_accession: CS20230722_SUPT_1162
@@ -5156,6 +5267,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1163
   name: 1163 Astro-TE NN_3
   cell_set_accession: CS20230722_SUPT_1163
@@ -5186,6 +5298,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1164
   name: 1164 Astro-TE NN_4
   cell_set_accession: CS20230722_SUPT_1164
@@ -5241,6 +5354,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1165
   name: 1165 Astro-TE NN_5
   cell_set_accession: CS20230722_SUPT_1165
@@ -5297,6 +5411,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1166
   name: 1166 Astro-OLF NN_1
   cell_set_accession: CS20230722_SUPT_1166
@@ -5342,6 +5457,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1167
   name: 1167 Astro-OLF NN_2
   cell_set_accession: CS20230722_SUPT_1167
@@ -5399,6 +5515,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1168
   name: 1168 Astro-OLF NN_3
   cell_set_accession: CS20230722_SUPT_1168
@@ -5436,6 +5553,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1158
   name: 1158 Astro-CB NN_1
   cell_set_accession: CS20230722_SUPT_1158
@@ -5493,6 +5611,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1159
   name: 1159 Astro-NT NN_1
   cell_set_accession: CS20230722_SUPT_1159
@@ -5532,6 +5651,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1030
   name: 1030 Pineal Crx Glut_1
   cell_set_accession: CS20230722_SUPT_1030
@@ -5558,6 +5678,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1031
   name: 1031 CS-RPO Meis2 Gaba_1
   cell_set_accession: CS20230722_SUPT_1031
@@ -5619,6 +5740,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1032
   name: 1032 CS-RPO Meis2 Gaba_2
   cell_set_accession: CS20230722_SUPT_1032
@@ -5669,6 +5791,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1033
   name: 1033 CS-RPO Meis2 Gaba_3
   cell_set_accession: CS20230722_SUPT_1033
@@ -5711,6 +5834,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1034
   name: 1034 CS-RPO Meis2 Gaba_4
   cell_set_accession: CS20230722_SUPT_1034
@@ -5753,6 +5877,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1035
   name: 1035 CS-RPO Meis2 Gaba_5
   cell_set_accession: CS20230722_SUPT_1035
@@ -5810,6 +5935,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1036
   name: 1036 PRNc Otp Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1036
@@ -5865,6 +5991,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1026
   name: 1026 HB Calcb Chol_2
   cell_set_accession: CS20230722_SUPT_1026
@@ -5909,6 +6036,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1027
   name: 1027 HB Calcb Chol_3
   cell_set_accession: CS20230722_SUPT_1027
@@ -5958,6 +6086,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1028
   name: 1028 HB Calcb Chol_4
   cell_set_accession: CS20230722_SUPT_1028
@@ -5992,6 +6121,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1029
   name: 1029 HB Calcb Chol_5
   cell_set_accession: CS20230722_SUPT_1029
@@ -6031,6 +6161,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1020
   name: 1020 SPVC Ccdc172 Glut_1
   cell_set_accession: CS20230722_SUPT_1020
@@ -6071,6 +6202,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1021
   name: 1021 SPVC Nmu Glut_1
   cell_set_accession: CS20230722_SUPT_1021
@@ -6109,6 +6241,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1022
   name: 1022 SPVC Nmu Glut_2
   cell_set_accession: CS20230722_SUPT_1022
@@ -6142,6 +6275,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1023
   name: 1023 MDRNd Bves Glut_1
   cell_set_accession: CS20230722_SUPT_1023
@@ -6193,6 +6327,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1024
   name: 1024 MDRNv Crp Glut_1
   cell_set_accession: CS20230722_SUPT_1024
@@ -6253,6 +6388,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1025
   name: 1025 HB Calcb Chol_1
   cell_set_accession: CS20230722_SUPT_1025
@@ -6297,6 +6433,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1015
   name: 1015 VCO Mafa Meis2 Glut_3
   cell_set_accession: CS20230722_SUPT_1015
@@ -6337,6 +6474,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1016
   name: 1016 VCO Mafa Meis2 Glut_4
   cell_set_accession: CS20230722_SUPT_1016
@@ -6381,6 +6519,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1017
   name: 1017 SPVO Mafa Meis2 Glut_1
   cell_set_accession: CS20230722_SUPT_1017
@@ -6433,6 +6572,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1018
   name: 1018 SPVC Mafa Glut_1
   cell_set_accession: CS20230722_SUPT_1018
@@ -6466,6 +6606,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1019
   name: 1019 SPVC Mafa Glut_2
   cell_set_accession: CS20230722_SUPT_1019
@@ -6506,6 +6647,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1010
   name: 1010 DMX VII Tbx20 Chol_1
   cell_set_accession: CS20230722_SUPT_1010
@@ -6554,6 +6696,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1011
   name: 1011 DMX VII Tbx20 Chol_2
   cell_set_accession: CS20230722_SUPT_1011
@@ -6602,6 +6745,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1012
   name: 1012 IO Fgl2 Glut_1
   cell_set_accession: CS20230722_SUPT_1012
@@ -6640,6 +6784,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1013
   name: 1013 VCO Mafa Meis2 Glut_1
   cell_set_accession: CS20230722_SUPT_1013
@@ -6678,6 +6823,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1014
   name: 1014 VCO Mafa Meis2 Glut_2
   cell_set_accession: CS20230722_SUPT_1014
@@ -6716,6 +6862,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1004
   name: 1004 NTS Dbh Glut_1
   cell_set_accession: CS20230722_SUPT_1004
@@ -6762,6 +6909,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1005
   name: 1005 NTS Dbh Glut_2
   cell_set_accession: CS20230722_SUPT_1005
@@ -6816,6 +6964,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1006
   name: 1006 NTS Dbh Glut_3
   cell_set_accession: CS20230722_SUPT_1006
@@ -6854,6 +7003,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1007
   name: 1007 NTS Dbh Glut_4
   cell_set_accession: CS20230722_SUPT_1007
@@ -6897,6 +7047,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1008
   name: 1008 NTS Dbh Glut_5
   cell_set_accession: CS20230722_SUPT_1008
@@ -6932,6 +7083,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1009
   name: 1009 NTS Dbh Glut_6
   cell_set_accession: CS20230722_SUPT_1009
@@ -6974,6 +7126,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1000
   name: 1000 MV-SPIV Zic4 Neurod2 Glut_4
   cell_set_accession: CS20230722_SUPT_1000
@@ -7022,6 +7175,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1001
   name: 1001 MV-SPIV Zic4 Neurod2 Glut_5
   cell_set_accession: CS20230722_SUPT_1001
@@ -7079,6 +7233,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1002
   name: 1002 NTS Aldh1a2 Glut_1
   cell_set_accession: CS20230722_SUPT_1002
@@ -7114,6 +7269,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1003
   name: 1003 CBN Neurod2 Pvalb Glut_1
   cell_set_accession: CS20230722_SUPT_1003
@@ -7175,6 +7331,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1070
   name: 1070 DTN-LDT-IPN Otp Pax3 Gaba_2
   cell_set_accession: CS20230722_SUPT_1070
@@ -7232,6 +7389,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1071
   name: 1071 DTN-LDT-IPN Otp Pax3 Gaba_3
   cell_set_accession: CS20230722_SUPT_1071
@@ -7306,6 +7464,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1072
   name: 1072 DTN-LDT-IPN Otp Pax3 Gaba_4
   cell_set_accession: CS20230722_SUPT_1072
@@ -7346,6 +7505,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1073
   name: 1073 DTN-LDT-IPN Otp Pax3 Gaba_5
   cell_set_accession: CS20230722_SUPT_1073
@@ -7403,6 +7563,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1074
   name: 1074 NLL Gata3 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1074
@@ -7464,6 +7625,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1075
   name: 1075 NLL Gata3 Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1075
@@ -7513,6 +7675,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1076
   name: 1076 NLL Gata3 Gly-Gaba_3
   cell_set_accession: CS20230722_SUPT_1076
@@ -7559,6 +7722,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1077
   name: 1077 NLL Gata3 Gly-Gaba_4
   cell_set_accession: CS20230722_SUPT_1077
@@ -7593,6 +7757,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1078
   name: 1078 PSV Pax2 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1078
@@ -7627,6 +7792,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1079
   name: 1079 PSV Pax2 Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1079
@@ -7661,6 +7827,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1060
   name: 1060 LDT-PCG-CS Gata3 Lhx1 Gaba_5
   cell_set_accession: CS20230722_SUPT_1060
@@ -7713,6 +7880,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1061
   name: 1061 PDTg-PCG Pax6 Gaba_1
   cell_set_accession: CS20230722_SUPT_1061
@@ -7758,6 +7926,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1062
   name: 1062 PDTg-PCG Pax6 Gaba_2
   cell_set_accession: CS20230722_SUPT_1062
@@ -7811,6 +7980,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1063
   name: 1063 PDTg-PCG Pax6 Gaba_3
   cell_set_accession: CS20230722_SUPT_1063
@@ -7846,6 +8016,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1064
   name: 1064 PDTg-PCG Pax6 Gaba_4
   cell_set_accession: CS20230722_SUPT_1064
@@ -7886,6 +8057,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1065
   name: 1065 PDTg Otp Shroom3 Gaba_1
   cell_set_accession: CS20230722_SUPT_1065
@@ -7918,6 +8090,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1066
   name: 1066 PDTg Otp Olig3 Gaba_1
   cell_set_accession: CS20230722_SUPT_1066
@@ -7948,6 +8121,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1067
   name: 1067 LDT-PCG St18 Gaba_1
   cell_set_accession: CS20230722_SUPT_1067
@@ -7992,6 +8166,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1068
   name: 1068 LDT-PCG St18 Gaba_2
   cell_set_accession: CS20230722_SUPT_1068
@@ -8051,6 +8226,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1069
   name: 1069 DTN-LDT-IPN Otp Pax3 Gaba_1
   cell_set_accession: CS20230722_SUPT_1069
@@ -8108,6 +8284,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1059
   name: 1059 LDT-PCG-CS Gata3 Lhx1 Gaba_4
   cell_set_accession: CS20230722_SUPT_1059
@@ -8165,6 +8342,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1050
   name: 1050 LDT-DTN Gata3 Nfix Gaba_1
   cell_set_accession: CS20230722_SUPT_1050
@@ -8224,6 +8402,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1051
   name: 1051 LDT-DTN Gata3 Nfix Gaba_2
   cell_set_accession: CS20230722_SUPT_1051
@@ -8264,6 +8443,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1052
   name: 1052 NI-RPO Gata3 Nr4a2 Gaba_1
   cell_set_accession: CS20230722_SUPT_1052
@@ -8332,6 +8512,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1053
   name: 1053 NI-RPO Gata3 Nr4a2 Gaba_2
   cell_set_accession: CS20230722_SUPT_1053
@@ -8376,6 +8557,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1054
   name: 1054 NI-RPO Gata3 Nr4a2 Gaba_3
   cell_set_accession: CS20230722_SUPT_1054
@@ -8418,6 +8600,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1055
   name: 1055 NI-RPO Gata3 Nr4a2 Gaba_4
   cell_set_accession: CS20230722_SUPT_1055
@@ -8487,6 +8670,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1056
   name: 1056 LDT-PCG-CS Gata3 Lhx1 Gaba_1
   cell_set_accession: CS20230722_SUPT_1056
@@ -8547,6 +8731,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1057
   name: 1057 LDT-PCG-CS Gata3 Lhx1 Gaba_2
   cell_set_accession: CS20230722_SUPT_1057
@@ -8588,6 +8773,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1058
   name: 1058 LDT-PCG-CS Gata3 Lhx1 Gaba_3
   cell_set_accession: CS20230722_SUPT_1058
@@ -8642,6 +8828,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1048
   name: 1048 CS-PRNr-DR En1 Sox2 Gaba_2
   cell_set_accession: CS20230722_SUPT_1048
@@ -8700,6 +8887,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1049
   name: 1049 LDT Fgf7 Gaba_1
   cell_set_accession: CS20230722_SUPT_1049
@@ -8750,6 +8938,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1040
   name: 1040 PRNc Otp Gly-Gaba_5
   cell_set_accession: CS20230722_SUPT_1040
@@ -8795,6 +8984,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1041
   name: 1041 PB Sst Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1041
@@ -8845,6 +9035,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1042
   name: 1042 PB Sst Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1042
@@ -8890,6 +9081,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1043
   name: 1043 PRNc Prox1 Brs3 Gly-Gaba_1
   cell_set_accession: CS20230722_SUPT_1043
@@ -8935,6 +9127,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1044
   name: 1044 CS-PRNr-PCG Tmem163 Otp Gaba_1
   cell_set_accession: CS20230722_SUPT_1044
@@ -8993,6 +9186,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1045
   name: 1045 CS-PRNr-PCG Tmem163 Otp Gaba_2
   cell_set_accession: CS20230722_SUPT_1045
@@ -9038,6 +9232,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1046
   name: 1046 CS-PRNr-PCG Tmem163 Otp Gaba_3
   cell_set_accession: CS20230722_SUPT_1046
@@ -9081,6 +9276,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1047
   name: 1047 CS-PRNr-DR En1 Sox2 Gaba_1
   cell_set_accession: CS20230722_SUPT_1047
@@ -9135,6 +9331,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1037
   name: 1037 PRNc Otp Gly-Gaba_2
   cell_set_accession: CS20230722_SUPT_1037
@@ -9188,6 +9385,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1038
   name: 1038 PRNc Otp Gly-Gaba_3
   cell_set_accession: CS20230722_SUPT_1038
@@ -9250,6 +9448,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1039
   name: 1039 PRNc Otp Gly-Gaba_4
   cell_set_accession: CS20230722_SUPT_1039
@@ -9312,6 +9511,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1200
   name: 1200 NK cells NN_3
   cell_set_accession: CS20230722_SUPT_1200
@@ -9345,6 +9545,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_1201
   name: 1201 T cells NN_4
   cell_set_accession: CS20230722_SUPT_1201
@@ -9367,6 +9568,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0019
   name: 0019 L5 IT CTX Glut_2
   cell_set_accession: CS20230722_SUPT_0019
@@ -9423,6 +9625,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0018
   name: 0018 L5 IT CTX Glut_1
   cell_set_accession: CS20230722_SUPT_0018
@@ -9463,6 +9666,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0017
   name: 0017 L6 IT CTX Glut_5
   cell_set_accession: CS20230722_SUPT_0017
@@ -9526,6 +9730,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0016
   name: 0016 L6 IT CTX Glut_4
   cell_set_accession: CS20230722_SUPT_0016
@@ -9575,6 +9780,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0015
   name: 0015 L6 IT CTX Glut_3
   cell_set_accession: CS20230722_SUPT_0015
@@ -9633,6 +9839,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0014
   name: 0014 L6 IT CTX Glut_2
   cell_set_accession: CS20230722_SUPT_0014
@@ -9698,6 +9905,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0024
   name: 0024 L4/5 IT CTX Glut_2
   cell_set_accession: CS20230722_SUPT_0024
@@ -9768,6 +9976,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0023
   name: 0023 L4/5 IT CTX Glut_1
   cell_set_accession: CS20230722_SUPT_0023
@@ -9825,6 +10034,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0022
   name: 0022 L5 IT CTX Glut_5
   cell_set_accession: CS20230722_SUPT_0022
@@ -9875,6 +10085,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0021
   name: 0021 L5 IT CTX Glut_4
   cell_set_accession: CS20230722_SUPT_0021
@@ -9926,6 +10137,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0020
   name: 0020 L5 IT CTX Glut_3
   cell_set_accession: CS20230722_SUPT_0020
@@ -9969,6 +10181,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0009
   name: 0009 L5/6 IT TPE-ENT Glut_3
   cell_set_accession: CS20230722_SUPT_0009
@@ -10024,6 +10237,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0008
   name: 0008 L5/6 IT TPE-ENT Glut_2
   cell_set_accession: CS20230722_SUPT_0008
@@ -10070,6 +10284,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0007
   name: 0007 L5/6 IT TPE-ENT Glut_1
   cell_set_accession: CS20230722_SUPT_0007
@@ -10107,6 +10322,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0006
   name: 0006 IT EP-CLA Glut_4
   cell_set_accession: CS20230722_SUPT_0006
@@ -10156,6 +10372,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0005
   name: 0005 IT EP-CLA Glut_3
   cell_set_accession: CS20230722_SUPT_0005
@@ -10201,6 +10418,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0004
   name: 0004 IT EP-CLA Glut_2
   cell_set_accession: CS20230722_SUPT_0004
@@ -10259,6 +10477,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0003
   name: 0003 IT EP-CLA Glut_1
   cell_set_accession: CS20230722_SUPT_0003
@@ -10319,6 +10538,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0013
   name: 0013 L6 IT CTX Glut_1
   cell_set_accession: CS20230722_SUPT_0013
@@ -10376,6 +10596,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0012
   name: 0012 L5/6 IT TPE-ENT Glut_6
   cell_set_accession: CS20230722_SUPT_0012
@@ -10421,6 +10642,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0011
   name: 0011 L5/6 IT TPE-ENT Glut_5
   cell_set_accession: CS20230722_SUPT_0011
@@ -10475,6 +10697,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0010
   name: 0010 L5/6 IT TPE-ENT Glut_4
   cell_set_accession: CS20230722_SUPT_0010
@@ -10526,6 +10749,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0002
   name: 0002 CLA-EPd-CTX Car3 Glut_2
   cell_set_accession: CS20230722_SUPT_0002
@@ -10574,6 +10798,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0001
   name: 0001 CLA-EPd-CTX Car3 Glut_1
   cell_set_accession: CS20230722_SUPT_0001
@@ -10598,6 +10823,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0059
   name: 0059 COAp Grxcr2 Glut_2
   cell_set_accession: CS20230722_SUPT_0059
@@ -10643,6 +10869,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0058
   name: 0058 COAp Grxcr2 Glut_1
   cell_set_accession: CS20230722_SUPT_0058
@@ -10710,6 +10937,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0068
   name: 0068 ENTmv-PA-COAp Glut_3
   cell_set_accession: CS20230722_SUPT_0068
@@ -10753,6 +10981,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0067
   name: 0067 ENTmv-PA-COAp Glut_2
   cell_set_accession: CS20230722_SUPT_0067
@@ -10822,6 +11051,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0066
   name: 0066 ENTmv-PA-COAp Glut_1
   cell_set_accession: CS20230722_SUPT_0066
@@ -10873,6 +11103,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0065
   name: 0065 LA-BLA-BMA-PA Glut_6
   cell_set_accession: CS20230722_SUPT_0065
@@ -10917,6 +11148,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0064
   name: 0064 LA-BLA-BMA-PA Glut_5
   cell_set_accession: CS20230722_SUPT_0064
@@ -10959,6 +11191,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0063
   name: 0063 LA-BLA-BMA-PA Glut_4
   cell_set_accession: CS20230722_SUPT_0063
@@ -11010,6 +11243,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0062
   name: 0062 LA-BLA-BMA-PA Glut_3
   cell_set_accession: CS20230722_SUPT_0062
@@ -11053,6 +11287,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0061
   name: 0061 LA-BLA-BMA-PA Glut_2
   cell_set_accession: CS20230722_SUPT_0061
@@ -11116,6 +11351,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0060
   name: 0060 LA-BLA-BMA-PA Glut_1
   cell_set_accession: CS20230722_SUPT_0060
@@ -11163,6 +11399,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0049
   name: 0049 IT AON-TT-DP Glut_4
   cell_set_accession: CS20230722_SUPT_0049
@@ -11207,6 +11444,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0048
   name: 0048 IT AON-TT-DP Glut_3
   cell_set_accession: CS20230722_SUPT_0048
@@ -11254,6 +11492,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0047
   name: 0047 IT AON-TT-DP Glut_2
   cell_set_accession: CS20230722_SUPT_0047
@@ -11295,6 +11534,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0057
   name: 0057 MEA Slc17a7 Glut_3
   cell_set_accession: CS20230722_SUPT_0057
@@ -11348,6 +11588,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0056
   name: 0056 MEA Slc17a7 Glut_2
   cell_set_accession: CS20230722_SUPT_0056
@@ -11411,6 +11652,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0055
   name: 0055 MEA Slc17a7 Glut_1
   cell_set_accession: CS20230722_SUPT_0055
@@ -11457,6 +11699,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0054
   name: 0054 L2 IT ENT-po Glut_4
   cell_set_accession: CS20230722_SUPT_0054
@@ -11505,6 +11748,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0053
   name: 0053 L2 IT ENT-po Glut_3
   cell_set_accession: CS20230722_SUPT_0053
@@ -11550,6 +11794,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0052
   name: 0052 L2 IT ENT-po Glut_2
   cell_set_accession: CS20230722_SUPT_0052
@@ -11603,6 +11848,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0051
   name: 0051 L2 IT ENT-po Glut_1
   cell_set_accession: CS20230722_SUPT_0051
@@ -11655,6 +11901,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0050
   name: 0050 IT AON-TT-DP Glut_5
   cell_set_accession: CS20230722_SUPT_0050
@@ -11698,6 +11945,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0039
   name: 0039 L2/3 IT PIR-ENTl Glut_1
   cell_set_accession: CS20230722_SUPT_0039
@@ -11756,6 +12004,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0038
   name: 0038 L2/3 IT ENT Glut_6
   cell_set_accession: CS20230722_SUPT_0038
@@ -11804,6 +12053,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0037
   name: 0037 L2/3 IT ENT Glut_5
   cell_set_accession: CS20230722_SUPT_0037
@@ -11860,6 +12110,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0036
   name: 0036 L2/3 IT ENT Glut_4
   cell_set_accession: CS20230722_SUPT_0036
@@ -11910,6 +12161,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0046
   name: 0046 IT AON-TT-DP Glut_1
   cell_set_accession: CS20230722_SUPT_0046
@@ -11971,6 +12223,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0045
   name: 0045 L2/3 IT PIR-ENTl Glut_7
   cell_set_accession: CS20230722_SUPT_0045
@@ -12033,6 +12286,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0044
   name: 0044 L2/3 IT PIR-ENTl Glut_6
   cell_set_accession: CS20230722_SUPT_0044
@@ -12088,6 +12342,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0043
   name: 0043 L2/3 IT PIR-ENTl Glut_5
   cell_set_accession: CS20230722_SUPT_0043
@@ -12143,6 +12398,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0042
   name: 0042 L2/3 IT PIR-ENTl Glut_4
   cell_set_accession: CS20230722_SUPT_0042
@@ -12186,6 +12442,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0041
   name: 0041 L2/3 IT PIR-ENTl Glut_3
   cell_set_accession: CS20230722_SUPT_0041
@@ -12235,6 +12492,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0040
   name: 0040 L2/3 IT PIR-ENTl Glut_2
   cell_set_accession: CS20230722_SUPT_0040
@@ -12273,6 +12531,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0029
   name: 0029 L2/3 IT CTX Glut_1
   cell_set_accession: CS20230722_SUPT_0029
@@ -12348,6 +12607,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0028
   name: 0028 L4/5 IT CTX Glut_6
   cell_set_accession: CS20230722_SUPT_0028
@@ -12398,6 +12658,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0027
   name: 0027 L4/5 IT CTX Glut_5
   cell_set_accession: CS20230722_SUPT_0027
@@ -12446,6 +12707,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0026
   name: 0026 L4/5 IT CTX Glut_4
   cell_set_accession: CS20230722_SUPT_0026
@@ -12511,6 +12773,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0025
   name: 0025 L4/5 IT CTX Glut_3
   cell_set_accession: CS20230722_SUPT_0025
@@ -12572,6 +12835,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0035
   name: 0035 L2/3 IT ENT Glut_3
   cell_set_accession: CS20230722_SUPT_0035
@@ -12632,6 +12896,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0034
   name: 0034 L2/3 IT ENT Glut_2
   cell_set_accession: CS20230722_SUPT_0034
@@ -12678,6 +12943,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0033
   name: 0033 L2/3 IT ENT Glut_1
   cell_set_accession: CS20230722_SUPT_0033
@@ -12734,6 +13000,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0032
   name: 0032 L2/3 IT CTX Glut_4
   cell_set_accession: CS20230722_SUPT_0032
@@ -12791,6 +13058,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0031
   name: 0031 L2/3 IT CTX Glut_3
   cell_set_accession: CS20230722_SUPT_0031
@@ -12853,6 +13121,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0030
   name: 0030 L2/3 IT CTX Glut_2
   cell_set_accession: CS20230722_SUPT_0030
@@ -12914,6 +13183,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0099
   name: 0099 L5 PPP Glut_1
   cell_set_accession: CS20230722_SUPT_0099
@@ -12952,6 +13222,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0098
   name: 0098 SUB-ProS Glut_3
   cell_set_accession: CS20230722_SUPT_0098
@@ -13003,6 +13274,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0097
   name: 0097 SUB-ProS Glut_2
   cell_set_accession: CS20230722_SUPT_0097
@@ -13062,6 +13334,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0096
   name: 0096 SUB-ProS Glut_1
   cell_set_accession: CS20230722_SUPT_0096
@@ -13102,6 +13375,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0095
   name: 0095 L5 ET CTX Glut_6
   cell_set_accession: CS20230722_SUPT_0095
@@ -13149,6 +13423,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0094
   name: 0094 L5 ET CTX Glut_5
   cell_set_accession: CS20230722_SUPT_0094
@@ -13215,6 +13490,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0093
   name: 0093 L5 ET CTX Glut_4
   cell_set_accession: CS20230722_SUPT_0093
@@ -13255,6 +13531,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0092
   name: 0092 L5 ET CTX Glut_3
   cell_set_accession: CS20230722_SUPT_0092
@@ -13296,6 +13573,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0091
   name: 0091 L5 ET CTX Glut_2
   cell_set_accession: CS20230722_SUPT_0091
@@ -13347,6 +13625,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0090
   name: 0090 L5 ET CTX Glut_1
   cell_set_accession: CS20230722_SUPT_0090
@@ -13405,6 +13684,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0089
   name: 0089 L4 RSP-ACA Glut_1
   cell_set_accession: CS20230722_SUPT_0089
@@ -13440,6 +13720,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0088
   name: 0088 L2/3 IT RSP Glut_2
   cell_set_accession: CS20230722_SUPT_0088
@@ -13475,6 +13756,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0087
   name: 0087 L2/3 IT RSP Glut_1
   cell_set_accession: CS20230722_SUPT_0087
@@ -13515,6 +13797,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0086
   name: 0086 L2/3 IT PPP Glut_3
   cell_set_accession: CS20230722_SUPT_0086
@@ -13559,6 +13842,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0085
   name: 0085 L2/3 IT PPP Glut_2
   cell_set_accession: CS20230722_SUPT_0085
@@ -13604,6 +13888,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0084
   name: 0084 L2/3 IT PPP Glut_1
   cell_set_accession: CS20230722_SUPT_0084
@@ -13657,6 +13942,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0083
   name: 0083 L2 IT PPP-APr Glut_4
   cell_set_accession: CS20230722_SUPT_0083
@@ -13692,6 +13978,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0082
   name: 0082 L2 IT PPP-APr Glut_3
   cell_set_accession: CS20230722_SUPT_0082
@@ -13730,6 +14017,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0081
   name: 0081 L2 IT PPP-APr Glut_2
   cell_set_accession: CS20230722_SUPT_0081
@@ -13785,6 +14073,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0080
   name: 0080 L2 IT PPP-APr Glut_1
   cell_set_accession: CS20230722_SUPT_0080
@@ -13827,6 +14116,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0069
   name: 0069 CA1-ProS Glut_1
   cell_set_accession: CS20230722_SUPT_0069
@@ -13873,6 +14163,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0079
   name: 0079 CA3 Glut_5
   cell_set_accession: CS20230722_SUPT_0079
@@ -13926,6 +14217,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0078
   name: 0078 CA3 Glut_4
   cell_set_accession: CS20230722_SUPT_0078
@@ -13978,6 +14270,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0077
   name: 0077 CA3 Glut_3
   cell_set_accession: CS20230722_SUPT_0077
@@ -14025,6 +14318,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0076
   name: 0076 CA3 Glut_2
   cell_set_accession: CS20230722_SUPT_0076
@@ -14071,6 +14365,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0075
   name: 0075 CA3 Glut_1
   cell_set_accession: CS20230722_SUPT_0075
@@ -14125,6 +14420,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0074
   name: 0074 CA1-ProS Glut_6
   cell_set_accession: CS20230722_SUPT_0074
@@ -14170,6 +14466,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0073
   name: 0073 CA1-ProS Glut_5
   cell_set_accession: CS20230722_SUPT_0073
@@ -14219,6 +14516,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0072
   name: 0072 CA1-ProS Glut_4
   cell_set_accession: CS20230722_SUPT_0072
@@ -14265,6 +14563,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0071
   name: 0071 CA1-ProS Glut_3
   cell_set_accession: CS20230722_SUPT_0071
@@ -14316,6 +14615,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0070
   name: 0070 CA1-ProS Glut_2
   cell_set_accession: CS20230722_SUPT_0070
@@ -14369,6 +14669,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0219
   name: 0219 Sst Gaba_6
   cell_set_accession: CS20230722_SUPT_0219
@@ -14422,6 +14723,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0218
   name: 0218 Sst Gaba_5
   cell_set_accession: CS20230722_SUPT_0218
@@ -14470,6 +14772,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0217
   name: 0217 Sst Gaba_4
   cell_set_accession: CS20230722_SUPT_0217
@@ -14515,6 +14818,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0216
   name: 0216 Sst Gaba_3
   cell_set_accession: CS20230722_SUPT_0216
@@ -14570,6 +14874,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0215
   name: 0215 Sst Gaba_2
   cell_set_accession: CS20230722_SUPT_0215
@@ -14620,6 +14925,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0214
   name: 0214 Sst Gaba_1
   cell_set_accession: CS20230722_SUPT_0214
@@ -14663,6 +14969,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0213
   name: 0213 Pvalb Gaba_9
   cell_set_accession: CS20230722_SUPT_0213
@@ -14716,6 +15023,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0212
   name: 0212 Pvalb Gaba_8
   cell_set_accession: CS20230722_SUPT_0212
@@ -14764,6 +15072,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0222
   name: 0222 Sst Gaba_9
   cell_set_accession: CS20230722_SUPT_0222
@@ -14805,6 +15114,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0221
   name: 0221 Sst Gaba_8
   cell_set_accession: CS20230722_SUPT_0221
@@ -14848,6 +15158,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0220
   name: 0220 Sst Gaba_7
   cell_set_accession: CS20230722_SUPT_0220
@@ -14891,6 +15202,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0209
   name: 0209 Pvalb Gaba_5
   cell_set_accession: CS20230722_SUPT_0209
@@ -14940,6 +15252,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0208
   name: 0208 Pvalb Gaba_4
   cell_set_accession: CS20230722_SUPT_0208
@@ -14980,6 +15293,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0207
   name: 0207 Pvalb Gaba_3
   cell_set_accession: CS20230722_SUPT_0207
@@ -15021,6 +15335,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0206
   name: 0206 Pvalb Gaba_2
   cell_set_accession: CS20230722_SUPT_0206
@@ -15067,6 +15382,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0205
   name: 0205 Pvalb Gaba_1
   cell_set_accession: CS20230722_SUPT_0205
@@ -15104,6 +15420,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0204
   name: 0204 Pvalb chandelier Gaba_1
   cell_set_accession: CS20230722_SUPT_0204
@@ -15134,6 +15451,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0203
   name: 0203 Lamp5 Lhx6 Gaba_1
   cell_set_accession: CS20230722_SUPT_0203
@@ -15178,6 +15496,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0202
   name: 0202 Lamp5 Gaba_4
   cell_set_accession: CS20230722_SUPT_0202
@@ -15210,6 +15529,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0201
   name: 0201 Lamp5 Gaba_3
   cell_set_accession: CS20230722_SUPT_0201
@@ -15246,6 +15566,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0211
   name: 0211 Pvalb Gaba_7
   cell_set_accession: CS20230722_SUPT_0211
@@ -15293,6 +15614,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0210
   name: 0210 Pvalb Gaba_6
   cell_set_accession: CS20230722_SUPT_0210
@@ -15329,6 +15651,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0200
   name: 0200 Lamp5 Gaba_2
   cell_set_accession: CS20230722_SUPT_0200
@@ -15363,6 +15686,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0259
   name: 0259 PAL-STR Gaba-Chol_1
   cell_set_accession: CS20230722_SUPT_0259
@@ -15422,6 +15746,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0258
   name: 0258 GPe-SI Sox6 Cyp26b1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0258
@@ -15477,6 +15802,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0257
   name: 0257 GPe-SI Sox6 Cyp26b1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0257
@@ -15517,6 +15843,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0256
   name: 0256 NDB-SI-MA-STRv Lhx8 Gaba_13
   cell_set_accession: CS20230722_SUPT_0256
@@ -15574,6 +15901,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0266
   name: 0266 STR D1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0266
@@ -15617,6 +15945,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0265
   name: 0265 STR D1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0265
@@ -15664,6 +15993,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0264
   name: 0264 OT D3 Folh1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0264
@@ -15704,6 +16034,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0263
   name: 0263 OT D3 Folh1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0263
@@ -15742,6 +16073,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0262
   name: 0262 OT D3 Folh1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0262
@@ -15780,6 +16112,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0261
   name: 0261 PAL-STR Gaba-Chol_3
   cell_set_accession: CS20230722_SUPT_0261
@@ -15834,6 +16167,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0260
   name: 0260 PAL-STR Gaba-Chol_2
   cell_set_accession: CS20230722_SUPT_0260
@@ -15877,6 +16211,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0249
   name: 0249 NDB-SI-MA-STRv Lhx8 Gaba_6
   cell_set_accession: CS20230722_SUPT_0249
@@ -15946,6 +16281,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0248
   name: 0248 NDB-SI-MA-STRv Lhx8 Gaba_5
   cell_set_accession: CS20230722_SUPT_0248
@@ -16006,6 +16342,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0247
   name: 0247 NDB-SI-MA-STRv Lhx8 Gaba_4
   cell_set_accession: CS20230722_SUPT_0247
@@ -16052,6 +16389,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0246
   name: 0246 NDB-SI-MA-STRv Lhx8 Gaba_3
   cell_set_accession: CS20230722_SUPT_0246
@@ -16100,6 +16438,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0245
   name: 0245 NDB-SI-MA-STRv Lhx8 Gaba_2
   cell_set_accession: CS20230722_SUPT_0245
@@ -16167,6 +16506,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0255
   name: 0255 NDB-SI-MA-STRv Lhx8 Gaba_12
   cell_set_accession: CS20230722_SUPT_0255
@@ -16224,6 +16564,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0254
   name: 0254 NDB-SI-MA-STRv Lhx8 Gaba_11
   cell_set_accession: CS20230722_SUPT_0254
@@ -16261,6 +16602,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0253
   name: 0253 NDB-SI-MA-STRv Lhx8 Gaba_10
   cell_set_accession: CS20230722_SUPT_0253
@@ -16326,6 +16668,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0252
   name: 0252 NDB-SI-MA-STRv Lhx8 Gaba_9
   cell_set_accession: CS20230722_SUPT_0252
@@ -16388,6 +16731,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0251
   name: 0251 NDB-SI-MA-STRv Lhx8 Gaba_8
   cell_set_accession: CS20230722_SUPT_0251
@@ -16447,6 +16791,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0250
   name: 0250 NDB-SI-MA-STRv Lhx8 Gaba_7
   cell_set_accession: CS20230722_SUPT_0250
@@ -16504,6 +16849,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0239
   name: 0239 Sst Chodl Gaba_2
   cell_set_accession: CS20230722_SUPT_0239
@@ -16550,6 +16896,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0238
   name: 0238 Sst Chodl Gaba_1
   cell_set_accession: CS20230722_SUPT_0238
@@ -16604,6 +16951,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0237
   name: 0237 STR Lhx8 Gaba_2
   cell_set_accession: CS20230722_SUPT_0237
@@ -16654,6 +17002,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0236
   name: 0236 STR Lhx8 Gaba_1
   cell_set_accession: CS20230722_SUPT_0236
@@ -16687,6 +17036,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0235
   name: 0235 STR Prox1 Lhx6 Gaba_3
   cell_set_accession: CS20230722_SUPT_0235
@@ -16730,6 +17080,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0234
   name: 0234 STR Prox1 Lhx6 Gaba_2
   cell_set_accession: CS20230722_SUPT_0234
@@ -16763,6 +17114,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0244
   name: 0244 NDB-SI-MA-STRv Lhx8 Gaba_1
   cell_set_accession: CS20230722_SUPT_0244
@@ -16831,6 +17183,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0243
   name: 0243 Sst Chodl Gaba_6
   cell_set_accession: CS20230722_SUPT_0243
@@ -16881,6 +17234,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0242
   name: 0242 Sst Chodl Gaba_5
   cell_set_accession: CS20230722_SUPT_0242
@@ -16932,6 +17286,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0241
   name: 0241 Sst Chodl Gaba_4
   cell_set_accession: CS20230722_SUPT_0241
@@ -16970,6 +17325,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0240
   name: 0240 Sst Chodl Gaba_3
   cell_set_accession: CS20230722_SUPT_0240
@@ -17036,6 +17392,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0229
   name: 0229 Sst Gaba_16
   cell_set_accession: CS20230722_SUPT_0229
@@ -17086,6 +17443,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0228
   name: 0228 Sst Gaba_15
   cell_set_accession: CS20230722_SUPT_0228
@@ -17154,6 +17512,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0227
   name: 0227 Sst Gaba_14
   cell_set_accession: CS20230722_SUPT_0227
@@ -17188,6 +17547,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0226
   name: 0226 Sst Gaba_13
   cell_set_accession: CS20230722_SUPT_0226
@@ -17226,6 +17586,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0225
   name: 0225 Sst Gaba_12
   cell_set_accession: CS20230722_SUPT_0225
@@ -17279,6 +17640,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0224
   name: 0224 Sst Gaba_11
   cell_set_accession: CS20230722_SUPT_0224
@@ -17323,6 +17685,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0223
   name: 0223 Sst Gaba_10
   cell_set_accession: CS20230722_SUPT_0223
@@ -17368,6 +17731,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0233
   name: 0233 STR Prox1 Lhx6 Gaba_1
   cell_set_accession: CS20230722_SUPT_0233
@@ -17417,6 +17781,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0232
   name: 0232 Sst Gaba_19
   cell_set_accession: CS20230722_SUPT_0232
@@ -17492,6 +17857,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0231
   name: 0231 Sst Gaba_18
   cell_set_accession: CS20230722_SUPT_0231
@@ -17550,6 +17916,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0230
   name: 0230 Sst Gaba_17
   cell_set_accession: CS20230722_SUPT_0230
@@ -17601,6 +17968,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0289
   name: 0289 STR-PAL Chst9 Gaba_5
   cell_set_accession: CS20230722_SUPT_0289
@@ -17660,6 +18028,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0299
   name: 0299 LSX Sall3 Pax6 Gaba_1
   cell_set_accession: CS20230722_SUPT_0299
@@ -17705,6 +18074,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0298
   name: 0298 NDB-SI-ant Prdm12 Gaba_4
   cell_set_accession: CS20230722_SUPT_0298
@@ -17758,6 +18128,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0297
   name: 0297 NDB-SI-ant Prdm12 Gaba_3
   cell_set_accession: CS20230722_SUPT_0297
@@ -17821,6 +18192,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0296
   name: 0296 NDB-SI-ant Prdm12 Gaba_2
   cell_set_accession: CS20230722_SUPT_0296
@@ -17881,6 +18253,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0295
   name: 0295 NDB-SI-ant Prdm12 Gaba_1
   cell_set_accession: CS20230722_SUPT_0295
@@ -17944,6 +18317,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0294
   name: 0294 IA Mgp Gaba_5
   cell_set_accession: CS20230722_SUPT_0294
@@ -18006,6 +18380,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0293
   name: 0293 IA Mgp Gaba_4
   cell_set_accession: CS20230722_SUPT_0293
@@ -18058,6 +18433,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0292
   name: 0292 IA Mgp Gaba_3
   cell_set_accession: CS20230722_SUPT_0292
@@ -18113,6 +18489,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0291
   name: 0291 IA Mgp Gaba_2
   cell_set_accession: CS20230722_SUPT_0291
@@ -18160,6 +18537,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0290
   name: 0290 IA Mgp Gaba_1
   cell_set_accession: CS20230722_SUPT_0290
@@ -18221,6 +18599,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0279
   name: 0279 STR D2 Gaba_6
   cell_set_accession: CS20230722_SUPT_0279
@@ -18254,6 +18633,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0278
   name: 0278 STR D2 Gaba_5
   cell_set_accession: CS20230722_SUPT_0278
@@ -18299,6 +18679,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0288
   name: 0288 STR-PAL Chst9 Gaba_4
   cell_set_accession: CS20230722_SUPT_0288
@@ -18363,6 +18744,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0287
   name: 0287 STR-PAL Chst9 Gaba_3
   cell_set_accession: CS20230722_SUPT_0287
@@ -18421,6 +18803,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0286
   name: 0286 STR-PAL Chst9 Gaba_2
   cell_set_accession: CS20230722_SUPT_0286
@@ -18479,6 +18862,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0285
   name: 0285 STR-PAL Chst9 Gaba_1
   cell_set_accession: CS20230722_SUPT_0285
@@ -18547,6 +18931,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0284
   name: 0284 STR D1 Sema5a Gaba_4
   cell_set_accession: CS20230722_SUPT_0284
@@ -18604,6 +18989,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0283
   name: 0283 STR D1 Sema5a Gaba_3
   cell_set_accession: CS20230722_SUPT_0283
@@ -18666,6 +19052,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0282
   name: 0282 STR D1 Sema5a Gaba_2
   cell_set_accession: CS20230722_SUPT_0282
@@ -18714,6 +19101,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0281
   name: 0281 STR D1 Sema5a Gaba_1
   cell_set_accession: CS20230722_SUPT_0281
@@ -18744,6 +19132,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0280
   name: 0280 STR D2 Gaba_7
   cell_set_accession: CS20230722_SUPT_0280
@@ -18796,6 +19185,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0269
   name: 0269 STR D1 Gaba_5
   cell_set_accession: CS20230722_SUPT_0269
@@ -18836,6 +19226,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0268
   name: 0268 STR D1 Gaba_4
   cell_set_accession: CS20230722_SUPT_0268
@@ -18870,6 +19261,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0267
   name: 0267 STR D1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0267
@@ -18902,6 +19294,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0277
   name: 0277 STR D2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0277
@@ -18936,6 +19329,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0276
   name: 0276 STR D2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0276
@@ -18980,6 +19374,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0275
   name: 0275 STR D2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0275
@@ -19026,6 +19421,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0274
   name: 0274 STR D2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0274
@@ -19078,6 +19474,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0273
   name: 0273 STR D1 Gaba_9
   cell_set_accession: CS20230722_SUPT_0273
@@ -19113,6 +19510,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0272
   name: 0272 STR D1 Gaba_8
   cell_set_accession: CS20230722_SUPT_0272
@@ -19156,6 +19554,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0271
   name: 0271 STR D1 Gaba_7
   cell_set_accession: CS20230722_SUPT_0271
@@ -19201,6 +19600,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0270
   name: 0270 STR D1 Gaba_6
   cell_set_accession: CS20230722_SUPT_0270
@@ -19249,6 +19649,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0101
   name: 0101 CA2-FC-IG Glut_2
   cell_set_accession: CS20230722_SUPT_0101
@@ -19304,6 +19705,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0100
   name: 0100 CA2-FC-IG Glut_1
   cell_set_accession: CS20230722_SUPT_0100
@@ -19357,6 +19759,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0139
   name: 0139 DG Glut_4
   cell_set_accession: CS20230722_SUPT_0139
@@ -19412,6 +19815,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0138
   name: 0138 DG Glut_3
   cell_set_accession: CS20230722_SUPT_0138
@@ -19460,6 +19864,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0137
   name: 0137 DG Glut_2
   cell_set_accession: CS20230722_SUPT_0137
@@ -19511,6 +19916,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0136
   name: 0136 DG Glut_1
   cell_set_accession: CS20230722_SUPT_0136
@@ -19571,6 +19977,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0135
   name: 0135 HPF CR Glut_1
   cell_set_accession: CS20230722_SUPT_0135
@@ -19606,6 +20013,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0145
   name: 0145 OB Meis2 Thsd7b Gaba_3
   cell_set_accession: CS20230722_SUPT_0145
@@ -19664,6 +20072,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0144
   name: 0144 OB Meis2 Thsd7b Gaba_2
   cell_set_accession: CS20230722_SUPT_0144
@@ -19712,6 +20121,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0143
   name: 0143 OB Meis2 Thsd7b Gaba_1
   cell_set_accession: CS20230722_SUPT_0143
@@ -19762,6 +20172,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0142
   name: 0142 DG-PIR Ex IMN_3
   cell_set_accession: CS20230722_SUPT_0142
@@ -19812,6 +20223,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0141
   name: 0141 DG-PIR Ex IMN_2
   cell_set_accession: CS20230722_SUPT_0141
@@ -19864,6 +20276,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0140
   name: 0140 DG-PIR Ex IMN_1
   cell_set_accession: CS20230722_SUPT_0140
@@ -19919,6 +20332,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0129
   name: 0129 NP PPP Glut_1
   cell_set_accession: CS20230722_SUPT_0129
@@ -19964,6 +20378,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0128
   name: 0128 NP SUB Glut_2
   cell_set_accession: CS20230722_SUPT_0128
@@ -20004,6 +20419,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0127
   name: 0127 NP SUB Glut_1
   cell_set_accession: CS20230722_SUPT_0127
@@ -20054,6 +20470,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0126
   name: 0126 L5 NP CTX Glut_5
   cell_set_accession: CS20230722_SUPT_0126
@@ -20091,6 +20508,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0125
   name: 0125 L5 NP CTX Glut_4
   cell_set_accession: CS20230722_SUPT_0125
@@ -20140,6 +20558,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0124
   name: 0124 L5 NP CTX Glut_3
   cell_set_accession: CS20230722_SUPT_0124
@@ -20201,6 +20620,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0134
   name: 0134 OB Eomes Ms4a15 Glut_5
   cell_set_accession: CS20230722_SUPT_0134
@@ -20239,6 +20659,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0133
   name: 0133 OB Eomes Ms4a15 Glut_4
   cell_set_accession: CS20230722_SUPT_0133
@@ -20282,6 +20703,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0132
   name: 0132 OB Eomes Ms4a15 Glut_3
   cell_set_accession: CS20230722_SUPT_0132
@@ -20330,6 +20752,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0131
   name: 0131 OB Eomes Ms4a15 Glut_2
   cell_set_accession: CS20230722_SUPT_0131
@@ -20373,6 +20796,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0130
   name: 0130 OB Eomes Ms4a15 Glut_1
   cell_set_accession: CS20230722_SUPT_0130
@@ -20430,6 +20854,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0119
   name: 0119 L6 CT CTX Glut_6
   cell_set_accession: CS20230722_SUPT_0119
@@ -20478,6 +20903,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0118
   name: 0118 L6 CT CTX Glut_5
   cell_set_accession: CS20230722_SUPT_0118
@@ -20531,6 +20957,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0117
   name: 0117 L6 CT CTX Glut_4
   cell_set_accession: CS20230722_SUPT_0117
@@ -20573,6 +21000,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0116
   name: 0116 L6 CT CTX Glut_3
   cell_set_accession: CS20230722_SUPT_0116
@@ -20632,6 +21060,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0115
   name: 0115 L6 CT CTX Glut_2
   cell_set_accession: CS20230722_SUPT_0115
@@ -20683,6 +21112,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0114
   name: 0114 L6 CT CTX Glut_1
   cell_set_accession: CS20230722_SUPT_0114
@@ -20733,6 +21163,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0113
   name: 0113 L6b CTX Glut_4
   cell_set_accession: CS20230722_SUPT_0113
@@ -20771,6 +21202,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0123
   name: 0123 L5 NP CTX Glut_2
   cell_set_accession: CS20230722_SUPT_0123
@@ -20809,6 +21241,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0122
   name: 0122 L5 NP CTX Glut_1
   cell_set_accession: CS20230722_SUPT_0122
@@ -20849,6 +21282,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0121
   name: 0121 CT SUB Glut_2
   cell_set_accession: CS20230722_SUPT_0121
@@ -20891,6 +21325,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0120
   name: 0120 CT SUB Glut_1
   cell_set_accession: CS20230722_SUPT_0120
@@ -20933,6 +21368,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0109
   name: 0109 L6b/CT ENT Glut_4
   cell_set_accession: CS20230722_SUPT_0109
@@ -20980,6 +21416,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0108
   name: 0108 L6b/CT ENT Glut_3
   cell_set_accession: CS20230722_SUPT_0108
@@ -21032,6 +21469,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0107
   name: 0107 L6b/CT ENT Glut_2
   cell_set_accession: CS20230722_SUPT_0107
@@ -21089,6 +21527,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0106
   name: 0106 L6b/CT ENT Glut_1
   cell_set_accession: CS20230722_SUPT_0106
@@ -21136,6 +21575,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0105
   name: 0105 L6b EPd Glut_3
   cell_set_accession: CS20230722_SUPT_0105
@@ -21177,6 +21617,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0104
   name: 0104 L6b EPd Glut_2
   cell_set_accession: CS20230722_SUPT_0104
@@ -21222,6 +21663,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0103
   name: 0103 L6b EPd Glut_1
   cell_set_accession: CS20230722_SUPT_0103
@@ -21267,6 +21709,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0102
   name: 0102 NLOT Rho Glut_1
   cell_set_accession: CS20230722_SUPT_0102
@@ -21312,6 +21755,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0112
   name: 0112 L6b CTX Glut_3
   cell_set_accession: CS20230722_SUPT_0112
@@ -21354,6 +21798,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0111
   name: 0111 L6b CTX Glut_2
   cell_set_accession: CS20230722_SUPT_0111
@@ -21395,6 +21840,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0110
   name: 0110 L6b CTX Glut_1
   cell_set_accession: CS20230722_SUPT_0110
@@ -21434,6 +21880,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0179
   name: 0179 Vip Gaba_7
   cell_set_accession: CS20230722_SUPT_0179
@@ -21500,6 +21947,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0189
   name: 0189 Sncg Gaba_5
   cell_set_accession: CS20230722_SUPT_0189
@@ -21542,6 +21990,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0188
   name: 0188 Sncg Gaba_4
   cell_set_accession: CS20230722_SUPT_0188
@@ -21575,6 +22024,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0187
   name: 0187 Sncg Gaba_3
   cell_set_accession: CS20230722_SUPT_0187
@@ -21611,6 +22061,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0186
   name: 0186 Sncg Gaba_2
   cell_set_accession: CS20230722_SUPT_0186
@@ -21647,6 +22098,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0185
   name: 0185 Sncg Gaba_1
   cell_set_accession: CS20230722_SUPT_0185
@@ -21681,6 +22133,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0184
   name: 0184 Vip Gaba_12
   cell_set_accession: CS20230722_SUPT_0184
@@ -21733,6 +22186,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0183
   name: 0183 Vip Gaba_11
   cell_set_accession: CS20230722_SUPT_0183
@@ -21772,6 +22226,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0182
   name: 0182 Vip Gaba_10
   cell_set_accession: CS20230722_SUPT_0182
@@ -21824,6 +22279,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0181
   name: 0181 Vip Gaba_9
   cell_set_accession: CS20230722_SUPT_0181
@@ -21882,6 +22338,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0180
   name: 0180 Vip Gaba_8
   cell_set_accession: CS20230722_SUPT_0180
@@ -21924,6 +22381,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0169
   name: 0169 OB-STR-CTX Inh IMN_4
   cell_set_accession: CS20230722_SUPT_0169
@@ -21982,6 +22440,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0168
   name: 0168 OB-STR-CTX Inh IMN_3
   cell_set_accession: CS20230722_SUPT_0168
@@ -22047,6 +22506,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0178
   name: 0178 Vip Gaba_6
   cell_set_accession: CS20230722_SUPT_0178
@@ -22088,6 +22548,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0177
   name: 0177 Vip Gaba_5
   cell_set_accession: CS20230722_SUPT_0177
@@ -22131,6 +22592,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0176
   name: 0176 Vip Gaba_4
   cell_set_accession: CS20230722_SUPT_0176
@@ -22170,6 +22632,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0175
   name: 0175 Vip Gaba_3
   cell_set_accession: CS20230722_SUPT_0175
@@ -22212,6 +22675,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0174
   name: 0174 Vip Gaba_2
   cell_set_accession: CS20230722_SUPT_0174
@@ -22250,6 +22714,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0173
   name: 0173 Vip Gaba_1
   cell_set_accession: CS20230722_SUPT_0173
@@ -22284,6 +22749,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0172
   name: 0172 OB-STR-CTX Inh IMN_7
   cell_set_accession: CS20230722_SUPT_0172
@@ -22339,6 +22805,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0171
   name: 0171 OB-STR-CTX Inh IMN_6
   cell_set_accession: CS20230722_SUPT_0171
@@ -22377,6 +22844,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0170
   name: 0170 OB-STR-CTX Inh IMN_5
   cell_set_accession: CS20230722_SUPT_0170
@@ -22440,6 +22908,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0159
   name: 0159 OB-out Frmd7 Gaba_2
   cell_set_accession: CS20230722_SUPT_0159
@@ -22483,6 +22952,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0158
   name: 0158 OB-out Frmd7 Gaba_1
   cell_set_accession: CS20230722_SUPT_0158
@@ -22530,6 +23000,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0157
   name: 0157 OB-in Frmd7 Gaba_8
   cell_set_accession: CS20230722_SUPT_0157
@@ -22587,6 +23058,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0167
   name: 0167 OB-STR-CTX Inh IMN_2
   cell_set_accession: CS20230722_SUPT_0167
@@ -22626,6 +23098,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0166
   name: 0166 OB-STR-CTX Inh IMN_1
   cell_set_accession: CS20230722_SUPT_0166
@@ -22674,6 +23147,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0165
   name: 0165 OB Dopa-Gaba_4
   cell_set_accession: CS20230722_SUPT_0165
@@ -22724,6 +23198,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0164
   name: 0164 OB Dopa-Gaba_3
   cell_set_accession: CS20230722_SUPT_0164
@@ -22767,6 +23242,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0163
   name: 0163 OB Dopa-Gaba_2
   cell_set_accession: CS20230722_SUPT_0163
@@ -22816,6 +23292,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0162
   name: 0162 OB Dopa-Gaba_1
   cell_set_accession: CS20230722_SUPT_0162
@@ -22865,6 +23342,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0161
   name: 0161 OB-mi Frmd7 Gaba_1
   cell_set_accession: CS20230722_SUPT_0161
@@ -22912,6 +23390,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0160
   name: 0160 OB-out Frmd7 Gaba_3
   cell_set_accession: CS20230722_SUPT_0160
@@ -22965,6 +23444,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0149
   name: 0149 OB Trdn Gaba_2
   cell_set_accession: CS20230722_SUPT_0149
@@ -23015,6 +23495,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0148
   name: 0148 OB Trdn Gaba_1
   cell_set_accession: CS20230722_SUPT_0148
@@ -23070,6 +23551,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0147
   name: 0147 OB Meis2 Thsd7b Gaba_5
   cell_set_accession: CS20230722_SUPT_0147
@@ -23118,6 +23600,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0146
   name: 0146 OB Meis2 Thsd7b Gaba_4
   cell_set_accession: CS20230722_SUPT_0146
@@ -23163,6 +23646,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0156
   name: 0156 OB-in Frmd7 Gaba_7
   cell_set_accession: CS20230722_SUPT_0156
@@ -23219,6 +23703,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0155
   name: 0155 OB-in Frmd7 Gaba_6
   cell_set_accession: CS20230722_SUPT_0155
@@ -23278,6 +23763,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0154
   name: 0154 OB-in Frmd7 Gaba_5
   cell_set_accession: CS20230722_SUPT_0154
@@ -23314,6 +23800,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0153
   name: 0153 OB-in Frmd7 Gaba_4
   cell_set_accession: CS20230722_SUPT_0153
@@ -23370,6 +23857,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0152
   name: 0152 OB-in Frmd7 Gaba_3
   cell_set_accession: CS20230722_SUPT_0152
@@ -23428,6 +23916,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0151
   name: 0151 OB-in Frmd7 Gaba_2
   cell_set_accession: CS20230722_SUPT_0151
@@ -23488,6 +23977,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0150
   name: 0150 OB-in Frmd7 Gaba_1
   cell_set_accession: CS20230722_SUPT_0150
@@ -23551,6 +24041,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0199
   name: 0199 Lamp5 Gaba_1
   cell_set_accession: CS20230722_SUPT_0199
@@ -23585,6 +24076,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0198
   name: 0198 RHP-COA Ndnf Gaba_6
   cell_set_accession: CS20230722_SUPT_0198
@@ -23640,6 +24132,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0197
   name: 0197 RHP-COA Ndnf Gaba_5
   cell_set_accession: CS20230722_SUPT_0197
@@ -23695,6 +24188,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0196
   name: 0196 RHP-COA Ndnf Gaba_4
   cell_set_accession: CS20230722_SUPT_0196
@@ -23753,6 +24247,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0195
   name: 0195 RHP-COA Ndnf Gaba_3
   cell_set_accession: CS20230722_SUPT_0195
@@ -23811,6 +24306,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0194
   name: 0194 RHP-COA Ndnf Gaba_2
   cell_set_accession: CS20230722_SUPT_0194
@@ -23863,6 +24359,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0193
   name: 0193 RHP-COA Ndnf Gaba_1
   cell_set_accession: CS20230722_SUPT_0193
@@ -23918,6 +24415,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0192
   name: 0192 Sncg Gaba_8
   cell_set_accession: CS20230722_SUPT_0192
@@ -23955,6 +24453,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0191
   name: 0191 Sncg Gaba_7
   cell_set_accession: CS20230722_SUPT_0191
@@ -23987,6 +24486,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0190
   name: 0190 Sncg Gaba_6
   cell_set_accession: CS20230722_SUPT_0190
@@ -24023,6 +24523,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0419
   name: 0419 PVR Six3 Sox3 Gaba_9
   cell_set_accession: CS20230722_SUPT_0419
@@ -24089,6 +24590,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0418
   name: 0418 PVR Six3 Sox3 Gaba_8
   cell_set_accession: CS20230722_SUPT_0418
@@ -24145,6 +24647,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0417
   name: 0417 PVR Six3 Sox3 Gaba_7
   cell_set_accession: CS20230722_SUPT_0417
@@ -24201,6 +24704,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0416
   name: 0416 PVR Six3 Sox3 Gaba_6
   cell_set_accession: CS20230722_SUPT_0416
@@ -24258,6 +24762,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0415
   name: 0415 PVR Six3 Sox3 Gaba_5
   cell_set_accession: CS20230722_SUPT_0415
@@ -24311,6 +24816,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0414
   name: 0414 PVR Six3 Sox3 Gaba_4
   cell_set_accession: CS20230722_SUPT_0414
@@ -24374,6 +24880,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0413
   name: 0413 PVR Six3 Sox3 Gaba_3
   cell_set_accession: CS20230722_SUPT_0413
@@ -24435,6 +24942,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0412
   name: 0412 PVR Six3 Sox3 Gaba_2
   cell_set_accession: CS20230722_SUPT_0412
@@ -24503,6 +25011,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0411
   name: 0411 PVR Six3 Sox3 Gaba_1
   cell_set_accession: CS20230722_SUPT_0411
@@ -24566,6 +25075,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0410
   name: 0410 BST Tac2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0410
@@ -24620,6 +25130,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0420
   name: 0420 BST-MPN Six3 Nrgn Gaba_1
   cell_set_accession: CS20230722_SUPT_0420
@@ -24666,6 +25177,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0409
   name: 0409 BST Tac2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0409
@@ -24726,6 +25238,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0408
   name: 0408 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_2
   cell_set_accession: CS20230722_SUPT_0408
@@ -24783,6 +25296,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0407
   name: 0407 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_1
   cell_set_accession: CS20230722_SUPT_0407
@@ -24846,6 +25360,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0406
   name: 0406 MPO-ADP Lhx8 Gaba_5
   cell_set_accession: CS20230722_SUPT_0406
@@ -24907,6 +25422,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0405
   name: 0405 MPO-ADP Lhx8 Gaba_4
   cell_set_accession: CS20230722_SUPT_0405
@@ -24960,6 +25476,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0404
   name: 0404 MPO-ADP Lhx8 Gaba_3
   cell_set_accession: CS20230722_SUPT_0404
@@ -25016,6 +25533,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0403
   name: 0403 MPO-ADP Lhx8 Gaba_2
   cell_set_accession: CS20230722_SUPT_0403
@@ -25082,6 +25600,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0402
   name: 0402 MPO-ADP Lhx8 Gaba_1
   cell_set_accession: CS20230722_SUPT_0402
@@ -25136,6 +25655,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0401
   name: 0401 SI-MPO-LPO Lhx8 Gaba_6
   cell_set_accession: CS20230722_SUPT_0401
@@ -25164,6 +25684,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0400
   name: 0400 SI-MPO-LPO Lhx8 Gaba_5
   cell_set_accession: CS20230722_SUPT_0400
@@ -25220,6 +25741,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0459
   name: 0459 ZI Pax6 Gaba_1
   cell_set_accession: CS20230722_SUPT_0459
@@ -25279,6 +25801,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0458
   name: 0458 AHN Onecut3 Gaba_3
   cell_set_accession: CS20230722_SUPT_0458
@@ -25340,6 +25863,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0457
   name: 0457 AHN Onecut3 Gaba_2
   cell_set_accession: CS20230722_SUPT_0457
@@ -25391,6 +25915,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0456
   name: 0456 AHN Onecut3 Gaba_1
   cell_set_accession: CS20230722_SUPT_0456
@@ -25444,6 +25969,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0455
   name: 0455 SBPV-PVa Six6 Satb2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0455
@@ -25512,6 +26038,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0454
   name: 0454 SBPV-PVa Six6 Satb2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0454
@@ -25575,6 +26102,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0464
   name: 0464 ZI Pax6 Gaba_6
   cell_set_accession: CS20230722_SUPT_0464
@@ -25629,6 +26157,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0463
   name: 0463 ZI Pax6 Gaba_5
   cell_set_accession: CS20230722_SUPT_0463
@@ -25665,6 +26194,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0462
   name: 0462 ZI Pax6 Gaba_4
   cell_set_accession: CS20230722_SUPT_0462
@@ -25708,6 +26238,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0461
   name: 0461 ZI Pax6 Gaba_3
   cell_set_accession: CS20230722_SUPT_0461
@@ -25763,6 +26294,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0460
   name: 0460 ZI Pax6 Gaba_2
   cell_set_accession: CS20230722_SUPT_0460
@@ -25813,6 +26345,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0449
   name: 0449 AHN-SBPV-PVHd Pdrm12 Gaba_4
   cell_set_accession: CS20230722_SUPT_0449
@@ -25859,6 +26392,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0448
   name: 0448 AHN-SBPV-PVHd Pdrm12 Gaba_3
   cell_set_accession: CS20230722_SUPT_0448
@@ -25914,6 +26448,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0447
   name: 0447 AHN-SBPV-PVHd Pdrm12 Gaba_2
   cell_set_accession: CS20230722_SUPT_0447
@@ -25965,6 +26500,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0446
   name: 0446 AHN-SBPV-PVHd Pdrm12 Gaba_1
   cell_set_accession: CS20230722_SUPT_0446
@@ -26018,6 +26554,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0445
   name: 0445 PVHd-SBPV Six3 Prox1 Gaba_4
   cell_set_accession: CS20230722_SUPT_0445
@@ -26078,6 +26615,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0444
   name: 0444 PVHd-SBPV Six3 Prox1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0444
@@ -26133,6 +26671,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0443
   name: 0443 PVHd-SBPV Six3 Prox1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0443
@@ -26177,6 +26716,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0453
   name: 0453 SBPV-PVa Six6 Satb2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0453
@@ -26230,6 +26770,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0452
   name: 0452 AHN-SBPV-PVHd Pdrm12 Gaba_7
   cell_set_accession: CS20230722_SUPT_0452
@@ -26283,6 +26824,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0451
   name: 0451 AHN-SBPV-PVHd Pdrm12 Gaba_6
   cell_set_accession: CS20230722_SUPT_0451
@@ -26334,6 +26876,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0450
   name: 0450 AHN-SBPV-PVHd Pdrm12 Gaba_5
   cell_set_accession: CS20230722_SUPT_0450
@@ -26376,6 +26919,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0439
   name: 0439 DMH Prdm13 Gaba_1
   cell_set_accession: CS20230722_SUPT_0439
@@ -26411,6 +26955,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0438
   name: 0438 SCH Six6 Cdc14a Gaba_3
   cell_set_accession: CS20230722_SUPT_0438
@@ -26456,6 +27001,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0437
   name: 0437 SCH Six6 Cdc14a Gaba_2
   cell_set_accession: CS20230722_SUPT_0437
@@ -26500,6 +27046,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0436
   name: 0436 SCH Six6 Cdc14a Gaba_1
   cell_set_accession: CS20230722_SUPT_0436
@@ -26554,6 +27101,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0435
   name: 0435 RT-ZI Gnb3 Gaba_5
   cell_set_accession: CS20230722_SUPT_0435
@@ -26590,6 +27138,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0434
   name: 0434 RT-ZI Gnb3 Gaba_4
   cell_set_accession: CS20230722_SUPT_0434
@@ -26646,6 +27195,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0433
   name: 0433 RT-ZI Gnb3 Gaba_3
   cell_set_accession: CS20230722_SUPT_0433
@@ -26682,6 +27232,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0432
   name: 0432 RT-ZI Gnb3 Gaba_2
   cell_set_accession: CS20230722_SUPT_0432
@@ -26720,6 +27271,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0442
   name: 0442 PVHd-SBPV Six3 Prox1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0442
@@ -26785,6 +27337,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0441
   name: 0441 PVHd Gsc Gaba_1
   cell_set_accession: CS20230722_SUPT_0441
@@ -26830,6 +27383,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0440
   name: 0440 DMH Prdm13 Gaba_2
   cell_set_accession: CS20230722_SUPT_0440
@@ -26867,6 +27421,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0429
   name: 0429 TMv-PMv Tbx3 Hist-Gaba_1
   cell_set_accession: CS20230722_SUPT_0429
@@ -26910,6 +27465,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0428
   name: 0428 ARH-PVi Six6 Dopa-Gaba_2
   cell_set_accession: CS20230722_SUPT_0428
@@ -26971,6 +27527,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0427
   name: 0427 ARH-PVi Six6 Dopa-Gaba_1
   cell_set_accession: CS20230722_SUPT_0427
@@ -27019,6 +27576,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0426
   name: 0426 BST-MPN Six3 Nrgn Gaba_7
   cell_set_accession: CS20230722_SUPT_0426
@@ -27066,6 +27624,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0425
   name: 0425 BST-MPN Six3 Nrgn Gaba_6
   cell_set_accession: CS20230722_SUPT_0425
@@ -27124,6 +27683,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0424
   name: 0424 BST-MPN Six3 Nrgn Gaba_5
   cell_set_accession: CS20230722_SUPT_0424
@@ -27184,6 +27744,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0423
   name: 0423 BST-MPN Six3 Nrgn Gaba_4
   cell_set_accession: CS20230722_SUPT_0423
@@ -27238,6 +27799,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0422
   name: 0422 BST-MPN Six3 Nrgn Gaba_3
   cell_set_accession: CS20230722_SUPT_0422
@@ -27286,6 +27848,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0421
   name: 0421 BST-MPN Six3 Nrgn Gaba_2
   cell_set_accession: CS20230722_SUPT_0421
@@ -27344,6 +27907,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0431
   name: 0431 RT-ZI Gnb3 Gaba_1
   cell_set_accession: CS20230722_SUPT_0431
@@ -27387,6 +27951,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0430
   name: 0430 TMv-PMv Tbx3 Hist-Gaba_2
   cell_set_accession: CS20230722_SUPT_0430
@@ -27445,6 +28010,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0499
   name: 0499 LGv-ZI Otx2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0499
@@ -27491,6 +28057,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0498
   name: 0498 LGv-ZI Otx2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0498
@@ -27531,6 +28098,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0489
   name: 0489 DMH Hmx2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0489
@@ -27581,6 +28149,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0488
   name: 0488 DMH Hmx2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0488
@@ -27659,6 +28228,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0487
   name: 0487 DMH Hmx2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0487
@@ -27707,6 +28277,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0497
   name: 0497 LGv-ZI Otx2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0497
@@ -27756,6 +28327,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0496
   name: 0496 LGv-ZI Otx2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0496
@@ -27812,6 +28384,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0495
   name: 0495 ARH-PVp Tbx3 Gaba_3
   cell_set_accession: CS20230722_SUPT_0495
@@ -27854,6 +28427,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0494
   name: 0494 ARH-PVp Tbx3 Gaba_2
   cell_set_accession: CS20230722_SUPT_0494
@@ -27903,6 +28477,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0493
   name: 0493 ARH-PVp Tbx3 Gaba_1
   cell_set_accession: CS20230722_SUPT_0493
@@ -27945,6 +28520,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0492
   name: 0492 DMH Hmx2 Gaba_6
   cell_set_accession: CS20230722_SUPT_0492
@@ -27992,6 +28568,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0491
   name: 0491 DMH Hmx2 Gaba_5
   cell_set_accession: CS20230722_SUPT_0491
@@ -28045,6 +28622,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0490
   name: 0490 DMH Hmx2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0490
@@ -28091,6 +28669,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0479
   name: 0479 TU-ARH Otp Six6 Gaba_2
   cell_set_accession: CS20230722_SUPT_0479
@@ -28152,6 +28731,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0478
   name: 0478 TU-ARH Otp Six6 Gaba_1
   cell_set_accession: CS20230722_SUPT_0478
@@ -28203,6 +28783,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0477
   name: 0477 PVHd-DMH Lhx6 Gaba_4
   cell_set_accession: CS20230722_SUPT_0477
@@ -28247,6 +28828,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0476
   name: 0476 PVHd-DMH Lhx6 Gaba_3
   cell_set_accession: CS20230722_SUPT_0476
@@ -28298,6 +28880,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0486
   name: 0486 PVpo-VMPO-MPN Hmx2 Gaba_5
   cell_set_accession: CS20230722_SUPT_0486
@@ -28351,6 +28934,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0485
   name: 0485 PVpo-VMPO-MPN Hmx2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0485
@@ -28402,6 +28986,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0484
   name: 0484 PVpo-VMPO-MPN Hmx2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0484
@@ -28458,6 +29043,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0483
   name: 0483 PVpo-VMPO-MPN Hmx2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0483
@@ -28521,6 +29107,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0482
   name: 0482 PVpo-VMPO-MPN Hmx2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0482
@@ -28594,6 +29181,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0481
   name: 0481 TMd-DMH Foxd2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0481
@@ -28646,6 +29234,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0480
   name: 0480 TU-ARH Otp Six6 Gaba_3
   cell_set_accession: CS20230722_SUPT_0480
@@ -28705,6 +29294,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0469
   name: 0469 ZI Pax6 Gaba_11
   cell_set_accession: CS20230722_SUPT_0469
@@ -28756,6 +29346,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0468
   name: 0468 ZI Pax6 Gaba_10
   cell_set_accession: CS20230722_SUPT_0468
@@ -28810,6 +29401,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0467
   name: 0467 ZI Pax6 Gaba_9
   cell_set_accession: CS20230722_SUPT_0467
@@ -28862,6 +29454,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0466
   name: 0466 ZI Pax6 Gaba_8
   cell_set_accession: CS20230722_SUPT_0466
@@ -28908,6 +29501,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0465
   name: 0465 ZI Pax6 Gaba_7
   cell_set_accession: CS20230722_SUPT_0465
@@ -28961,6 +29555,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0475
   name: 0475 PVHd-DMH Lhx6 Gaba_2
   cell_set_accession: CS20230722_SUPT_0475
@@ -29011,6 +29606,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0474
   name: 0474 PVHd-DMH Lhx6 Gaba_1
   cell_set_accession: CS20230722_SUPT_0474
@@ -29060,6 +29656,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0473
   name: 0473 DMH-LHA Gsx1 Gaba_4
   cell_set_accession: CS20230722_SUPT_0473
@@ -29100,6 +29697,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0472
   name: 0472 DMH-LHA Gsx1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0472
@@ -29148,6 +29746,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0471
   name: 0471 DMH-LHA Gsx1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0471
@@ -29201,6 +29800,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0470
   name: 0470 DMH-LHA Gsx1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0470
@@ -29259,6 +29859,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0339
   name: 0339 MEA-BST Sox6 Gaba_3
   cell_set_accession: CS20230722_SUPT_0339
@@ -29317,6 +29918,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0338
   name: 0338 MEA-BST Sox6 Gaba_2
   cell_set_accession: CS20230722_SUPT_0338
@@ -29374,6 +29976,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0337
   name: 0337 MEA-BST Sox6 Gaba_1
   cell_set_accession: CS20230722_SUPT_0337
@@ -29422,6 +30025,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0336
   name: 0336 LSX Sall3 Lmo1 Gaba_6
   cell_set_accession: CS20230722_SUPT_0336
@@ -29471,6 +30075,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0335
   name: 0335 LSX Sall3 Lmo1 Gaba_5
   cell_set_accession: CS20230722_SUPT_0335
@@ -29515,6 +30120,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0334
   name: 0334 LSX Sall3 Lmo1 Gaba_4
   cell_set_accession: CS20230722_SUPT_0334
@@ -29548,6 +30154,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0333
   name: 0333 LSX Sall3 Lmo1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0333
@@ -29603,6 +30210,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0343
   name: 0343 MEA-BST Sox6 Gaba_7
   cell_set_accession: CS20230722_SUPT_0343
@@ -29645,6 +30253,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0342
   name: 0342 MEA-BST Sox6 Gaba_6
   cell_set_accession: CS20230722_SUPT_0342
@@ -29693,6 +30302,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0341
   name: 0341 MEA-BST Sox6 Gaba_5
   cell_set_accession: CS20230722_SUPT_0341
@@ -29745,6 +30355,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0340
   name: 0340 MEA-BST Sox6 Gaba_4
   cell_set_accession: CS20230722_SUPT_0340
@@ -29799,6 +30410,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0329
   name: 0329 LSX Prdm12 Zeb2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0329
@@ -29836,6 +30448,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0328
   name: 0328 LSX Prdm12 Zeb2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0328
@@ -29886,6 +30499,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0327
   name: 0327 LSX Prdm12 Zeb2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0327
@@ -29928,6 +30542,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0326
   name: 0326 LSX Prdm12 Zeb2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0326
@@ -29971,6 +30586,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0325
   name: 0325 LSX Prdm12 Slit2 Gaba_9
   cell_set_accession: CS20230722_SUPT_0325
@@ -30018,6 +30634,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0324
   name: 0324 LSX Prdm12 Slit2 Gaba_8
   cell_set_accession: CS20230722_SUPT_0324
@@ -30068,6 +30685,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0323
   name: 0323 LSX Prdm12 Slit2 Gaba_7
   cell_set_accession: CS20230722_SUPT_0323
@@ -30107,6 +30725,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0322
   name: 0322 LSX Prdm12 Slit2 Gaba_6
   cell_set_accession: CS20230722_SUPT_0322
@@ -30155,6 +30774,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0332
   name: 0332 LSX Sall3 Lmo1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0332
@@ -30196,6 +30816,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0331
   name: 0331 LSX Sall3 Lmo1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0331
@@ -30242,6 +30863,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0330
   name: 0330 LSX Prdm12 Zeb2 Gaba_5
   cell_set_accession: CS20230722_SUPT_0330
@@ -30281,6 +30903,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0319
   name: 0319 LSX Prdm12 Slit2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0319
@@ -30324,6 +30947,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0318
   name: 0318 LSX Prdm12 Slit2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0318
@@ -30369,6 +30993,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0317
   name: 0317 LSX Prdm12 Slit2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0317
@@ -30412,6 +31037,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0316
   name: 0316 LSX Nkx2-1 Gaba_11
   cell_set_accession: CS20230722_SUPT_0316
@@ -30459,6 +31085,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0315
   name: 0315 LSX Nkx2-1 Gaba_10
   cell_set_accession: CS20230722_SUPT_0315
@@ -30496,6 +31123,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0314
   name: 0314 LSX Nkx2-1 Gaba_9
   cell_set_accession: CS20230722_SUPT_0314
@@ -30537,6 +31165,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0313
   name: 0313 LSX Nkx2-1 Gaba_8
   cell_set_accession: CS20230722_SUPT_0313
@@ -30583,6 +31212,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0312
   name: 0312 LSX Nkx2-1 Gaba_7
   cell_set_accession: CS20230722_SUPT_0312
@@ -30622,6 +31252,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0311
   name: 0311 LSX Nkx2-1 Gaba_6
   cell_set_accession: CS20230722_SUPT_0311
@@ -30672,6 +31303,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0321
   name: 0321 LSX Prdm12 Slit2 Gaba_5
   cell_set_accession: CS20230722_SUPT_0321
@@ -30715,6 +31347,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0320
   name: 0320 LSX Prdm12 Slit2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0320
@@ -30760,6 +31393,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0309
   name: 0309 LSX Nkx2-1 Gaba_4
   cell_set_accession: CS20230722_SUPT_0309
@@ -30807,6 +31441,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0308
   name: 0308 LSX Nkx2-1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0308
@@ -30855,6 +31490,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0307
   name: 0307 LSX Nkx2-1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0307
@@ -30898,6 +31534,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0306
   name: 0306 LSX Nkx2-1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0306
@@ -30948,6 +31585,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0305
   name: 0305 LSX Otx2 Gaba_5
   cell_set_accession: CS20230722_SUPT_0305
@@ -30995,6 +31633,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0304
   name: 0304 LSX Otx2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0304
@@ -31034,6 +31673,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0303
   name: 0303 LSX Otx2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0303
@@ -31077,6 +31717,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0302
   name: 0302 LSX Otx2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0302
@@ -31125,6 +31766,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0301
   name: 0301 LSX Otx2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0301
@@ -31166,6 +31808,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0300
   name: 0300 LSX Sall3 Pax6 Gaba_2
   cell_set_accession: CS20230722_SUPT_0300
@@ -31209,6 +31852,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0310
   name: 0310 LSX Nkx2-1 Gaba_5
   cell_set_accession: CS20230722_SUPT_0310
@@ -31254,6 +31898,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0379
   name: 0379 CEA-AAA-BST Six3 Sp9 Gaba_7
   cell_set_accession: CS20230722_SUPT_0379
@@ -31305,6 +31950,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0378
   name: 0378 CEA-AAA-BST Six3 Sp9 Gaba_6
   cell_set_accession: CS20230722_SUPT_0378
@@ -31368,6 +32014,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0377
   name: 0377 CEA-AAA-BST Six3 Sp9 Gaba_5
   cell_set_accession: CS20230722_SUPT_0377
@@ -31427,6 +32074,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0387
   name: 0387 CEA-BST Ebf1 Pdyn Gaba_4
   cell_set_accession: CS20230722_SUPT_0387
@@ -31488,6 +32136,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0386
   name: 0386 CEA-BST Ebf1 Pdyn Gaba_3
   cell_set_accession: CS20230722_SUPT_0386
@@ -31545,6 +32194,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0385
   name: 0385 CEA-BST Ebf1 Pdyn Gaba_2
   cell_set_accession: CS20230722_SUPT_0385
@@ -31602,6 +32252,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0384
   name: 0384 CEA-BST Ebf1 Pdyn Gaba_1
   cell_set_accession: CS20230722_SUPT_0384
@@ -31674,6 +32325,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0383
   name: 0383 ACB-BST-FS D1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0383
@@ -31723,6 +32375,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0382
   name: 0382 ACB-BST-FS D1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0382
@@ -31781,6 +32434,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0381
   name: 0381 ACB-BST-FS D1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0381
@@ -31829,6 +32483,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0380
   name: 0380 CEA-AAA-BST Six3 Sp9 Gaba_8
   cell_set_accession: CS20230722_SUPT_0380
@@ -31895,6 +32550,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0369
   name: 0369 CEA-BST Six3 Cyp26b1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0369
@@ -31951,6 +32607,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0368
   name: 0368 CEA-BST Six3 Cyp26b1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0368
@@ -32001,6 +32658,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0367
   name: 0367 CEA-BST Six3 Cyp26b1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0367
@@ -32052,6 +32710,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0366
   name: 0366 SI-MA-ACB Ebf1 Bnc2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0366
@@ -32107,6 +32766,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0376
   name: 0376 CEA-AAA-BST Six3 Sp9 Gaba_4
   cell_set_accession: CS20230722_SUPT_0376
@@ -32170,6 +32830,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0375
   name: 0375 CEA-AAA-BST Six3 Sp9 Gaba_3
   cell_set_accession: CS20230722_SUPT_0375
@@ -32216,6 +32877,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0374
   name: 0374 CEA-AAA-BST Six3 Sp9 Gaba_2
   cell_set_accession: CS20230722_SUPT_0374
@@ -32283,6 +32945,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0373
   name: 0373 CEA-AAA-BST Six3 Sp9 Gaba_1
   cell_set_accession: CS20230722_SUPT_0373
@@ -32341,6 +33004,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0372
   name: 0372 CEA-BST Six3 Cyp26b1 Gaba_6
   cell_set_accession: CS20230722_SUPT_0372
@@ -32389,6 +33053,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0371
   name: 0371 CEA-BST Six3 Cyp26b1 Gaba_5
   cell_set_accession: CS20230722_SUPT_0371
@@ -32450,6 +33115,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0370
   name: 0370 CEA-BST Six3 Cyp26b1 Gaba_4
   cell_set_accession: CS20230722_SUPT_0370
@@ -32494,6 +33160,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0359
   name: 0359 MEA-BST Lhx6 Nfib Gaba_3
   cell_set_accession: CS20230722_SUPT_0359
@@ -32533,6 +33200,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0358
   name: 0358 MEA-BST Lhx6 Nfib Gaba_2
   cell_set_accession: CS20230722_SUPT_0358
@@ -32574,6 +33242,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0357
   name: 0357 MEA-BST Lhx6 Nfib Gaba_1
   cell_set_accession: CS20230722_SUPT_0357
@@ -32635,6 +33304,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0356
   name: 0356 MEA-BST Lhx6 Nr2e1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0356
@@ -32690,6 +33360,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0355
   name: 0355 MEA-BST Lhx6 Nr2e1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0355
@@ -32742,6 +33413,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0365
   name: 0365 SI-MA-ACB Ebf1 Bnc2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0365
@@ -32790,6 +33462,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0364
   name: 0364 SI-MA-ACB Ebf1 Bnc2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0364
@@ -32834,6 +33507,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0363
   name: 0363 CEA-BST Gal Avp Gaba_1
   cell_set_accession: CS20230722_SUPT_0363
@@ -32869,6 +33543,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0362
   name: 0362 MEA-BST Lhx6 Nfib Gaba_6
   cell_set_accession: CS20230722_SUPT_0362
@@ -32922,6 +33597,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0361
   name: 0361 MEA-BST Lhx6 Nfib Gaba_5
   cell_set_accession: CS20230722_SUPT_0361
@@ -32975,6 +33651,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0360
   name: 0360 MEA-BST Lhx6 Nfib Gaba_4
   cell_set_accession: CS20230722_SUPT_0360
@@ -33031,6 +33708,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0349
   name: 0349 MEA-BST Lhx6 Sp9 Gaba_3
   cell_set_accession: CS20230722_SUPT_0349
@@ -33079,6 +33757,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0348
   name: 0348 MEA-BST Lhx6 Sp9 Gaba_2
   cell_set_accession: CS20230722_SUPT_0348
@@ -33143,6 +33822,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0347
   name: 0347 MEA-BST Lhx6 Sp9 Gaba_1
   cell_set_accession: CS20230722_SUPT_0347
@@ -33191,6 +33871,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0346
   name: 0346 MEA-BST Sox6 Gaba_10
   cell_set_accession: CS20230722_SUPT_0346
@@ -33253,6 +33934,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0345
   name: 0345 MEA-BST Sox6 Gaba_9
   cell_set_accession: CS20230722_SUPT_0345
@@ -33295,6 +33977,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0344
   name: 0344 MEA-BST Sox6 Gaba_8
   cell_set_accession: CS20230722_SUPT_0344
@@ -33334,6 +34017,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0354
   name: 0354 MEA-BST Lhx6 Nr2e1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0354
@@ -33376,6 +34060,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0353
   name: 0353 MEA-BST Lhx6 Sp9 Gaba_7
   cell_set_accession: CS20230722_SUPT_0353
@@ -33431,6 +34116,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0352
   name: 0352 MEA-BST Lhx6 Sp9 Gaba_6
   cell_set_accession: CS20230722_SUPT_0352
@@ -33482,6 +34168,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0351
   name: 0351 MEA-BST Lhx6 Sp9 Gaba_5
   cell_set_accession: CS20230722_SUPT_0351
@@ -33533,6 +34220,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0350
   name: 0350 MEA-BST Lhx6 Sp9 Gaba_4
   cell_set_accession: CS20230722_SUPT_0350
@@ -33578,6 +34266,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0399
   name: 0399 SI-MPO-LPO Lhx8 Gaba_4
   cell_set_accession: CS20230722_SUPT_0399
@@ -33644,6 +34333,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0389
   name: 0389 CEA-BST Ebf1 Pdyn Gaba_6
   cell_set_accession: CS20230722_SUPT_0389
@@ -33694,6 +34384,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0388
   name: 0388 CEA-BST Ebf1 Pdyn Gaba_5
   cell_set_accession: CS20230722_SUPT_0388
@@ -33755,6 +34446,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0398
   name: 0398 SI-MPO-LPO Lhx8 Gaba_3
   cell_set_accession: CS20230722_SUPT_0398
@@ -33805,6 +34497,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0397
   name: 0397 SI-MPO-LPO Lhx8 Gaba_2
   cell_set_accession: CS20230722_SUPT_0397
@@ -33883,6 +34576,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0396
   name: 0396 SI-MPO-LPO Lhx8 Gaba_1
   cell_set_accession: CS20230722_SUPT_0396
@@ -33941,6 +34635,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0395
   name: 0395 BST-SI-AAA Six3 Slc22a3 Gaba_2
   cell_set_accession: CS20230722_SUPT_0395
@@ -34020,6 +34715,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0394
   name: 0394 BST-SI-AAA Six3 Slc22a3 Gaba_1
   cell_set_accession: CS20230722_SUPT_0394
@@ -34089,6 +34785,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0393
   name: 0393 CEA-BST Rai14 Pdyn Crh Gaba_2
   cell_set_accession: CS20230722_SUPT_0393
@@ -34134,6 +34831,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0392
   name: 0392 CEA-BST Rai14 Pdyn Crh Gaba_1
   cell_set_accession: CS20230722_SUPT_0392
@@ -34177,6 +34875,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0391
   name: 0391 CEA-BST Ebf1 Pdyn Gaba_8
   cell_set_accession: CS20230722_SUPT_0391
@@ -34229,6 +34928,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0390
   name: 0390 CEA-BST Ebf1 Pdyn Gaba_7
   cell_set_accession: CS20230722_SUPT_0390
@@ -34284,6 +34984,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0619
   name: 0619 PMd-LHA Foxb1 Glut_1
   cell_set_accession: CS20230722_SUPT_0619
@@ -34329,6 +35030,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0618
   name: 0618 PH-LHA Foxb1 Glut_7
   cell_set_accession: CS20230722_SUPT_0618
@@ -34364,6 +35066,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0617
   name: 0617 PH-LHA Foxb1 Glut_6
   cell_set_accession: CS20230722_SUPT_0617
@@ -34412,6 +35115,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0616
   name: 0616 PH-LHA Foxb1 Glut_5
   cell_set_accession: CS20230722_SUPT_0616
@@ -34454,6 +35158,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0615
   name: 0615 PH-LHA Foxb1 Glut_4
   cell_set_accession: CS20230722_SUPT_0615
@@ -34508,6 +35213,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0614
   name: 0614 PH-LHA Foxb1 Glut_3
   cell_set_accession: CS20230722_SUPT_0614
@@ -34546,6 +35252,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0613
   name: 0613 PH-LHA Foxb1 Glut_2
   cell_set_accession: CS20230722_SUPT_0613
@@ -34584,6 +35291,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0612
   name: 0612 PH-LHA Foxb1 Glut_1
   cell_set_accession: CS20230722_SUPT_0612
@@ -34639,6 +35347,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0611
   name: 0611 PH Pitx2 Glut_2
   cell_set_accession: CS20230722_SUPT_0611
@@ -34687,6 +35396,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0610
   name: 0610 PH Pitx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0610
@@ -34731,6 +35441,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0609
   name: 0609 PH-an Pitx2 Glut_2
   cell_set_accession: CS20230722_SUPT_0609
@@ -34769,6 +35480,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0608
   name: 0608 PH-an Pitx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0608
@@ -34812,6 +35524,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0607
   name: 0607 PMv-TMv Pitx2 Glut_3
   cell_set_accession: CS20230722_SUPT_0607
@@ -34858,6 +35571,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0606
   name: 0606 PMv-TMv Pitx2 Glut_2
   cell_set_accession: CS20230722_SUPT_0606
@@ -34903,6 +35617,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0605
   name: 0605 PMv-TMv Pitx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0605
@@ -34961,6 +35676,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0604
   name: 0604 STN-PSTN Pitx2 Glut_7
   cell_set_accession: CS20230722_SUPT_0604
@@ -35014,6 +35730,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0603
   name: 0603 STN-PSTN Pitx2 Glut_6
   cell_set_accession: CS20230722_SUPT_0603
@@ -35080,6 +35797,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0602
   name: 0602 STN-PSTN Pitx2 Glut_5
   cell_set_accession: CS20230722_SUPT_0602
@@ -35136,6 +35854,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0601
   name: 0601 STN-PSTN Pitx2 Glut_4
   cell_set_accession: CS20230722_SUPT_0601
@@ -35175,6 +35894,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0600
   name: 0600 STN-PSTN Pitx2 Glut_3
   cell_set_accession: CS20230722_SUPT_0600
@@ -35226,6 +35946,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0659
   name: 0659 TH Prkcd Grin2c Glut_6
   cell_set_accession: CS20230722_SUPT_0659
@@ -35281,6 +36002,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0658
   name: 0658 TH Prkcd Grin2c Glut_5
   cell_set_accession: CS20230722_SUPT_0658
@@ -35326,6 +36048,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0657
   name: 0657 TH Prkcd Grin2c Glut_4
   cell_set_accession: CS20230722_SUPT_0657
@@ -35371,6 +36094,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0656
   name: 0656 TH Prkcd Grin2c Glut_3
   cell_set_accession: CS20230722_SUPT_0656
@@ -35431,6 +36155,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0655
   name: 0655 TH Prkcd Grin2c Glut_2
   cell_set_accession: CS20230722_SUPT_0655
@@ -35480,6 +36205,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0654
   name: 0654 TH Prkcd Grin2c Glut_1
   cell_set_accession: CS20230722_SUPT_0654
@@ -35527,6 +36253,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0653
   name: 0653 CM-IAD-CL-PCN Sema5b Glut_5
   cell_set_accession: CS20230722_SUPT_0653
@@ -35569,6 +36296,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0652
   name: 0652 CM-IAD-CL-PCN Sema5b Glut_4
   cell_set_accession: CS20230722_SUPT_0652
@@ -35622,6 +36350,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0662
   name: 0662 TH Prkcd Grin2c Glut_9
   cell_set_accession: CS20230722_SUPT_0662
@@ -35669,6 +36398,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0661
   name: 0661 TH Prkcd Grin2c Glut_8
   cell_set_accession: CS20230722_SUPT_0661
@@ -35739,6 +36469,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0660
   name: 0660 TH Prkcd Grin2c Glut_7
   cell_set_accession: CS20230722_SUPT_0660
@@ -35787,6 +36518,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0649
   name: 0649 CM-IAD-CL-PCN Sema5b Glut_1
   cell_set_accession: CS20230722_SUPT_0649
@@ -35837,6 +36569,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0648
   name: 0648 PVT-PT Ntrk1 Glut_6
   cell_set_accession: CS20230722_SUPT_0648
@@ -35882,6 +36615,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0647
   name: 0647 PVT-PT Ntrk1 Glut_5
   cell_set_accession: CS20230722_SUPT_0647
@@ -35930,6 +36664,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0646
   name: 0646 PVT-PT Ntrk1 Glut_4
   cell_set_accession: CS20230722_SUPT_0646
@@ -35994,6 +36729,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0645
   name: 0645 PVT-PT Ntrk1 Glut_3
   cell_set_accession: CS20230722_SUPT_0645
@@ -36038,6 +36774,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0644
   name: 0644 PVT-PT Ntrk1 Glut_2
   cell_set_accession: CS20230722_SUPT_0644
@@ -36083,6 +36820,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0643
   name: 0643 PVT-PT Ntrk1 Glut_1
   cell_set_accession: CS20230722_SUPT_0643
@@ -36131,6 +36869,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0642
   name: 0642 AV Col27a1 Glut_1
   cell_set_accession: CS20230722_SUPT_0642
@@ -36168,6 +36907,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0641
   name: 0641 AD Serpinb7 Glut_1
   cell_set_accession: CS20230722_SUPT_0641
@@ -36203,6 +36943,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0651
   name: 0651 CM-IAD-CL-PCN Sema5b Glut_3
   cell_set_accession: CS20230722_SUPT_0651
@@ -36255,6 +36996,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0650
   name: 0650 CM-IAD-CL-PCN Sema5b Glut_2
   cell_set_accession: CS20230722_SUPT_0650
@@ -36304,6 +37046,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0639
   name: 0639 LH Pou4f1 Sox1 Glut_3
   cell_set_accession: CS20230722_SUPT_0639
@@ -36336,6 +37079,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0638
   name: 0638 LH Pou4f1 Sox1 Glut_2
   cell_set_accession: CS20230722_SUPT_0638
@@ -36379,6 +37123,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0637
   name: 0637 LH Pou4f1 Sox1 Glut_1
   cell_set_accession: CS20230722_SUPT_0637
@@ -36421,6 +37166,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0636
   name: 0636 MH Tac2 Glut_5
   cell_set_accession: CS20230722_SUPT_0636
@@ -36454,6 +37200,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0635
   name: 0635 MH Tac2 Glut_4
   cell_set_accession: CS20230722_SUPT_0635
@@ -36486,6 +37233,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0634
   name: 0634 MH Tac2 Glut_3
   cell_set_accession: CS20230722_SUPT_0634
@@ -36522,6 +37270,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0633
   name: 0633 MH Tac2 Glut_2
   cell_set_accession: CS20230722_SUPT_0633
@@ -36552,6 +37301,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0632
   name: 0632 MH Tac2 Glut_1
   cell_set_accession: CS20230722_SUPT_0632
@@ -36591,6 +37341,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0631
   name: 0631 MM Foxb1 Glut_2
   cell_set_accession: CS20230722_SUPT_0631
@@ -36636,6 +37387,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0630
   name: 0630 MM Foxb1 Glut_1
   cell_set_accession: CS20230722_SUPT_0630
@@ -36681,6 +37433,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0640
   name: 0640 LH Pou4f1 Sox1 Glut_4
   cell_set_accession: CS20230722_SUPT_0640
@@ -36720,6 +37473,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0629
   name: 0629 MM-ant Foxb1 Glut_1
   cell_set_accession: CS20230722_SUPT_0629
@@ -36782,6 +37536,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0628
   name: 0628 HY Gnrh1 Glut_1
   cell_set_accession: CS20230722_SUPT_0628
@@ -36823,6 +37578,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0627
   name: 0627 PH-SUM Foxa1 Glut_6
   cell_set_accession: CS20230722_SUPT_0627
@@ -36874,6 +37630,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0626
   name: 0626 PH-SUM Foxa1 Glut_5
   cell_set_accession: CS20230722_SUPT_0626
@@ -36938,6 +37695,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0625
   name: 0625 PH-SUM Foxa1 Glut_4
   cell_set_accession: CS20230722_SUPT_0625
@@ -36980,6 +37738,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0624
   name: 0624 PH-SUM Foxa1 Glut_3
   cell_set_accession: CS20230722_SUPT_0624
@@ -37028,6 +37787,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0623
   name: 0623 PH-SUM Foxa1 Glut_2
   cell_set_accession: CS20230722_SUPT_0623
@@ -37080,6 +37840,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0622
   name: 0622 PH-SUM Foxa1 Glut_1
   cell_set_accession: CS20230722_SUPT_0622
@@ -37129,6 +37890,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0621
   name: 0621 PMd-LHA Foxb1 Glut_3
   cell_set_accession: CS20230722_SUPT_0621
@@ -37174,6 +37936,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0620
   name: 0620 PMd-LHA Foxb1 Glut_2
   cell_set_accession: CS20230722_SUPT_0620
@@ -37221,6 +37984,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0699
   name: 0699 CUN Evx2 Lhx2 Glut_3
   cell_set_accession: CS20230722_SUPT_0699
@@ -37275,6 +38039,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0698
   name: 0698 CUN Evx2 Lhx2 Glut_2
   cell_set_accession: CS20230722_SUPT_0698
@@ -37327,6 +38092,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0697
   name: 0697 CUN Evx2 Lhx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0697
@@ -37378,6 +38144,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0696
   name: 0696 PAG Pou4f3 Glut_3
   cell_set_accession: CS20230722_SUPT_0696
@@ -37423,6 +38190,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0689
   name: 0689 IF-RL-CLI-PAG Foxa1 Glut_5
   cell_set_accession: CS20230722_SUPT_0689
@@ -37463,6 +38231,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0688
   name: 0688 IF-RL-CLI-PAG Foxa1 Glut_4
   cell_set_accession: CS20230722_SUPT_0688
@@ -37520,6 +38289,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0687
   name: 0687 IF-RL-CLI-PAG Foxa1 Glut_3
   cell_set_accession: CS20230722_SUPT_0687
@@ -37559,6 +38329,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0686
   name: 0686 IF-RL-CLI-PAG Foxa1 Glut_2
   cell_set_accession: CS20230722_SUPT_0686
@@ -37596,6 +38367,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0685
   name: 0685 IF-RL-CLI-PAG Foxa1 Glut_1
   cell_set_accession: CS20230722_SUPT_0685
@@ -37647,6 +38419,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0695
   name: 0695 PAG Pou4f3 Glut_2
   cell_set_accession: CS20230722_SUPT_0695
@@ -37696,6 +38469,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0694
   name: 0694 PAG Pou4f3 Glut_1
   cell_set_accession: CS20230722_SUPT_0694
@@ -37735,6 +38509,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0693
   name: 0693 PAG-SC Neurod2 Meis2 Glut_4
   cell_set_accession: CS20230722_SUPT_0693
@@ -37782,6 +38557,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0692
   name: 0692 PAG-SC Neurod2 Meis2 Glut_3
   cell_set_accession: CS20230722_SUPT_0692
@@ -37839,6 +38615,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0691
   name: 0691 PAG-SC Neurod2 Meis2 Glut_2
   cell_set_accession: CS20230722_SUPT_0691
@@ -37887,6 +38664,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0690
   name: 0690 PAG-SC Neurod2 Meis2 Glut_1
   cell_set_accession: CS20230722_SUPT_0690
@@ -37948,6 +38726,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0679
   name: 0679 PRC-PAG Pax6 Glut_4
   cell_set_accession: CS20230722_SUPT_0679
@@ -37997,6 +38776,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0678
   name: 0678 PRC-PAG Pax6 Glut_3
   cell_set_accession: CS20230722_SUPT_0678
@@ -38041,6 +38821,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0677
   name: 0677 PRC-PAG Pax6 Glut_2
   cell_set_accession: CS20230722_SUPT_0677
@@ -38107,6 +38888,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0676
   name: 0676 PRC-PAG Pax6 Glut_1
   cell_set_accession: CS20230722_SUPT_0676
@@ -38165,6 +38947,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0675
   name: 0675 PF Fzd5 Glut_2
   cell_set_accession: CS20230722_SUPT_0675
@@ -38224,6 +39007,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0674
   name: 0674 PF Fzd5 Glut_1
   cell_set_accession: CS20230722_SUPT_0674
@@ -38285,6 +39069,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0684
   name: 0684 MRN-PAG Nkx6-1 Glut_2
   cell_set_accession: CS20230722_SUPT_0684
@@ -38328,6 +39113,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0683
   name: 0683 MRN-PAG Nkx6-1 Glut_1
   cell_set_accession: CS20230722_SUPT_0683
@@ -38368,6 +39154,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0682
   name: 0682 RN Spp1 Glut_1
   cell_set_accession: CS20230722_SUPT_0682
@@ -38404,6 +39191,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0681
   name: 0681 MB-ant-ve Dmrta2 Glut_1
   cell_set_accession: CS20230722_SUPT_0681
@@ -38464,6 +39252,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0680
   name: 0680 PRC-PAG Pax6 Glut_5
   cell_set_accession: CS20230722_SUPT_0680
@@ -38504,6 +39293,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0669
   name: 0669 RE-Xi Nox4 Glut_2
   cell_set_accession: CS20230722_SUPT_0669
@@ -38561,6 +39351,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0668
   name: 0668 RE-Xi Nox4 Glut_1
   cell_set_accession: CS20230722_SUPT_0668
@@ -38624,6 +39415,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0667
   name: 0667 TH Prkcd Grin2c Glut_14
   cell_set_accession: CS20230722_SUPT_0667
@@ -38684,6 +39476,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0666
   name: 0666 TH Prkcd Grin2c Glut_13
   cell_set_accession: CS20230722_SUPT_0666
@@ -38742,6 +39535,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0665
   name: 0665 TH Prkcd Grin2c Glut_12
   cell_set_accession: CS20230722_SUPT_0665
@@ -38789,6 +39583,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0664
   name: 0664 TH Prkcd Grin2c Glut_11
   cell_set_accession: CS20230722_SUPT_0664
@@ -38855,6 +39650,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0663
   name: 0663 TH Prkcd Grin2c Glut_10
   cell_set_accession: CS20230722_SUPT_0663
@@ -38907,6 +39703,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0673
   name: 0673 MG-POL-SGN Nts Glut_2
   cell_set_accession: CS20230722_SUPT_0673
@@ -38962,6 +39759,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0672
   name: 0672 MG-POL-SGN Nts Glut_1
   cell_set_accession: CS20230722_SUPT_0672
@@ -39025,6 +39823,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0671
   name: 0671 RE-Xi Nox4 Glut_4
   cell_set_accession: CS20230722_SUPT_0671
@@ -39070,6 +39869,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0670
   name: 0670 RE-Xi Nox4 Glut_3
   cell_set_accession: CS20230722_SUPT_0670
@@ -39114,6 +39914,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0539
   name: 0539 MEA-BST Otp Zic2 Glut_1
   cell_set_accession: CS20230722_SUPT_0539
@@ -39173,6 +39974,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0538
   name: 0538 MEA Otp Foxp2 Glut_1
   cell_set_accession: CS20230722_SUPT_0538
@@ -39222,6 +40024,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0537
   name: 0537 SI-MA-LPO-LHA Skor1 Glut_8
   cell_set_accession: CS20230722_SUPT_0537
@@ -39266,6 +40069,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0536
   name: 0536 SI-MA-LPO-LHA Skor1 Glut_7
   cell_set_accession: CS20230722_SUPT_0536
@@ -39310,6 +40114,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0535
   name: 0535 SI-MA-LPO-LHA Skor1 Glut_6
   cell_set_accession: CS20230722_SUPT_0535
@@ -39380,6 +40185,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0534
   name: 0534 SI-MA-LPO-LHA Skor1 Glut_5
   cell_set_accession: CS20230722_SUPT_0534
@@ -39436,6 +40242,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0533
   name: 0533 SI-MA-LPO-LHA Skor1 Glut_4
   cell_set_accession: CS20230722_SUPT_0533
@@ -39484,6 +40291,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0532
   name: 0532 SI-MA-LPO-LHA Skor1 Glut_3
   cell_set_accession: CS20230722_SUPT_0532
@@ -39547,6 +40355,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0531
   name: 0531 SI-MA-LPO-LHA Skor1 Glut_2
   cell_set_accession: CS20230722_SUPT_0531
@@ -39603,6 +40412,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0541
   name: 0541 MEA-BST Otp Zic2 Glut_3
   cell_set_accession: CS20230722_SUPT_0541
@@ -39638,6 +40448,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0540
   name: 0540 MEA-BST Otp Zic2 Glut_2
   cell_set_accession: CS20230722_SUPT_0540
@@ -39675,6 +40486,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0529
   name: 0529 ADP-MPO Trp73 Glut_3
   cell_set_accession: CS20230722_SUPT_0529
@@ -39724,6 +40536,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0528
   name: 0528 ADP-MPO Trp73 Glut_2
   cell_set_accession: CS20230722_SUPT_0528
@@ -39787,6 +40600,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0527
   name: 0527 ADP-MPO Trp73 Glut_1
   cell_set_accession: CS20230722_SUPT_0527
@@ -39848,6 +40662,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0526
   name: 0526 LHA Barhl2 Glut_3
   cell_set_accession: CS20230722_SUPT_0526
@@ -39893,6 +40708,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0525
   name: 0525 LHA Barhl2 Glut_2
   cell_set_accession: CS20230722_SUPT_0525
@@ -39945,6 +40761,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0524
   name: 0524 LHA Barhl2 Glut_1
   cell_set_accession: CS20230722_SUPT_0524
@@ -40003,6 +40820,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0523
   name: 0523 AVPV-MEPO-SFO Tbr1 Glut_5
   cell_set_accession: CS20230722_SUPT_0523
@@ -40068,6 +40886,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0522
   name: 0522 AVPV-MEPO-SFO Tbr1 Glut_4
   cell_set_accession: CS20230722_SUPT_0522
@@ -40118,6 +40937,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0521
   name: 0521 AVPV-MEPO-SFO Tbr1 Glut_3
   cell_set_accession: CS20230722_SUPT_0521
@@ -40179,6 +40999,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0520
   name: 0520 AVPV-MEPO-SFO Tbr1 Glut_2
   cell_set_accession: CS20230722_SUPT_0520
@@ -40235,6 +41056,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0530
   name: 0530 SI-MA-LPO-LHA Skor1 Glut_1
   cell_set_accession: CS20230722_SUPT_0530
@@ -40293,6 +41115,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0519
   name: 0519 AVPV-MEPO-SFO Tbr1 Glut_1
   cell_set_accession: CS20230722_SUPT_0519
@@ -40361,6 +41184,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0518
   name: 0518 MS-SF Bsx Glut_1
   cell_set_accession: CS20230722_SUPT_0518
@@ -40418,6 +41242,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0517
   name: 0517 COAa-PAA-MEA Barhl2 Glut_9
   cell_set_accession: CS20230722_SUPT_0517
@@ -40463,6 +41288,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0516
   name: 0516 COAa-PAA-MEA Barhl2 Glut_8
   cell_set_accession: CS20230722_SUPT_0516
@@ -40523,6 +41349,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0515
   name: 0515 COAa-PAA-MEA Barhl2 Glut_7
   cell_set_accession: CS20230722_SUPT_0515
@@ -40581,6 +41408,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0514
   name: 0514 COAa-PAA-MEA Barhl2 Glut_6
   cell_set_accession: CS20230722_SUPT_0514
@@ -40618,6 +41446,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0513
   name: 0513 COAa-PAA-MEA Barhl2 Glut_5
   cell_set_accession: CS20230722_SUPT_0513
@@ -40687,6 +41516,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0512
   name: 0512 COAa-PAA-MEA Barhl2 Glut_4
   cell_set_accession: CS20230722_SUPT_0512
@@ -40742,6 +41572,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0511
   name: 0511 COAa-PAA-MEA Barhl2 Glut_3
   cell_set_accession: CS20230722_SUPT_0511
@@ -40784,6 +41615,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0510
   name: 0510 COAa-PAA-MEA Barhl2 Glut_2
   cell_set_accession: CS20230722_SUPT_0510
@@ -40845,6 +41677,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0509
   name: 0509 COAa-PAA-MEA Barhl2 Glut_1
   cell_set_accession: CS20230722_SUPT_0509
@@ -40904,6 +41737,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0508
   name: 0508 MEA-COA-BMA Ccdc42 Glut_4
   cell_set_accession: CS20230722_SUPT_0508
@@ -40948,6 +41782,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0507
   name: 0507 MEA-COA-BMA Ccdc42 Glut_3
   cell_set_accession: CS20230722_SUPT_0507
@@ -40982,6 +41817,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0506
   name: 0506 MEA-COA-BMA Ccdc42 Glut_2
   cell_set_accession: CS20230722_SUPT_0506
@@ -41029,6 +41865,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0505
   name: 0505 MEA-COA-BMA Ccdc42 Glut_1
   cell_set_accession: CS20230722_SUPT_0505
@@ -41078,6 +41915,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0504
   name: 0504 GPi Tbr1 Cngb3 Gaba-Glut_1
   cell_set_accession: CS20230722_SUPT_0504
@@ -41134,6 +41972,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0503
   name: 0503 TRS-BAC Sln Glut_2
   cell_set_accession: CS20230722_SUPT_0503
@@ -41179,6 +42018,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0502
   name: 0502 TRS-BAC Sln Glut_1
   cell_set_accession: CS20230722_SUPT_0502
@@ -41222,6 +42062,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0501
   name: 0501 BST-po Iigp1 Glut_1
   cell_set_accession: CS20230722_SUPT_0501
@@ -41267,6 +42108,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0500
   name: 0500 LGv-ZI Otx2 Gaba_5
   cell_set_accession: CS20230722_SUPT_0500
@@ -41320,6 +42162,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0579
   name: 0579 AHN-RCH-LHA Otp Fezf1 Glut_1
   cell_set_accession: CS20230722_SUPT_0579
@@ -41366,6 +42209,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0578
   name: 0578 LHA-AHN-PVH Otp Trh Glut_5
   cell_set_accession: CS20230722_SUPT_0578
@@ -41421,6 +42265,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0577
   name: 0577 LHA-AHN-PVH Otp Trh Glut_4
   cell_set_accession: CS20230722_SUPT_0577
@@ -41476,6 +42321,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0576
   name: 0576 LHA-AHN-PVH Otp Trh Glut_3
   cell_set_accession: CS20230722_SUPT_0576
@@ -41521,6 +42367,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0575
   name: 0575 LHA-AHN-PVH Otp Trh Glut_2
   cell_set_accession: CS20230722_SUPT_0575
@@ -41568,6 +42415,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0585
   name: 0585 PVH-SO-PVa Otp Glut_1
   cell_set_accession: CS20230722_SUPT_0585
@@ -41611,6 +42459,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0584
   name: 0584 AHN-RCH-LHA Otp Fezf1 Glut_6
   cell_set_accession: CS20230722_SUPT_0584
@@ -41649,6 +42498,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0583
   name: 0583 AHN-RCH-LHA Otp Fezf1 Glut_5
   cell_set_accession: CS20230722_SUPT_0583
@@ -41699,6 +42549,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0582
   name: 0582 AHN-RCH-LHA Otp Fezf1 Glut_4
   cell_set_accession: CS20230722_SUPT_0582
@@ -41740,6 +42591,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0581
   name: 0581 AHN-RCH-LHA Otp Fezf1 Glut_3
   cell_set_accession: CS20230722_SUPT_0581
@@ -41793,6 +42645,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0580
   name: 0580 AHN-RCH-LHA Otp Fezf1 Glut_2
   cell_set_accession: CS20230722_SUPT_0580
@@ -41841,6 +42694,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0569
   name: 0569 VMH Nr5a1 Glut_4
   cell_set_accession: CS20230722_SUPT_0569
@@ -41884,6 +42738,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0568
   name: 0568 VMH Nr5a1 Glut_3
   cell_set_accession: CS20230722_SUPT_0568
@@ -41923,6 +42778,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0567
   name: 0567 VMH Nr5a1 Glut_2
   cell_set_accession: CS20230722_SUPT_0567
@@ -41965,6 +42821,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0566
   name: 0566 VMH Nr5a1 Glut_1
   cell_set_accession: CS20230722_SUPT_0566
@@ -42021,6 +42878,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0565
   name: 0565 VMH Fezf1 Glut_3
   cell_set_accession: CS20230722_SUPT_0565
@@ -42061,6 +42919,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0564
   name: 0564 VMH Fezf1 Glut_2
   cell_set_accession: CS20230722_SUPT_0564
@@ -42103,6 +42962,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0574
   name: 0574 LHA-AHN-PVH Otp Trh Glut_1
   cell_set_accession: CS20230722_SUPT_0574
@@ -42168,6 +43028,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0573
   name: 0573 LHA Pmch Glut_2
   cell_set_accession: CS20230722_SUPT_0573
@@ -42216,6 +43077,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0572
   name: 0572 LHA Pmch Glut_1
   cell_set_accession: CS20230722_SUPT_0572
@@ -42259,6 +43121,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0571
   name: 0571 VMH Nr5a1 Glut_6
   cell_set_accession: CS20230722_SUPT_0571
@@ -42297,6 +43160,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0570
   name: 0570 VMH Nr5a1 Glut_5
   cell_set_accession: CS20230722_SUPT_0570
@@ -42341,6 +43205,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0559
   name: 0559 DMH-LHA Vgll2 Glut_1
   cell_set_accession: CS20230722_SUPT_0559
@@ -42384,6 +43249,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0558
   name: 0558 ARH-PVp Tbx3 Glut_5
   cell_set_accession: CS20230722_SUPT_0558
@@ -42442,6 +43308,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0557
   name: 0557 ARH-PVp Tbx3 Glut_4
   cell_set_accession: CS20230722_SUPT_0557
@@ -42485,6 +43352,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0556
   name: 0556 ARH-PVp Tbx3 Glut_3
   cell_set_accession: CS20230722_SUPT_0556
@@ -42528,6 +43396,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0555
   name: 0555 ARH-PVp Tbx3 Glut_2
   cell_set_accession: CS20230722_SUPT_0555
@@ -42571,6 +43440,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0554
   name: 0554 ARH-PVp Tbx3 Glut_1
   cell_set_accession: CS20230722_SUPT_0554
@@ -42615,6 +43485,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0553
   name: 0553 DMH Hmx2 Glut_2
   cell_set_accession: CS20230722_SUPT_0553
@@ -42665,6 +43536,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0563
   name: 0563 VMH Fezf1 Glut_1
   cell_set_accession: CS20230722_SUPT_0563
@@ -42709,6 +43581,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0562
   name: 0562 DMH-LHA Vgll2 Glut_4
   cell_set_accession: CS20230722_SUPT_0562
@@ -42752,6 +43625,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0561
   name: 0561 DMH-LHA Vgll2 Glut_3
   cell_set_accession: CS20230722_SUPT_0561
@@ -42793,6 +43667,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0560
   name: 0560 DMH-LHA Vgll2 Glut_2
   cell_set_accession: CS20230722_SUPT_0560
@@ -42836,6 +43711,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0549
   name: 0549 MPN-MPO-PVpo Hmx2 Glut_4
   cell_set_accession: CS20230722_SUPT_0549
@@ -42887,6 +43763,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0548
   name: 0548 MPN-MPO-PVpo Hmx2 Glut_3
   cell_set_accession: CS20230722_SUPT_0548
@@ -42946,6 +43823,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0547
   name: 0547 MPN-MPO-PVpo Hmx2 Glut_2
   cell_set_accession: CS20230722_SUPT_0547
@@ -43001,6 +43879,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0546
   name: 0546 MPN-MPO-PVpo Hmx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0546
@@ -43069,6 +43948,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0545
   name: 0545 DMH Nkx2-4 Glut_2
   cell_set_accession: CS20230722_SUPT_0545
@@ -43106,6 +43986,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0544
   name: 0544 DMH Nkx2-4 Glut_1
   cell_set_accession: CS20230722_SUPT_0544
@@ -43141,6 +44022,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0543
   name: 0543 LHA-MEA Otp Glut_2
   cell_set_accession: CS20230722_SUPT_0543
@@ -43178,6 +44060,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0542
   name: 0542 LHA-MEA Otp Glut_1
   cell_set_accession: CS20230722_SUPT_0542
@@ -43230,6 +44113,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0552
   name: 0552 DMH Hmx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0552
@@ -43279,6 +44163,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0551
   name: 0551 MPN-MPO-PVpo Hmx2 Glut_6
   cell_set_accession: CS20230722_SUPT_0551
@@ -43333,6 +44218,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0550
   name: 0550 MPN-MPO-PVpo Hmx2 Glut_5
   cell_set_accession: CS20230722_SUPT_0550
@@ -43387,6 +44273,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0599
   name: 0599 STN-PSTN Pitx2 Glut_2
   cell_set_accession: CS20230722_SUPT_0599
@@ -43443,6 +44330,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0598
   name: 0598 STN-PSTN Pitx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0598
@@ -43489,6 +44377,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0597
   name: 0597 PH-ant-LHA Otp Bsx Glut_7
   cell_set_accession: CS20230722_SUPT_0597
@@ -43540,6 +44429,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0589
   name: 0589 PVH-SO-PVa Otp Glut_5
   cell_set_accession: CS20230722_SUPT_0589
@@ -43597,6 +44487,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0588
   name: 0588 PVH-SO-PVa Otp Glut_4
   cell_set_accession: CS20230722_SUPT_0588
@@ -43652,6 +44543,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0587
   name: 0587 PVH-SO-PVa Otp Glut_3
   cell_set_accession: CS20230722_SUPT_0587
@@ -43687,6 +44579,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0586
   name: 0586 PVH-SO-PVa Otp Glut_2
   cell_set_accession: CS20230722_SUPT_0586
@@ -43745,6 +44638,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0596
   name: 0596 PH-ant-LHA Otp Bsx Glut_6
   cell_set_accession: CS20230722_SUPT_0596
@@ -43800,6 +44694,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0595
   name: 0595 PH-ant-LHA Otp Bsx Glut_5
   cell_set_accession: CS20230722_SUPT_0595
@@ -43846,6 +44741,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0594
   name: 0594 PH-ant-LHA Otp Bsx Glut_4
   cell_set_accession: CS20230722_SUPT_0594
@@ -43899,6 +44795,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0593
   name: 0593 PH-ant-LHA Otp Bsx Glut_3
   cell_set_accession: CS20230722_SUPT_0593
@@ -43952,6 +44849,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0592
   name: 0592 PH-ant-LHA Otp Bsx Glut_2
   cell_set_accession: CS20230722_SUPT_0592
@@ -43996,6 +44894,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0591
   name: 0591 PH-ant-LHA Otp Bsx Glut_1
   cell_set_accession: CS20230722_SUPT_0591
@@ -44049,6 +44948,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0590
   name: 0590 PVH-SO-PVa Otp Glut_6
   cell_set_accession: CS20230722_SUPT_0590
@@ -44087,6 +44987,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0819
   name: 0819 PAG-ND-PCG Onecut1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0819
@@ -44148,6 +45049,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0818
   name: 0818 PAG-ND-PCG Onecut1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0818
@@ -44203,6 +45105,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0817
   name: 0817 PAG-MRN-RN Foxa2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0817
@@ -44244,6 +45147,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0816
   name: 0816 PAG-MRN-RN Foxa2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0816
@@ -44293,6 +45197,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0815
   name: 0815 PAG-MRN-RN Foxa2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0815
@@ -44337,6 +45242,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0814
   name: 0814 PAG-MRN-RN Foxa2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0814
@@ -44391,6 +45297,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0813
   name: 0813 IC Six3 En2 Gaba_7
   cell_set_accession: CS20230722_SUPT_0813
@@ -44439,6 +45346,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0812
   name: 0812 IC Six3 En2 Gaba_6
   cell_set_accession: CS20230722_SUPT_0812
@@ -44495,6 +45403,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0811
   name: 0811 IC Six3 En2 Gaba_5
   cell_set_accession: CS20230722_SUPT_0811
@@ -44548,6 +45457,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0810
   name: 0810 IC Six3 En2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0810
@@ -44609,6 +45519,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0809
   name: 0809 IC Six3 En2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0809
@@ -44659,6 +45570,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0808
   name: 0808 IC Six3 En2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0808
@@ -44705,6 +45617,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0807
   name: 0807 IC Six3 En2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0807
@@ -44761,6 +45674,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0806
   name: 0806 SNr Six3 Gaba_1
   cell_set_accession: CS20230722_SUPT_0806
@@ -44822,6 +45736,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0805
   name: 0805 PAG-PPN Pax5 Sox21 Gaba_4
   cell_set_accession: CS20230722_SUPT_0805
@@ -44869,6 +45784,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0804
   name: 0804 PAG-PPN Pax5 Sox21 Gaba_3
   cell_set_accession: CS20230722_SUPT_0804
@@ -44928,6 +45844,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0803
   name: 0803 PAG-PPN Pax5 Sox21 Gaba_2
   cell_set_accession: CS20230722_SUPT_0803
@@ -44975,6 +45892,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0802
   name: 0802 PAG-PPN Pax5 Sox21 Gaba_1
   cell_set_accession: CS20230722_SUPT_0802
@@ -45021,6 +45939,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0801
   name: 0801 SNr-VTA Pax5 Npas1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0801
@@ -45064,6 +45983,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0800
   name: 0800 SNr-VTA Pax5 Npas1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0800
@@ -45114,6 +46034,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0859
   name: 0859 SCs Pax7 Nfia Gaba_1
   cell_set_accession: CS20230722_SUPT_0859
@@ -45173,6 +46094,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0858
   name: 0858 SC Lef1 Otx2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0858
@@ -45213,6 +46135,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0857
   name: 0857 SC Lef1 Otx2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0857
@@ -45270,6 +46193,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0856
   name: 0856 SCs Dmbx1 Gaba_5
   cell_set_accession: CS20230722_SUPT_0856
@@ -45330,6 +46254,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0855
   name: 0855 SCs Dmbx1 Gaba_4
   cell_set_accession: CS20230722_SUPT_0855
@@ -45393,6 +46318,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0854
   name: 0854 SCs Dmbx1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0854
@@ -45438,6 +46364,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0853
   name: 0853 SCs Dmbx1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0853
@@ -45490,6 +46417,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0852
   name: 0852 SCs Dmbx1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0852
@@ -45541,6 +46469,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0851
   name: 0851 SCm-PAG Cdh23 Gaba_4
   cell_set_accession: CS20230722_SUPT_0851
@@ -45599,6 +46528,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0850
   name: 0850 SCm-PAG Cdh23 Gaba_3
   cell_set_accession: CS20230722_SUPT_0850
@@ -45659,6 +46589,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0860
   name: 0860 SCs Pax7 Nfia Gaba_2
   cell_set_accession: CS20230722_SUPT_0860
@@ -45703,6 +46634,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0849
   name: 0849 SCm-PAG Cdh23 Gaba_2
   cell_set_accession: CS20230722_SUPT_0849
@@ -45756,6 +46688,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0848
   name: 0848 SCm-PAG Cdh23 Gaba_1
   cell_set_accession: CS20230722_SUPT_0848
@@ -45800,6 +46733,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0847
   name: 0847 SC-PAG Lef1 Emx2 Gaba_5
   cell_set_accession: CS20230722_SUPT_0847
@@ -45857,6 +46791,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0846
   name: 0846 SC-PAG Lef1 Emx2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0846
@@ -45908,6 +46843,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0845
   name: 0845 SC-PAG Lef1 Emx2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0845
@@ -45970,6 +46906,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0844
   name: 0844 SC-PAG Lef1 Emx2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0844
@@ -46028,6 +46965,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0843
   name: 0843 SC-PAG Lef1 Emx2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0843
@@ -46088,6 +47026,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0842
   name: 0842 SC Otx2 Gcnt4 Gaba_2
   cell_set_accession: CS20230722_SUPT_0842
@@ -46128,6 +47067,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0841
   name: 0841 SC Otx2 Gcnt4 Gaba_1
   cell_set_accession: CS20230722_SUPT_0841
@@ -46183,6 +47123,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0840
   name: 0840 LGv-SPFp-SPFm Nkx2-2 Tcf7l2 Gaba_7
   cell_set_accession: CS20230722_SUPT_0840
@@ -46225,6 +47166,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0839
   name: 0839 LGv-SPFp-SPFm Nkx2-2 Tcf7l2 Gaba_6
   cell_set_accession: CS20230722_SUPT_0839
@@ -46291,6 +47233,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0838
   name: 0838 LGv-SPFp-SPFm Nkx2-2 Tcf7l2 Gaba_5
   cell_set_accession: CS20230722_SUPT_0838
@@ -46353,6 +47296,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0837
   name: 0837 LGv-SPFp-SPFm Nkx2-2 Tcf7l2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0837
@@ -46407,6 +47351,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0836
   name: 0836 LGv-SPFp-SPFm Nkx2-2 Tcf7l2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0836
@@ -46463,6 +47408,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0835
   name: 0835 LGv-SPFp-SPFm Nkx2-2 Tcf7l2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0835
@@ -46521,6 +47467,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0834
   name: 0834 LGv-SPFp-SPFm Nkx2-2 Tcf7l2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0834
@@ -46574,6 +47521,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0833
   name: 0833 PRT Tcf7l2 Gaba_5
   cell_set_accession: CS20230722_SUPT_0833
@@ -46629,6 +47577,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0832
   name: 0832 PRT Tcf7l2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0832
@@ -46680,6 +47629,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0831
   name: 0831 PRT Tcf7l2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0831
@@ -46726,6 +47676,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0830
   name: 0830 PRT Tcf7l2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0830
@@ -46775,6 +47726,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0829
   name: 0829 PRT Tcf7l2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0829
@@ -46834,6 +47786,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0828
   name: 0828 PAG-RN Nkx2-2 Otx1 Gaba_6
   cell_set_accession: CS20230722_SUPT_0828
@@ -46875,6 +47828,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0827
   name: 0827 PAG-RN Nkx2-2 Otx1 Gaba_5
   cell_set_accession: CS20230722_SUPT_0827
@@ -46917,6 +47871,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0826
   name: 0826 PAG-RN Nkx2-2 Otx1 Gaba_4
   cell_set_accession: CS20230722_SUPT_0826
@@ -46959,6 +47914,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0825
   name: 0825 PAG-RN Nkx2-2 Otx1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0825
@@ -47005,6 +47961,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0824
   name: 0824 PAG-RN Nkx2-2 Otx1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0824
@@ -47046,6 +48003,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0823
   name: 0823 PAG-RN Nkx2-2 Otx1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0823
@@ -47097,6 +48055,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0822
   name: 0822 PAG-ND-PCG Onecut1 Gaba_5
   cell_set_accession: CS20230722_SUPT_0822
@@ -47145,6 +48104,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0821
   name: 0821 PAG-ND-PCG Onecut1 Gaba_4
   cell_set_accession: CS20230722_SUPT_0821
@@ -47193,6 +48153,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0820
   name: 0820 PAG-ND-PCG Onecut1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0820
@@ -47232,6 +48193,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0899
   name: 0899 PB Lmx1a Glut_5
   cell_set_accession: CS20230722_SUPT_0899
@@ -47290,6 +48252,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0898
   name: 0898 PB Lmx1a Glut_4
   cell_set_accession: CS20230722_SUPT_0898
@@ -47336,6 +48299,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0897
   name: 0897 PB Lmx1a Glut_3
   cell_set_accession: CS20230722_SUPT_0897
@@ -47392,6 +48356,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0896
   name: 0896 PB Lmx1a Glut_2
   cell_set_accession: CS20230722_SUPT_0896
@@ -47437,6 +48402,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0895
   name: 0895 PB Lmx1a Glut_1
   cell_set_accession: CS20230722_SUPT_0895
@@ -47488,6 +48454,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0894
   name: 0894 MB-MY Tph2 Glut-Sero_7
   cell_set_accession: CS20230722_SUPT_0894
@@ -47533,6 +48500,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0889
   name: 0889 MB-MY Tph2 Glut-Sero_2
   cell_set_accession: CS20230722_SUPT_0889
@@ -47606,6 +48574,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0888
   name: 0888 MB-MY Tph2 Glut-Sero_1
   cell_set_accession: CS20230722_SUPT_0888
@@ -47665,6 +48634,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0887
   name: 0887 SNc-VTA-RAmb Foxa1 Dopa_8
   cell_set_accession: CS20230722_SUPT_0887
@@ -47705,6 +48675,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0886
   name: 0886 SNc-VTA-RAmb Foxa1 Dopa_7
   cell_set_accession: CS20230722_SUPT_0886
@@ -47755,6 +48726,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0885
   name: 0885 SNc-VTA-RAmb Foxa1 Dopa_6
   cell_set_accession: CS20230722_SUPT_0885
@@ -47792,6 +48764,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0884
   name: 0884 SNc-VTA-RAmb Foxa1 Dopa_5
   cell_set_accession: CS20230722_SUPT_0884
@@ -47858,6 +48831,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0883
   name: 0883 SNc-VTA-RAmb Foxa1 Dopa_4
   cell_set_accession: CS20230722_SUPT_0883
@@ -47916,6 +48890,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0893
   name: 0893 MB-MY Tph2 Glut-Sero_6
   cell_set_accession: CS20230722_SUPT_0893
@@ -47974,6 +48949,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0892
   name: 0892 MB-MY Tph2 Glut-Sero_5
   cell_set_accession: CS20230722_SUPT_0892
@@ -48019,6 +48995,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0891
   name: 0891 MB-MY Tph2 Glut-Sero_4
   cell_set_accession: CS20230722_SUPT_0891
@@ -48081,6 +49058,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0890
   name: 0890 MB-MY Tph2 Glut-Sero_3
   cell_set_accession: CS20230722_SUPT_0890
@@ -48128,6 +49106,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0879
   name: 0879 IPN Otp Crisp1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0879
@@ -48173,6 +49152,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0878
   name: 0878 IPN Otp Crisp1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0878
@@ -48231,6 +49211,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0877
   name: 0877 IPN Otp Crisp1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0877
@@ -48274,6 +49255,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0876
   name: 0876 SCsg Gabrr2 Gaba_5
   cell_set_accession: CS20230722_SUPT_0876
@@ -48314,6 +49296,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0875
   name: 0875 SCsg Gabrr2 Gaba_4
   cell_set_accession: CS20230722_SUPT_0875
@@ -48367,6 +49350,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0874
   name: 0874 SCsg Gabrr2 Gaba_3
   cell_set_accession: CS20230722_SUPT_0874
@@ -48413,6 +49397,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0873
   name: 0873 SCsg Gabrr2 Gaba_2
   cell_set_accession: CS20230722_SUPT_0873
@@ -48459,6 +49444,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0872
   name: 0872 SCsg Gabrr2 Gaba_1
   cell_set_accession: CS20230722_SUPT_0872
@@ -48513,6 +49499,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0882
   name: 0882 SNc-VTA-RAmb Foxa1 Dopa_3
   cell_set_accession: CS20230722_SUPT_0882
@@ -48567,6 +49554,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0881
   name: 0881 SNc-VTA-RAmb Foxa1 Dopa_2
   cell_set_accession: CS20230722_SUPT_0881
@@ -48611,6 +49599,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0880
   name: 0880 SNc-VTA-RAmb Foxa1 Dopa_1
   cell_set_accession: CS20230722_SUPT_0880
@@ -48657,6 +49646,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0869
   name: 0869 SCs Lef1 Gli3 Gaba_1
   cell_set_accession: CS20230722_SUPT_0869
@@ -48701,6 +49691,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0868
   name: 0868 SC Tnnt1 Gli3 Gaba_2
   cell_set_accession: CS20230722_SUPT_0868
@@ -48756,6 +49747,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0867
   name: 0867 SC Tnnt1 Gli3 Gaba_1
   cell_set_accession: CS20230722_SUPT_0867
@@ -48801,6 +49793,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0866
   name: 0866 PRT Mecom Gaba_3
   cell_set_accession: CS20230722_SUPT_0866
@@ -48846,6 +49839,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0865
   name: 0865 PRT Mecom Gaba_2
   cell_set_accession: CS20230722_SUPT_0865
@@ -48888,6 +49882,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0864
   name: 0864 PRT Mecom Gaba_1
   cell_set_accession: CS20230722_SUPT_0864
@@ -48944,6 +49939,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0863
   name: 0863 SCs Pax7 Nfia Gaba_5
   cell_set_accession: CS20230722_SUPT_0863
@@ -49001,6 +49997,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0862
   name: 0862 SCs Pax7 Nfia Gaba_4
   cell_set_accession: CS20230722_SUPT_0862
@@ -49051,6 +50048,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0861
   name: 0861 SCs Pax7 Nfia Gaba_3
   cell_set_accession: CS20230722_SUPT_0861
@@ -49093,6 +50091,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0871
   name: 0871 SCs Lef1 Gli3 Gaba_3
   cell_set_accession: CS20230722_SUPT_0871
@@ -49138,6 +50137,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0870
   name: 0870 SCs Lef1 Gli3 Gaba_2
   cell_set_accession: CS20230722_SUPT_0870
@@ -49176,6 +50176,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0739
   name: 0739 PAG Pou4f1 Ebf2 Glut_3
   cell_set_accession: CS20230722_SUPT_0739
@@ -49231,6 +50232,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0738
   name: 0738 PAG Pou4f1 Ebf2 Glut_2
   cell_set_accession: CS20230722_SUPT_0738
@@ -49271,6 +50273,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0737
   name: 0737 PAG Pou4f1 Ebf2 Glut_1
   cell_set_accession: CS20230722_SUPT_0737
@@ -49314,6 +50317,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0736
   name: 0736 PAG Pou4f1 Bnc2 Glut_2
   cell_set_accession: CS20230722_SUPT_0736
@@ -49369,6 +50373,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0735
   name: 0735 PAG Pou4f1 Bnc2 Glut_1
   cell_set_accession: CS20230722_SUPT_0735
@@ -49419,6 +50424,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0734
   name: 0734 PAG-MRN Tfap2b Glut_2
   cell_set_accession: CS20230722_SUPT_0734
@@ -49467,6 +50473,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0733
   name: 0733 PAG-MRN Tfap2b Glut_1
   cell_set_accession: CS20230722_SUPT_0733
@@ -49517,6 +50524,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0732
   name: 0732 PAG-SC Pou4f1 Zic1 Glut_3
   cell_set_accession: CS20230722_SUPT_0732
@@ -49571,6 +50579,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0731
   name: 0731 PAG-SC Pou4f1 Zic1 Glut_2
   cell_set_accession: CS20230722_SUPT_0731
@@ -49649,6 +50658,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0730
   name: 0730 PAG-SC Pou4f1 Zic1 Glut_1
   cell_set_accession: CS20230722_SUPT_0730
@@ -49706,6 +50716,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0729
   name: 0729 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_12
   cell_set_accession: CS20230722_SUPT_0729
@@ -49759,6 +50770,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0728
   name: 0728 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_11
   cell_set_accession: CS20230722_SUPT_0728
@@ -49814,6 +50826,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0727
   name: 0727 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_10
   cell_set_accession: CS20230722_SUPT_0727
@@ -49864,6 +50877,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0726
   name: 0726 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_9
   cell_set_accession: CS20230722_SUPT_0726
@@ -49905,6 +50919,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0725
   name: 0725 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_8
   cell_set_accession: CS20230722_SUPT_0725
@@ -49963,6 +50978,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0724
   name: 0724 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_7
   cell_set_accession: CS20230722_SUPT_0724
@@ -50042,6 +51058,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0723
   name: 0723 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_6
   cell_set_accession: CS20230722_SUPT_0723
@@ -50101,6 +51118,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0722
   name: 0722 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_5
   cell_set_accession: CS20230722_SUPT_0722
@@ -50163,6 +51181,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0721
   name: 0721 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_4
   cell_set_accession: CS20230722_SUPT_0721
@@ -50233,6 +51252,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0720
   name: 0720 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_3
   cell_set_accession: CS20230722_SUPT_0720
@@ -50305,6 +51325,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0719
   name: 0719 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_2
   cell_set_accession: CS20230722_SUPT_0719
@@ -50365,6 +51386,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0718
   name: 0718 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_1
   cell_set_accession: CS20230722_SUPT_0718
@@ -50425,6 +51447,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0717
   name: 0717 PRC-PAG Tcf7l2 Irx2 Glut_5
   cell_set_accession: CS20230722_SUPT_0717
@@ -50489,6 +51512,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0716
   name: 0716 PRC-PAG Tcf7l2 Irx2 Glut_4
   cell_set_accession: CS20230722_SUPT_0716
@@ -50539,6 +51563,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0715
   name: 0715 PRC-PAG Tcf7l2 Irx2 Glut_3
   cell_set_accession: CS20230722_SUPT_0715
@@ -50590,6 +51615,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0714
   name: 0714 PRC-PAG Tcf7l2 Irx2 Glut_2
   cell_set_accession: CS20230722_SUPT_0714
@@ -50650,6 +51676,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0713
   name: 0713 PRC-PAG Tcf7l2 Irx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0713
@@ -50708,6 +51735,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0712
   name: 0712 MRN Pou3f1 C1ql4 Glut_3
   cell_set_accession: CS20230722_SUPT_0712
@@ -50762,6 +51790,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0711
   name: 0711 MRN Pou3f1 C1ql4 Glut_2
   cell_set_accession: CS20230722_SUPT_0711
@@ -50820,6 +51849,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0710
   name: 0710 MRN Pou3f1 C1ql4 Glut_1
   cell_set_accession: CS20230722_SUPT_0710
@@ -50878,6 +51908,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0709
   name: 0709 PAG-MRN Pou3f1 Glut_6
   cell_set_accession: CS20230722_SUPT_0709
@@ -50928,6 +51959,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0708
   name: 0708 PAG-MRN Pou3f1 Glut_5
   cell_set_accession: CS20230722_SUPT_0708
@@ -50986,6 +52018,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0707
   name: 0707 PAG-MRN Pou3f1 Glut_4
   cell_set_accession: CS20230722_SUPT_0707
@@ -51031,6 +52064,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0706
   name: 0706 PAG-MRN Pou3f1 Glut_3
   cell_set_accession: CS20230722_SUPT_0706
@@ -51059,6 +52093,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0705
   name: 0705 PAG-MRN Pou3f1 Glut_2
   cell_set_accession: CS20230722_SUPT_0705
@@ -51096,6 +52131,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0704
   name: 0704 PAG-MRN Pou3f1 Glut_1
   cell_set_accession: CS20230722_SUPT_0704
@@ -51147,6 +52183,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0703
   name: 0703 APN C1ql4 Glut_1
   cell_set_accession: CS20230722_SUPT_0703
@@ -51193,6 +52230,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0702
   name: 0702 APN C1ql2 Glut_1
   cell_set_accession: CS20230722_SUPT_0702
@@ -51232,6 +52270,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0701
   name: 0701 CUN Evx2 Lhx2 Glut_5
   cell_set_accession: CS20230722_SUPT_0701
@@ -51290,6 +52329,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0700
   name: 0700 CUN Evx2 Lhx2 Glut_4
   cell_set_accession: CS20230722_SUPT_0700
@@ -51333,6 +52373,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0779
   name: 0779 CUN-PPN Evx2 Meis2 Glut_4
   cell_set_accession: CS20230722_SUPT_0779
@@ -51385,6 +52426,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0778
   name: 0778 CUN-PPN Evx2 Meis2 Glut_3
   cell_set_accession: CS20230722_SUPT_0778
@@ -51445,6 +52487,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0777
   name: 0777 CUN-PPN Evx2 Meis2 Glut_2
   cell_set_accession: CS20230722_SUPT_0777
@@ -51508,6 +52551,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0776
   name: 0776 CUN-PPN Evx2 Meis2 Glut_1
   cell_set_accession: CS20230722_SUPT_0776
@@ -51558,6 +52602,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0775
   name: 0775 IC Tfap2d Maf Glut_6
   cell_set_accession: CS20230722_SUPT_0775
@@ -51611,6 +52656,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0774
   name: 0774 IC Tfap2d Maf Glut_5
   cell_set_accession: CS20230722_SUPT_0774
@@ -51646,6 +52692,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0773
   name: 0773 IC Tfap2d Maf Glut_4
   cell_set_accession: CS20230722_SUPT_0773
@@ -51705,6 +52752,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0783
   name: 0783 SCig Tfap2b Chrnb3 Glut_1
   cell_set_accession: CS20230722_SUPT_0783
@@ -51761,6 +52809,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0782
   name: 0782 PAG Tcf24 Glut_1
   cell_set_accession: CS20230722_SUPT_0782
@@ -51809,6 +52858,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0781
   name: 0781 PBG Mtnr1a Glut-Chol_1
   cell_set_accession: CS20230722_SUPT_0781
@@ -51849,6 +52899,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0780
   name: 0780 CUN-PPN Evx2 Meis2 Glut_5
   cell_set_accession: CS20230722_SUPT_0780
@@ -51905,6 +52956,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0769
   name: 0769 SCiw Pitx2 Glut_3
   cell_set_accession: CS20230722_SUPT_0769
@@ -51948,6 +53000,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0768
   name: 0768 SCiw Pitx2 Glut_2
   cell_set_accession: CS20230722_SUPT_0768
@@ -51992,6 +53045,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0767
   name: 0767 SCiw Pitx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0767
@@ -52053,6 +53107,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0766
   name: 0766 SCdg-PAG Tfap2b Glut_1
   cell_set_accession: CS20230722_SUPT_0766
@@ -52106,6 +53161,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0765
   name: 0765 SCig Foxb1 Otx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0765
@@ -52153,6 +53209,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0764
   name: 0764 SCig-an-PPT Foxb1 Glut_1
   cell_set_accession: CS20230722_SUPT_0764
@@ -52209,6 +53266,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0763
   name: 0763 SCig Foxb1 Glut_4
   cell_set_accession: CS20230722_SUPT_0763
@@ -52265,6 +53323,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0762
   name: 0762 SCig Foxb1 Glut_3
   cell_set_accession: CS20230722_SUPT_0762
@@ -52313,6 +53372,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0772
   name: 0772 IC Tfap2d Maf Glut_3
   cell_set_accession: CS20230722_SUPT_0772
@@ -52368,6 +53428,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0771
   name: 0771 IC Tfap2d Maf Glut_2
   cell_set_accession: CS20230722_SUPT_0771
@@ -52425,6 +53486,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0770
   name: 0770 IC Tfap2d Maf Glut_1
   cell_set_accession: CS20230722_SUPT_0770
@@ -52478,6 +53540,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0759
   name: 0759 SC Bnc2 Glut_4
   cell_set_accession: CS20230722_SUPT_0759
@@ -52533,6 +53596,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0758
   name: 0758 SC Bnc2 Glut_3
   cell_set_accession: CS20230722_SUPT_0758
@@ -52587,6 +53651,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0757
   name: 0757 SC Bnc2 Glut_2
   cell_set_accession: CS20230722_SUPT_0757
@@ -52639,6 +53704,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0756
   name: 0756 SC Bnc2 Glut_1
   cell_set_accession: CS20230722_SUPT_0756
@@ -52688,6 +53754,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0755
   name: 0755 PAG Pou4f2 Mesi2 Glut_6
   cell_set_accession: CS20230722_SUPT_0755
@@ -52738,6 +53805,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0754
   name: 0754 PAG Pou4f2 Mesi2 Glut_5
   cell_set_accession: CS20230722_SUPT_0754
@@ -52770,6 +53838,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0753
   name: 0753 PAG Pou4f2 Mesi2 Glut_4
   cell_set_accession: CS20230722_SUPT_0753
@@ -52831,6 +53900,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0752
   name: 0752 PAG Pou4f2 Mesi2 Glut_3
   cell_set_accession: CS20230722_SUPT_0752
@@ -52869,6 +53939,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0751
   name: 0751 PAG Pou4f2 Mesi2 Glut_2
   cell_set_accession: CS20230722_SUPT_0751
@@ -52909,6 +53980,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0761
   name: 0761 SCig Foxb1 Glut_2
   cell_set_accession: CS20230722_SUPT_0761
@@ -52967,6 +54039,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0760
   name: 0760 SCig Foxb1 Glut_1
   cell_set_accession: CS20230722_SUPT_0760
@@ -53018,6 +54091,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0749
   name: 0749 PAG Pou4f2 Glut_5
   cell_set_accession: CS20230722_SUPT_0749
@@ -53066,6 +54140,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0748
   name: 0748 PAG Pou4f2 Glut_4
   cell_set_accession: CS20230722_SUPT_0748
@@ -53125,6 +54200,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0747
   name: 0747 PAG Pou4f2 Glut_3
   cell_set_accession: CS20230722_SUPT_0747
@@ -53169,6 +54245,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0746
   name: 0746 PAG Pou4f2 Glut_2
   cell_set_accession: CS20230722_SUPT_0746
@@ -53212,6 +54289,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0745
   name: 0745 PAG Pou4f2 Glut_1
   cell_set_accession: CS20230722_SUPT_0745
@@ -53276,6 +54354,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0744
   name: 0744 PAG Pou4f1 Ebf2 Glut_8
   cell_set_accession: CS20230722_SUPT_0744
@@ -53323,6 +54402,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0743
   name: 0743 PAG Pou4f1 Ebf2 Glut_7
   cell_set_accession: CS20230722_SUPT_0743
@@ -53364,6 +54444,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0742
   name: 0742 PAG Pou4f1 Ebf2 Glut_6
   cell_set_accession: CS20230722_SUPT_0742
@@ -53402,6 +54483,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0741
   name: 0741 PAG Pou4f1 Ebf2 Glut_5
   cell_set_accession: CS20230722_SUPT_0741
@@ -53440,6 +54522,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0740
   name: 0740 PAG Pou4f1 Ebf2 Glut_4
   cell_set_accession: CS20230722_SUPT_0740
@@ -53480,6 +54563,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0750
   name: 0750 PAG Pou4f2 Mesi2 Glut_1
   cell_set_accession: CS20230722_SUPT_0750
@@ -53516,6 +54600,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0799
   name: 0799 MRN-VTN-PPN Pax5 Cdh23 Gaba_2
   cell_set_accession: CS20230722_SUPT_0799
@@ -53570,6 +54655,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0798
   name: 0798 MRN-VTN-PPN Pax5 Cdh23 Gaba_1
   cell_set_accession: CS20230722_SUPT_0798
@@ -53635,6 +54721,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0797
   name: 0797 MRN-PPN-CUN Pax8 Gaba_3
   cell_set_accession: CS20230722_SUPT_0797
@@ -53698,6 +54785,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0796
   name: 0796 MRN-PPN-CUN Pax8 Gaba_2
   cell_set_accession: CS20230722_SUPT_0796
@@ -53745,6 +54833,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0795
   name: 0795 MRN-PPN-CUN Pax8 Gaba_1
   cell_set_accession: CS20230722_SUPT_0795
@@ -53806,6 +54895,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0789
   name: 0789 PAG Ucn Glut_1
   cell_set_accession: CS20230722_SUPT_0789
@@ -53854,6 +54944,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0788
   name: 0788 SCop Sln Glut_1
   cell_set_accession: CS20230722_SUPT_0788
@@ -53900,6 +54991,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0787
   name: 0787 SCsg Pde5a Glut_3
   cell_set_accession: CS20230722_SUPT_0787
@@ -53950,6 +55042,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0786
   name: 0786 SCsg Pde5a Glut_2
   cell_set_accession: CS20230722_SUPT_0786
@@ -53995,6 +55088,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0785
   name: 0785 SCsg Pde5a Glut_1
   cell_set_accession: CS20230722_SUPT_0785
@@ -54033,6 +55127,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0784
   name: 0784 SCop Pou4f2 Neurod2 Glut_1
   cell_set_accession: CS20230722_SUPT_0784
@@ -54090,6 +55185,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0794
   name: 0794 PPN-CUN-PCG Otp En1 Gaba_3
   cell_set_accession: CS20230722_SUPT_0794
@@ -54161,6 +55257,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0793
   name: 0793 PPN-CUN-PCG Otp En1 Gaba_2
   cell_set_accession: CS20230722_SUPT_0793
@@ -54217,6 +55314,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0792
   name: 0792 PPN-CUN-PCG Otp En1 Gaba_1
   cell_set_accession: CS20230722_SUPT_0792
@@ -54271,6 +55369,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0791
   name: 0791 PAG-MRN Rln3 Gaba_1
   cell_set_accession: CS20230722_SUPT_0791
@@ -54307,6 +55406,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0790
   name: 0790 ND-INC Foxd2 Glut_1
   cell_set_accession: CS20230722_SUPT_0790
@@ -54350,6 +55450,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0939
   name: 0939 PSV Pvalb Lhx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0939
@@ -54388,6 +55489,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0938
   name: 0938 PB-PSV Phox2b Glut_1
   cell_set_accession: CS20230722_SUPT_0938
@@ -54454,6 +55556,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0937
   name: 0937 PRNc-PARN Tlx1 Glut_3
   cell_set_accession: CS20230722_SUPT_0937
@@ -54497,6 +55600,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0936
   name: 0936 PRNc-PARN Tlx1 Glut_2
   cell_set_accession: CS20230722_SUPT_0936
@@ -54555,6 +55659,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0935
   name: 0935 PRNc-PARN Tlx1 Glut_1
   cell_set_accession: CS20230722_SUPT_0935
@@ -54600,6 +55705,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0934
   name: 0934 PRNc-NI-SG-RPO Vsx2 Nr4a2 Glut_4
   cell_set_accession: CS20230722_SUPT_0934
@@ -54652,6 +55758,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0933
   name: 0933 PRNc-NI-SG-RPO Vsx2 Nr4a2 Glut_3
   cell_set_accession: CS20230722_SUPT_0933
@@ -54709,6 +55816,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0932
   name: 0932 PRNc-NI-SG-RPO Vsx2 Nr4a2 Glut_2
   cell_set_accession: CS20230722_SUPT_0932
@@ -54773,6 +55881,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0931
   name: 0931 PRNc-NI-SG-RPO Vsx2 Nr4a2 Glut_1
   cell_set_accession: CS20230722_SUPT_0931
@@ -54820,6 +55929,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0930
   name: 0930 PCG-PRNr Vsx2 Nkx6-1 Glut_6
   cell_set_accession: CS20230722_SUPT_0930
@@ -54868,6 +55978,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0929
   name: 0929 PCG-PRNr Vsx2 Nkx6-1 Glut_5
   cell_set_accession: CS20230722_SUPT_0929
@@ -54910,6 +56021,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0928
   name: 0928 PCG-PRNr Vsx2 Nkx6-1 Glut_4
   cell_set_accession: CS20230722_SUPT_0928
@@ -54943,6 +56055,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0927
   name: 0927 PCG-PRNr Vsx2 Nkx6-1 Glut_3
   cell_set_accession: CS20230722_SUPT_0927
@@ -54986,6 +56099,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0926
   name: 0926 PCG-PRNr Vsx2 Nkx6-1 Glut_2
   cell_set_accession: CS20230722_SUPT_0926
@@ -55051,6 +56165,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0925
   name: 0925 PCG-PRNr Vsx2 Nkx6-1 Glut_1
   cell_set_accession: CS20230722_SUPT_0925
@@ -55088,6 +56203,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0924
   name: 0924 B-PB Nr4a2 Glut_2
   cell_set_accession: CS20230722_SUPT_0924
@@ -55141,6 +56257,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0923
   name: 0923 B-PB Nr4a2 Glut_1
   cell_set_accession: CS20230722_SUPT_0923
@@ -55198,6 +56315,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0922
   name: 0922 PB Evx2 Glut_9
   cell_set_accession: CS20230722_SUPT_0922
@@ -55264,6 +56382,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0921
   name: 0921 PB Evx2 Glut_8
   cell_set_accession: CS20230722_SUPT_0921
@@ -55327,6 +56446,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0920
   name: 0920 PB Evx2 Glut_7
   cell_set_accession: CS20230722_SUPT_0920
@@ -55367,6 +56487,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0919
   name: 0919 PB Evx2 Glut_6
   cell_set_accession: CS20230722_SUPT_0919
@@ -55413,6 +56534,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0918
   name: 0918 PB Evx2 Glut_5
   cell_set_accession: CS20230722_SUPT_0918
@@ -55449,6 +56571,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0917
   name: 0917 PB Evx2 Glut_4
   cell_set_accession: CS20230722_SUPT_0917
@@ -55507,6 +56630,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0916
   name: 0916 PB Evx2 Glut_3
   cell_set_accession: CS20230722_SUPT_0916
@@ -55572,6 +56696,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0915
   name: 0915 PB Evx2 Glut_2
   cell_set_accession: CS20230722_SUPT_0915
@@ -55625,6 +56750,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0914
   name: 0914 PB Evx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0914
@@ -55673,6 +56799,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0913
   name: 0913 LDT-PCG Vsx2 Lhx4 Glut_8
   cell_set_accession: CS20230722_SUPT_0913
@@ -55722,6 +56849,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0912
   name: 0912 LDT-PCG Vsx2 Lhx4 Glut_7
   cell_set_accession: CS20230722_SUPT_0912
@@ -55776,6 +56904,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0911
   name: 0911 LDT-PCG Vsx2 Lhx4 Glut_6
   cell_set_accession: CS20230722_SUPT_0911
@@ -55820,6 +56949,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0910
   name: 0910 LDT-PCG Vsx2 Lhx4 Glut_5
   cell_set_accession: CS20230722_SUPT_0910
@@ -55880,6 +57010,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0909
   name: 0909 LDT-PCG Vsx2 Lhx4 Glut_4
   cell_set_accession: CS20230722_SUPT_0909
@@ -55916,6 +57047,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0908
   name: 0908 LDT-PCG Vsx2 Lhx4 Glut_3
   cell_set_accession: CS20230722_SUPT_0908
@@ -55960,6 +57092,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0907
   name: 0907 LDT-PCG Vsx2 Lhx4 Glut_2
   cell_set_accession: CS20230722_SUPT_0907
@@ -56001,6 +57134,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0906
   name: 0906 LDT-PCG Vsx2 Lhx4 Glut_1
   cell_set_accession: CS20230722_SUPT_0906
@@ -56062,6 +57196,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0905
   name: 0905 PB Pax5 Glut_2
   cell_set_accession: CS20230722_SUPT_0905
@@ -56100,6 +57235,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0904
   name: 0904 PB Pax5 Glut_1
   cell_set_accession: CS20230722_SUPT_0904
@@ -56150,6 +57286,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0903
   name: 0903 PB-SUT Tlx3 Lhx2 Glut_1
   cell_set_accession: CS20230722_SUPT_0903
@@ -56191,6 +57328,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0902
   name: 0902 PSV Lmx1a Trpv6 Glut_1
   cell_set_accession: CS20230722_SUPT_0902
@@ -56254,6 +57392,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0901
   name: 0901 PB Lmx1a Glut_7
   cell_set_accession: CS20230722_SUPT_0901
@@ -56306,6 +57445,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0900
   name: 0900 PB Lmx1a Glut_6
   cell_set_accession: CS20230722_SUPT_0900
@@ -56348,6 +57488,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0979
   name: 0979 PGRN-PARN-MDRN Hoxb5 Glut_7
   cell_set_accession: CS20230722_SUPT_0979
@@ -56424,6 +57565,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0978
   name: 0978 PGRN-PARN-MDRN Hoxb5 Glut_6
   cell_set_accession: CS20230722_SUPT_0978
@@ -56491,6 +57633,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0977
   name: 0977 PGRN-PARN-MDRN Hoxb5 Glut_5
   cell_set_accession: CS20230722_SUPT_0977
@@ -56552,6 +57695,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0976
   name: 0976 PGRN-PARN-MDRN Hoxb5 Glut_4
   cell_set_accession: CS20230722_SUPT_0976
@@ -56593,6 +57737,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0975
   name: 0975 PGRN-PARN-MDRN Hoxb5 Glut_3
   cell_set_accession: CS20230722_SUPT_0975
@@ -56664,6 +57809,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0974
   name: 0974 PGRN-PARN-MDRN Hoxb5 Glut_2
   cell_set_accession: CS20230722_SUPT_0974
@@ -56730,6 +57876,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0973
   name: 0973 PGRN-PARN-MDRN Hoxb5 Glut_1
   cell_set_accession: CS20230722_SUPT_0973
@@ -56790,6 +57937,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0972
   name: 0972 PGRNd Dmbx1 Glut_1
   cell_set_accession: CS20230722_SUPT_0972
@@ -56843,6 +57991,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0971
   name: 0971 NTS Mbnl3 Glut_1
   cell_set_accession: CS20230722_SUPT_0971
@@ -56878,6 +58027,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0981
   name: 0981 SPVI-SPVC Tlx3 Ebf3 Glut_1
   cell_set_accession: CS20230722_SUPT_0981
@@ -56925,6 +58075,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0980
   name: 0980 MV-SPIV Slc6a2 Glut_1
   cell_set_accession: CS20230722_SUPT_0980
@@ -56981,6 +58132,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0969
   name: 0969 MARN-GRN Pyy Glut_1
   cell_set_accession: CS20230722_SUPT_0969
@@ -57017,6 +58169,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0968
   name: 0968 NTS Phox2b Glut_10
   cell_set_accession: CS20230722_SUPT_0968
@@ -57079,6 +58232,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0967
   name: 0967 NTS Phox2b Glut_9
   cell_set_accession: CS20230722_SUPT_0967
@@ -57140,6 +58294,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0966
   name: 0966 NTS Phox2b Glut_8
   cell_set_accession: CS20230722_SUPT_0966
@@ -57196,6 +58351,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0965
   name: 0965 NTS Phox2b Glut_7
   cell_set_accession: CS20230722_SUPT_0965
@@ -57247,6 +58403,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0964
   name: 0964 NTS Phox2b Glut_6
   cell_set_accession: CS20230722_SUPT_0964
@@ -57291,6 +58448,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0963
   name: 0963 NTS Phox2b Glut_5
   cell_set_accession: CS20230722_SUPT_0963
@@ -57344,6 +58502,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0962
   name: 0962 NTS Phox2b Glut_4
   cell_set_accession: CS20230722_SUPT_0962
@@ -57393,6 +58552,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0961
   name: 0961 NTS Phox2b Glut_3
   cell_set_accession: CS20230722_SUPT_0961
@@ -57437,6 +58597,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0960
   name: 0960 NTS Phox2b Glut_2
   cell_set_accession: CS20230722_SUPT_0960
@@ -57485,6 +58646,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0970
   name: 0970 MDRNv Lhx4 Qrfprl Glut_1
   cell_set_accession: CS20230722_SUPT_0970
@@ -57532,6 +58694,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0959
   name: 0959 NTS Phox2b Glut_1
   cell_set_accession: CS20230722_SUPT_0959
@@ -57595,6 +58758,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0958
   name: 0958 PRP-NI-PRNc-GRN Otp Glut_4
   cell_set_accession: CS20230722_SUPT_0958
@@ -57642,6 +58806,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0957
   name: 0957 PRP-NI-PRNc-GRN Otp Glut_3
   cell_set_accession: CS20230722_SUPT_0957
@@ -57705,6 +58870,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0956
   name: 0956 PRP-NI-PRNc-GRN Otp Glut_2
   cell_set_accession: CS20230722_SUPT_0956
@@ -57760,6 +58926,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0955
   name: 0955 PRP-NI-PRNc-GRN Otp Glut_1
   cell_set_accession: CS20230722_SUPT_0955
@@ -57803,6 +58970,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0954
   name: 0954 IRN Vip Glut_1
   cell_set_accession: CS20230722_SUPT_0954
@@ -57843,6 +59011,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0953
   name: 0953 PG-TRN-LRN Fat2 Glut_1
   cell_set_accession: CS20230722_SUPT_0953
@@ -57885,6 +59054,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0952
   name: 0952 MEV Ppp1r1c Glut_1
   cell_set_accession: CS20230722_SUPT_0952
@@ -57936,6 +59106,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0951
   name: 0951 NLL-SOC Spp1 Glut_2
   cell_set_accession: CS20230722_SUPT_0951
@@ -57980,6 +59151,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0950
   name: 0950 NLL-SOC Spp1 Glut_1
   cell_set_accession: CS20230722_SUPT_0950
@@ -58019,6 +59191,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0949
   name: 0949 LDT Vsx2 Nkx6-1 Nfib Glut_2
   cell_set_accession: CS20230722_SUPT_0949
@@ -58059,6 +59232,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0948
   name: 0948 LDT Vsx2 Nkx6-1 Nfib Glut_1
   cell_set_accession: CS20230722_SUPT_0948
@@ -58096,6 +59270,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0947
   name: 0947 IPN-LDT Vsx2 Nkx6-1 Glut_2
   cell_set_accession: CS20230722_SUPT_0947
@@ -58139,6 +59314,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0946
   name: 0946 IPN-LDT Vsx2 Nkx6-1 Glut_1
   cell_set_accession: CS20230722_SUPT_0946
@@ -58187,6 +59363,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0945
   name: 0945 PRNr Otp Nfib Glut_1
   cell_set_accession: CS20230722_SUPT_0945
@@ -58243,6 +59420,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0944
   name: 0944 PB-NTS Phox2b Ebf3 Lmx1b Glut_2
   cell_set_accession: CS20230722_SUPT_0944
@@ -58293,6 +59471,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0943
   name: 0943 PB-NTS Phox2b Ebf3 Lmx1b Glut_1
   cell_set_accession: CS20230722_SUPT_0943
@@ -58341,6 +59520,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0942
   name: 0942 PSV Pvalb Lhx2 Glut_4
   cell_set_accession: CS20230722_SUPT_0942
@@ -58379,6 +59559,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0941
   name: 0941 PSV Pvalb Lhx2 Glut_3
   cell_set_accession: CS20230722_SUPT_0941
@@ -58432,6 +59613,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0940
   name: 0940 PSV Pvalb Lhx2 Glut_2
   cell_set_accession: CS20230722_SUPT_0940
@@ -58486,6 +59668,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0999
   name: 0999 MV-SPIV Zic4 Neurod2 Glut_3
   cell_set_accession: CS20230722_SUPT_0999
@@ -58528,6 +59711,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0998
   name: 0998 MV-SPIV Zic4 Neurod2 Glut_2
   cell_set_accession: CS20230722_SUPT_0998
@@ -58575,6 +59759,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0997
   name: 0997 MV-SPIV Zic4 Neurod2 Glut_1
   cell_set_accession: CS20230722_SUPT_0997
@@ -58625,6 +59810,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0996
   name: 0996 MV-SPIV Phox2b Ebf3 Lbx1 Glut_5
   cell_set_accession: CS20230722_SUPT_0996
@@ -58673,6 +59859,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0995
   name: 0995 MV-SPIV Phox2b Ebf3 Lbx1 Glut_4
   cell_set_accession: CS20230722_SUPT_0995
@@ -58726,6 +59913,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0994
   name: 0994 MV-SPIV Phox2b Ebf3 Lbx1 Glut_3
   cell_set_accession: CS20230722_SUPT_0994
@@ -58761,6 +59949,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0993
   name: 0993 MV-SPIV Phox2b Ebf3 Lbx1 Glut_2
   cell_set_accession: CS20230722_SUPT_0993
@@ -58814,6 +60003,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0989
   name: 0989 CU-ECU-SPVI Foxb1 Glut_2
   cell_set_accession: CS20230722_SUPT_0989
@@ -58861,6 +60051,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0988
   name: 0988 CU-ECU-SPVI Foxb1 Glut_1
   cell_set_accession: CS20230722_SUPT_0988
@@ -58917,6 +60108,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0987
   name: 0987 SPVI-SPVC Tlx3 Ebf3 Glut_7
   cell_set_accession: CS20230722_SUPT_0987
@@ -58963,6 +60155,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0986
   name: 0986 SPVI-SPVC Tlx3 Ebf3 Glut_6
   cell_set_accession: CS20230722_SUPT_0986
@@ -58995,6 +60188,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0985
   name: 0985 SPVI-SPVC Tlx3 Ebf3 Glut_5
   cell_set_accession: CS20230722_SUPT_0985
@@ -59047,6 +60241,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0984
   name: 0984 SPVI-SPVC Tlx3 Ebf3 Glut_4
   cell_set_accession: CS20230722_SUPT_0984
@@ -59095,6 +60290,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0983
   name: 0983 SPVI-SPVC Tlx3 Ebf3 Glut_3
   cell_set_accession: CS20230722_SUPT_0983
@@ -59139,6 +60335,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0982
   name: 0982 SPVI-SPVC Tlx3 Ebf3 Glut_2
   cell_set_accession: CS20230722_SUPT_0982
@@ -59188,6 +60385,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0992
   name: 0992 MV-SPIV Phox2b Ebf3 Lbx1 Glut_1
   cell_set_accession: CS20230722_SUPT_0992
@@ -59232,6 +60430,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0991
   name: 0991 CU-ECU-SPVI Foxb1 Glut_4
   cell_set_accession: CS20230722_SUPT_0991
@@ -59282,6 +60481,7 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1
 - id: WMB:CS20230722_SUPT_0990
   name: 0990 CU-ECU-SPVI Foxb1 Glut_3
   cell_set_accession: CS20230722_SUPT_0990
@@ -59315,3 +60515,4 @@ nodes:
     id: NCBITaxon:10090
     label: Mus musculus
     name_in_source: Mus musculus
+  taxonomy_rank: 1

--- a/kb/taxonomy/CCN20230722/taxonomy_meta.yaml
+++ b/kb/taxonomy/CCN20230722/taxonomy_meta.yaml
@@ -7,23 +7,27 @@ tissue_label: brain
 anatomy_ontology: MBA
 source_query: inputs/taxonomies/CCN20230722.cypher
 source_file: wmbv1_full.json
-ingest_date: '2026-04-22'
+ingest_date: '2026-04-23'
 level_hierarchy:
-  - level_name: CLUSTER
-    rank: 0
-    count: 5322
-    is_terminal: true
-  - level_name: SUPERTYPE
-    rank: 1
-    count: 1201
-  - level_name: SUBCLASS
-    rank: 2
-    count: 338
-  - level_name: CLASS
-    rank: 3
-    count: 34
-  # NEUROTRANSMITTER is not a hierarchical level (orthogonal annotation)
-  # and has no rank in the level hierarchy.
+- level_name: CLUSTER
+  rank: 0
+  count: 5322
+  is_terminal: true
+- level_name: SUPERTYPE
+  rank: 1
+  count: 1201
+- level_name: SUBCLASS
+  rank: 2
+  count: 338
+- level_name: CLASS
+  rank: 3
+  count: 34
+level_counts:
+  class: 34
+  cluster: 5322
+  neurotransmitter: 10
+  subclass: 338
+  supertype: 1201
 mapmycells:
   at_taxonomy_id: CCN20230722
   stats_s3_url: https://allen-brain-cell-atlas.s3.us-west-2.amazonaws.com/mapmycells/WMB-10X/20240831/precomputed_stats_ABC_revision_230821.h5

--- a/kb/taxonomy/CS202106160/class.yaml
+++ b/kb/taxonomy/CS202106160/class.yaml
@@ -1,0 +1,34 @@
+taxonomy_id: CS202106160
+taxonomy_level: CLASS
+taxonomy_rank: 2
+nodes:
+- id: CTX-HPF:class_label:0ecf35ea0b
+  name: GABAergic
+  cell_set_accession: class_label:0ecf35ea0b
+  taxonomy_id: CS202106160
+  taxonomy_level: CLASS
+  taxonomy_rank: 2
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  species: &id001
+    id: NCBITaxon:10090
+    label: Mus musculus
+    name_in_source: Mus musculus
+- id: CTX-HPF:class_label:b7c6ca690a
+  name: Non-Neuronal
+  cell_set_accession: class_label:b7c6ca690a
+  taxonomy_id: CS202106160
+  taxonomy_level: CLASS
+  taxonomy_rank: 2
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  species: *id001
+- id: CTX-HPF:class_label:de8ed2ce0f
+  name: Glutamatergic
+  cell_set_accession: class_label:de8ed2ce0f
+  taxonomy_id: CS202106160
+  taxonomy_level: CLASS
+  taxonomy_rank: 2
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  species: *id001

--- a/kb/taxonomy/CS202106160/cluster.yaml
+++ b/kb/taxonomy/CS202106160/cluster.yaml
@@ -1,0 +1,6199 @@
+taxonomy_id: CS202106160
+taxonomy_level: CLUSTER
+taxonomy_rank: 0
+nodes:
+- id: CTX-HPF:CS202106160_1
+  name: 1_CR
+  cell_set_accession: CS202106160_1
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CR
+    cell_set_accession: subclass_label:da99a9426c
+  species: &id001
+    id: NCBITaxon:10090
+    label: Mus musculus
+    name_in_source: Mus musculus
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 001
+- id: CTX-HPF:CS202106160_10
+  name: 10_Lamp5
+  cell_set_accession: CS202106160_10
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 010
+- id: CTX-HPF:CS202106160_100
+  name: 100_Sst
+  cell_set_accession: CS202106160_100
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 100
+- id: CTX-HPF:CS202106160_101
+  name: 101_Sst
+  cell_set_accession: CS202106160_101
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 101
+- id: CTX-HPF:CS202106160_102
+  name: 102_Sst HPF
+  cell_set_accession: CS202106160_102
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 102
+- id: CTX-HPF:CS202106160_103
+  name: 103_Sst HPF
+  cell_set_accession: CS202106160_103
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 103
+- id: CTX-HPF:CS202106160_104
+  name: 104_Sst HPF
+  cell_set_accession: CS202106160_104
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 104
+- id: CTX-HPF:CS202106160_105
+  name: 105_Sst HPF
+  cell_set_accession: CS202106160_105
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 105
+- id: CTX-HPF:CS202106160_106
+  name: 106_Sst HPF
+  cell_set_accession: CS202106160_106
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 106
+- id: CTX-HPF:CS202106160_107
+  name: 107_Sst HPF
+  cell_set_accession: CS202106160_107
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 107
+- id: CTX-HPF:CS202106160_108
+  name: 108_Pvalb
+  cell_set_accession: CS202106160_108
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 108
+- id: CTX-HPF:CS202106160_109
+  name: 109_Pvalb
+  cell_set_accession: CS202106160_109
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 109
+- id: CTX-HPF:CS202106160_11
+  name: 11_Lamp5
+  cell_set_accession: CS202106160_11
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 011
+- id: CTX-HPF:CS202106160_110
+  name: 110_Pvalb
+  cell_set_accession: CS202106160_110
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 110
+- id: CTX-HPF:CS202106160_111
+  name: 111_Pvalb
+  cell_set_accession: CS202106160_111
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 111
+- id: CTX-HPF:CS202106160_112
+  name: 112_Pvalb
+  cell_set_accession: CS202106160_112
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 112
+- id: CTX-HPF:CS202106160_113
+  name: 113_Pvalb
+  cell_set_accession: CS202106160_113
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 113
+- id: CTX-HPF:CS202106160_114
+  name: 114_Pvalb
+  cell_set_accession: CS202106160_114
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 114
+- id: CTX-HPF:CS202106160_115
+  name: 115_Pvalb
+  cell_set_accession: CS202106160_115
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 115
+- id: CTX-HPF:CS202106160_116
+  name: 116_Pvalb
+  cell_set_accession: CS202106160_116
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 116
+- id: CTX-HPF:CS202106160_117
+  name: 117_Pvalb
+  cell_set_accession: CS202106160_117
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 117
+- id: CTX-HPF:CS202106160_118
+  name: 118_Pvalb
+  cell_set_accession: CS202106160_118
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 118
+- id: CTX-HPF:CS202106160_119
+  name: 119_Pvalb
+  cell_set_accession: CS202106160_119
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 119
+- id: CTX-HPF:CS202106160_12
+  name: 12_Lamp5
+  cell_set_accession: CS202106160_12
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 012
+- id: CTX-HPF:CS202106160_120
+  name: 120_Pvalb
+  cell_set_accession: CS202106160_120
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 120
+- id: CTX-HPF:CS202106160_121
+  name: 121_Pvalb
+  cell_set_accession: CS202106160_121
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 121
+- id: CTX-HPF:CS202106160_122
+  name: 122_Pvalb Vipr2
+  cell_set_accession: CS202106160_122
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 122
+- id: CTX-HPF:CS202106160_123
+  name: 123_Pvalb Vipr2
+  cell_set_accession: CS202106160_123
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Pvalb
+    cell_set_accession: CS202106160_463
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 123
+- id: CTX-HPF:CS202106160_124
+  name: 124_L2 IT APr
+  cell_set_accession: CS202106160_124
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 124
+- id: CTX-HPF:CS202106160_125
+  name: 125_L2 IT APr
+  cell_set_accession: CS202106160_125
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 125
+- id: CTX-HPF:CS202106160_126
+  name: 126_L2 IT APr
+  cell_set_accession: CS202106160_126
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 126
+- id: CTX-HPF:CS202106160_127
+  name: 127_L2 IT APr
+  cell_set_accession: CS202106160_127
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 127
+- id: CTX-HPF:CS202106160_128
+  name: 128_L2 IT APr
+  cell_set_accession: CS202106160_128
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 128
+- id: CTX-HPF:CS202106160_129
+  name: 129_L2/3 IT POST-PRE
+  cell_set_accession: CS202106160_129
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 129
+- id: CTX-HPF:CS202106160_13
+  name: 13_Lamp5
+  cell_set_accession: CS202106160_13
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 013
+- id: CTX-HPF:CS202106160_130
+  name: 130_L2/3 IT POST-PRE
+  cell_set_accession: CS202106160_130
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 130
+- id: CTX-HPF:CS202106160_131
+  name: 131_L2/3 IT POST-PRE
+  cell_set_accession: CS202106160_131
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 131
+- id: CTX-HPF:CS202106160_132
+  name: 132_L2 IT RSPv-POST-PRE
+  cell_set_accession: CS202106160_132
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 132
+- id: CTX-HPF:CS202106160_133
+  name: 133_L2 IT RSPv-POST-PRE
+  cell_set_accession: CS202106160_133
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 133
+- id: CTX-HPF:CS202106160_134
+  name: 134_L2 IT RSP-ACA
+  cell_set_accession: CS202106160_134
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 134
+- id: CTX-HPF:CS202106160_135
+  name: 135_L3 IT ENTm
+  cell_set_accession: CS202106160_135
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L3 IT ENT
+    cell_set_accession: CS202106160_480
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 135
+- id: CTX-HPF:CS202106160_136
+  name: 136_L3 IT ENTm
+  cell_set_accession: CS202106160_136
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L3 IT ENT
+    cell_set_accession: CS202106160_480
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 136
+- id: CTX-HPF:CS202106160_137
+  name: 137_L3 IT ENTm
+  cell_set_accession: CS202106160_137
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L3 IT ENT
+    cell_set_accession: CS202106160_480
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 137
+- id: CTX-HPF:CS202106160_138
+  name: 138_L3 IT ENTm
+  cell_set_accession: CS202106160_138
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L3 IT ENT
+    cell_set_accession: CS202106160_480
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 138
+- id: CTX-HPF:CS202106160_139
+  name: 139_L3 IT ENTl
+  cell_set_accession: CS202106160_139
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L3 IT ENT
+    cell_set_accession: CS202106160_480
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 139
+- id: CTX-HPF:CS202106160_14
+  name: 14_Lamp5
+  cell_set_accession: CS202106160_14
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 014
+- id: CTX-HPF:CS202106160_140
+  name: 140_L3 IT ENTl
+  cell_set_accession: CS202106160_140
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L3 IT ENT
+    cell_set_accession: CS202106160_480
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 140
+- id: CTX-HPF:CS202106160_141
+  name: 141_L2/3 IT PAR
+  cell_set_accession: CS202106160_141
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 141
+- id: CTX-HPF:CS202106160_142
+  name: 142_L2/3 IT PAR
+  cell_set_accession: CS202106160_142
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 142
+- id: CTX-HPF:CS202106160_143
+  name: 143_L2/3 IT PAR
+  cell_set_accession: CS202106160_143
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 143
+- id: CTX-HPF:CS202106160_144
+  name: 144_L2/3 IT PAR
+  cell_set_accession: CS202106160_144
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 144
+- id: CTX-HPF:CS202106160_145
+  name: 145_L2/3 IT PAR
+  cell_set_accession: CS202106160_145
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT PPP
+    cell_set_accession: subclass_label:5d7a3b937f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 145
+- id: CTX-HPF:CS202106160_146
+  name: 146_L2 IT ENTm
+  cell_set_accession: CS202106160_146
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2 IT ENTm
+    cell_set_accession: CS202106160_486
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 146
+- id: CTX-HPF:CS202106160_147
+  name: 147_L2 IT ENTm
+  cell_set_accession: CS202106160_147
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2 IT ENTm
+    cell_set_accession: CS202106160_486
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 147
+- id: CTX-HPF:CS202106160_148
+  name: 148_L2 IT ENTm
+  cell_set_accession: CS202106160_148
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2 IT ENTm
+    cell_set_accession: CS202106160_486
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 148
+- id: CTX-HPF:CS202106160_149
+  name: 149_L2 IT ENTm
+  cell_set_accession: CS202106160_149
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2 IT ENTm
+    cell_set_accession: CS202106160_486
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 149
+- id: CTX-HPF:CS202106160_15
+  name: 15_Lamp5
+  cell_set_accession: CS202106160_15
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 015
+- id: CTX-HPF:CS202106160_150
+  name: 150_L2 IT ENTm
+  cell_set_accession: CS202106160_150
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2 IT ENTm
+    cell_set_accession: CS202106160_486
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 150
+- id: CTX-HPF:CS202106160_151
+  name: 151_L2 IT ENTl
+  cell_set_accession: CS202106160_151
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2 IT ENTl
+    cell_set_accession: subclass_label:ad2ac45237
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 151
+- id: CTX-HPF:CS202106160_152
+  name: 152_L2/3 IT ENTl
+  cell_set_accession: CS202106160_152
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT ENTl
+    cell_set_accession: subclass_label:9c706e279e
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 152
+- id: CTX-HPF:CS202106160_153
+  name: 153_L2/3 IT ENTl
+  cell_set_accession: CS202106160_153
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT ENTl
+    cell_set_accession: subclass_label:9c706e279e
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 153
+- id: CTX-HPF:CS202106160_154
+  name: 154_L2/3 IT ENTl
+  cell_set_accession: CS202106160_154
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT ENTl
+    cell_set_accession: subclass_label:9c706e279e
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 154
+- id: CTX-HPF:CS202106160_155
+  name: 155_L2/3 IT ENTl
+  cell_set_accession: CS202106160_155
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT ENTl
+    cell_set_accession: subclass_label:9c706e279e
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 155
+- id: CTX-HPF:CS202106160_156
+  name: 156_L2/3 IT ENTl
+  cell_set_accession: CS202106160_156
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT ENTl
+    cell_set_accession: subclass_label:9c706e279e
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 156
+- id: CTX-HPF:CS202106160_157
+  name: 157_L2/3 IT ENTl
+  cell_set_accession: CS202106160_157
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT ENTl
+    cell_set_accession: subclass_label:9c706e279e
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 157
+- id: CTX-HPF:CS202106160_158
+  name: 158_L2/3 IT AI
+  cell_set_accession: CS202106160_158
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT ENTl
+    cell_set_accession: subclass_label:9c706e279e
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 158
+- id: CTX-HPF:CS202106160_159
+  name: 159_L2/3 IT AI
+  cell_set_accession: CS202106160_159
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT ENTl
+    cell_set_accession: subclass_label:9c706e279e
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 159
+- id: CTX-HPF:CS202106160_16
+  name: 16_Lamp5
+  cell_set_accession: CS202106160_16
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 016
+- id: CTX-HPF:CS202106160_160
+  name: 160_L2/3 IT ENTl
+  cell_set_accession: CS202106160_160
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT ENTl
+    cell_set_accession: subclass_label:9c706e279e
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 160
+- id: CTX-HPF:CS202106160_161
+  name: 161_L2/3 IT ENTl
+  cell_set_accession: CS202106160_161
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT ENTl
+    cell_set_accession: subclass_label:9c706e279e
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 161
+- id: CTX-HPF:CS202106160_162
+  name: 162_L2/3 IT CTX
+  cell_set_accession: CS202106160_162
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT CTX
+    cell_set_accession: CS202106160_494
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 162
+- id: CTX-HPF:CS202106160_163
+  name: 163_L2/3 IT CTX
+  cell_set_accession: CS202106160_163
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT CTX
+    cell_set_accession: CS202106160_494
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 163
+- id: CTX-HPF:CS202106160_164
+  name: 164_L2/3 IT CTX
+  cell_set_accession: CS202106160_164
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT CTX
+    cell_set_accession: CS202106160_494
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 164
+- id: CTX-HPF:CS202106160_165
+  name: 165_L2/3 IT CTX
+  cell_set_accession: CS202106160_165
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT CTX
+    cell_set_accession: CS202106160_494
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 165
+- id: CTX-HPF:CS202106160_166
+  name: 166_L2/3 IT CTX
+  cell_set_accession: CS202106160_166
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT CTX
+    cell_set_accession: CS202106160_494
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 166
+- id: CTX-HPF:CS202106160_167
+  name: 167_L2/3 IT CTX
+  cell_set_accession: CS202106160_167
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT CTX
+    cell_set_accession: CS202106160_494
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 167
+- id: CTX-HPF:CS202106160_168
+  name: 168_L2/3 IT CTX
+  cell_set_accession: CS202106160_168
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT CTX
+    cell_set_accession: CS202106160_494
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 168
+- id: CTX-HPF:CS202106160_169
+  name: 169_L2/3 IT CTX
+  cell_set_accession: CS202106160_169
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT CTX
+    cell_set_accession: CS202106160_494
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 169
+- id: CTX-HPF:CS202106160_17
+  name: 17_Lamp5
+  cell_set_accession: CS202106160_17
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 017
+- id: CTX-HPF:CS202106160_170
+  name: 170_L2/3 IT CTX
+  cell_set_accession: CS202106160_170
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT CTX
+    cell_set_accession: CS202106160_494
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 170
+- id: CTX-HPF:CS202106160_171
+  name: 171_L2/3 IT CTX
+  cell_set_accession: CS202106160_171
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT CTX
+    cell_set_accession: CS202106160_494
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 171
+- id: CTX-HPF:CS202106160_172
+  name: 172_L2/3 IT ProS
+  cell_set_accession: CS202106160_172
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT RHP
+    cell_set_accession: CS202106160_498
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 172
+- id: CTX-HPF:CS202106160_173
+  name: 173_L2/3 IT ProS
+  cell_set_accession: CS202106160_173
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT RHP
+    cell_set_accession: CS202106160_498
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 173
+- id: CTX-HPF:CS202106160_174
+  name: 174_IT HATA
+  cell_set_accession: CS202106160_174
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT RHP
+    cell_set_accession: CS202106160_498
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 174
+- id: CTX-HPF:CS202106160_175
+  name: 175_IT HATA
+  cell_set_accession: CS202106160_175
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT RHP
+    cell_set_accession: CS202106160_498
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 175
+- id: CTX-HPF:CS202106160_176
+  name: 176_IT HATA
+  cell_set_accession: CS202106160_176
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT RHP
+    cell_set_accession: CS202106160_498
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 176
+- id: CTX-HPF:CS202106160_177
+  name: 177_IT HATA
+  cell_set_accession: CS202106160_177
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L2/3 IT RHP
+    cell_set_accession: CS202106160_498
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 177
+- id: CTX-HPF:CS202106160_178
+  name: 178_L4 IT CTX
+  cell_set_accession: CS202106160_178
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 178
+- id: CTX-HPF:CS202106160_179
+  name: 179_L4 IT CTX
+  cell_set_accession: CS202106160_179
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 179
+- id: CTX-HPF:CS202106160_18
+  name: 18_Lamp5
+  cell_set_accession: CS202106160_18
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 018
+- id: CTX-HPF:CS202106160_180
+  name: 180_L4 IT CTX
+  cell_set_accession: CS202106160_180
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 180
+- id: CTX-HPF:CS202106160_181
+  name: 181_L4 IT CTX
+  cell_set_accession: CS202106160_181
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 181
+- id: CTX-HPF:CS202106160_182
+  name: 182_L4/5 IT CTX
+  cell_set_accession: CS202106160_182
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 182
+- id: CTX-HPF:CS202106160_183
+  name: 183_L4/5 IT CTX
+  cell_set_accession: CS202106160_183
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 183
+- id: CTX-HPF:CS202106160_184
+  name: 184_L4/5 IT CTX
+  cell_set_accession: CS202106160_184
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 184
+- id: CTX-HPF:CS202106160_185
+  name: 185_L4/5 IT CTX
+  cell_set_accession: CS202106160_185
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 185
+- id: CTX-HPF:CS202106160_186
+  name: 186_L4/5 IT CTX
+  cell_set_accession: CS202106160_186
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 186
+- id: CTX-HPF:CS202106160_187
+  name: 187_L4/5 IT CTX
+  cell_set_accession: CS202106160_187
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 187
+- id: CTX-HPF:CS202106160_188
+  name: 188_L4/5 IT CTX
+  cell_set_accession: CS202106160_188
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 188
+- id: CTX-HPF:CS202106160_189
+  name: 189_L4/5 IT CTX
+  cell_set_accession: CS202106160_189
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 189
+- id: CTX-HPF:CS202106160_19
+  name: 19_Pax6
+  cell_set_accession: CS202106160_19
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 019
+- id: CTX-HPF:CS202106160_190
+  name: 190_L4/5 IT CTX
+  cell_set_accession: CS202106160_190
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 190
+- id: CTX-HPF:CS202106160_191
+  name: 191_L4/5 IT CTX
+  cell_set_accession: CS202106160_191
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 191
+- id: CTX-HPF:CS202106160_192
+  name: 192_L4/5 IT CTX
+  cell_set_accession: CS202106160_192
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 192
+- id: CTX-HPF:CS202106160_193
+  name: 193_L4/5 IT CTX
+  cell_set_accession: CS202106160_193
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4/5 IT CTX
+    cell_set_accession: subclass_label:40ec201664
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 193
+- id: CTX-HPF:CS202106160_194
+  name: 194_L5 IT RSP-ACA
+  cell_set_accession: CS202106160_194
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 194
+- id: CTX-HPF:CS202106160_195
+  name: 195_L5 IT RSP-ACA
+  cell_set_accession: CS202106160_195
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 195
+- id: CTX-HPF:CS202106160_196
+  name: 196_L5 IT CTX
+  cell_set_accession: CS202106160_196
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 196
+- id: CTX-HPF:CS202106160_197
+  name: 197_L5 IT CTX
+  cell_set_accession: CS202106160_197
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 197
+- id: CTX-HPF:CS202106160_198
+  name: 198_L5 IT CTX
+  cell_set_accession: CS202106160_198
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 198
+- id: CTX-HPF:CS202106160_199
+  name: 199_L5 IT CTX
+  cell_set_accession: CS202106160_199
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 199
+- id: CTX-HPF:CS202106160_2
+  name: 2_Meis2
+  cell_set_accession: CS202106160_2
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Meis2
+    cell_set_accession: CS202106160_396
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 002
+- id: CTX-HPF:CS202106160_20
+  name: 20_Pax6
+  cell_set_accession: CS202106160_20
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 020
+- id: CTX-HPF:CS202106160_200
+  name: 200_L5 IT CTX
+  cell_set_accession: CS202106160_200
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 200
+- id: CTX-HPF:CS202106160_201
+  name: 201_L5 IT CTX
+  cell_set_accession: CS202106160_201
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 201
+- id: CTX-HPF:CS202106160_202
+  name: 202_L5 IT CTX
+  cell_set_accession: CS202106160_202
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 202
+- id: CTX-HPF:CS202106160_203
+  name: 203_L5/6 IT CTX
+  cell_set_accession: CS202106160_203
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 203
+- id: CTX-HPF:CS202106160_204
+  name: 204_L5/6 IT CTX
+  cell_set_accession: CS202106160_204
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 204
+- id: CTX-HPF:CS202106160_205
+  name: 205_L5/6 IT CTX
+  cell_set_accession: CS202106160_205
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 205
+- id: CTX-HPF:CS202106160_206
+  name: 206_L5/6 IT CTX
+  cell_set_accession: CS202106160_206
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 206
+- id: CTX-HPF:CS202106160_207
+  name: 207_L5/6 IT CTX
+  cell_set_accession: CS202106160_207
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 207
+- id: CTX-HPF:CS202106160_208
+  name: 208_L5/6 IT CTX
+  cell_set_accession: CS202106160_208
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 208
+- id: CTX-HPF:CS202106160_209
+  name: 209_L5/6 IT CTX
+  cell_set_accession: CS202106160_209
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 IT CTX
+    cell_set_accession: subclass_label:d88cf82cba
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 209
+- id: CTX-HPF:CS202106160_21
+  name: 21_Sncg
+  cell_set_accession: CS202106160_21
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 021
+- id: CTX-HPF:CS202106160_210
+  name: 210_L5/6 IT TPE-ENT
+  cell_set_accession: CS202106160_210
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 IT TPE-ENT
+    cell_set_accession: subclass_label:753888bc28
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 210
+- id: CTX-HPF:CS202106160_211
+  name: 211_L5/6 IT TPE-ENT
+  cell_set_accession: CS202106160_211
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 IT TPE-ENT
+    cell_set_accession: subclass_label:753888bc28
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 211
+- id: CTX-HPF:CS202106160_212
+  name: 212_L5/6 IT TPE-ENT
+  cell_set_accession: CS202106160_212
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 IT TPE-ENT
+    cell_set_accession: subclass_label:753888bc28
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 212
+- id: CTX-HPF:CS202106160_213
+  name: 213_L5/6 IT TPE-ENT
+  cell_set_accession: CS202106160_213
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 IT TPE-ENT
+    cell_set_accession: subclass_label:753888bc28
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 213
+- id: CTX-HPF:CS202106160_214
+  name: 214_L5/6 IT PFC
+  cell_set_accession: CS202106160_214
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 IT TPE-ENT
+    cell_set_accession: subclass_label:753888bc28
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 214
+- id: CTX-HPF:CS202106160_215
+  name: 215_L5/6 IT TPE-ENT
+  cell_set_accession: CS202106160_215
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 IT TPE-ENT
+    cell_set_accession: subclass_label:753888bc28
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 215
+- id: CTX-HPF:CS202106160_216
+  name: 216_L5/6 IT TPE-ENT
+  cell_set_accession: CS202106160_216
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 IT TPE-ENT
+    cell_set_accession: subclass_label:753888bc28
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 216
+- id: CTX-HPF:CS202106160_217
+  name: 217_L6 IT CTX
+  cell_set_accession: CS202106160_217
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 217
+- id: CTX-HPF:CS202106160_218
+  name: 218_L6 IT CTX
+  cell_set_accession: CS202106160_218
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 218
+- id: CTX-HPF:CS202106160_219
+  name: 219_L6 IT CTX
+  cell_set_accession: CS202106160_219
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 219
+- id: CTX-HPF:CS202106160_22
+  name: 22_Sncg
+  cell_set_accession: CS202106160_22
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 022
+- id: CTX-HPF:CS202106160_220
+  name: 220_L6 IT CTX
+  cell_set_accession: CS202106160_220
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 220
+- id: CTX-HPF:CS202106160_221
+  name: 221_L6 IT CTX
+  cell_set_accession: CS202106160_221
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 221
+- id: CTX-HPF:CS202106160_222
+  name: 222_L6 IT CTX
+  cell_set_accession: CS202106160_222
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 222
+- id: CTX-HPF:CS202106160_223
+  name: 223_L6 IT CTX
+  cell_set_accession: CS202106160_223
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 223
+- id: CTX-HPF:CS202106160_224
+  name: 224_L6 IT CTX
+  cell_set_accession: CS202106160_224
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 224
+- id: CTX-HPF:CS202106160_225
+  name: 225_L6 IT CTX
+  cell_set_accession: CS202106160_225
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 225
+- id: CTX-HPF:CS202106160_226
+  name: 226_L6 IT CTX
+  cell_set_accession: CS202106160_226
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 226
+- id: CTX-HPF:CS202106160_227
+  name: 227_L6 IT CTX
+  cell_set_accession: CS202106160_227
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 227
+- id: CTX-HPF:CS202106160_228
+  name: 228_L6 IT CTX
+  cell_set_accession: CS202106160_228
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 228
+- id: CTX-HPF:CS202106160_229
+  name: 229_L6 IT CTX
+  cell_set_accession: CS202106160_229
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 229
+- id: CTX-HPF:CS202106160_23
+  name: 23_Sncg
+  cell_set_accession: CS202106160_23
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 023
+- id: CTX-HPF:CS202106160_230
+  name: 230_L6 IT CTX
+  cell_set_accession: CS202106160_230
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 230
+- id: CTX-HPF:CS202106160_231
+  name: 231_L6 IT CTX
+  cell_set_accession: CS202106160_231
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 231
+- id: CTX-HPF:CS202106160_232
+  name: 232_L6 IT CTX
+  cell_set_accession: CS202106160_232
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT CTX
+    cell_set_accession: subclass_label:10db4e9506
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 232
+- id: CTX-HPF:CS202106160_233
+  name: 233_L6 IT ENTl
+  cell_set_accession: CS202106160_233
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT ENTl
+    cell_set_accession: subclass_label:7ec93c83f4
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 233
+- id: CTX-HPF:CS202106160_234
+  name: 234_L6 IT ENTl
+  cell_set_accession: CS202106160_234
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT ENTl
+    cell_set_accession: subclass_label:7ec93c83f4
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 234
+- id: CTX-HPF:CS202106160_235
+  name: 235_L6 IT ENTl
+  cell_set_accession: CS202106160_235
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 IT ENTl
+    cell_set_accession: subclass_label:7ec93c83f4
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 235
+- id: CTX-HPF:CS202106160_236
+  name: 236_Car3
+  cell_set_accession: CS202106160_236
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Car3
+    cell_set_accession: CS202106160_525
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 236
+- id: CTX-HPF:CS202106160_237
+  name: 237_Car3
+  cell_set_accession: CS202106160_237
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Car3
+    cell_set_accession: CS202106160_525
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 237
+- id: CTX-HPF:CS202106160_238
+  name: 238_Car3
+  cell_set_accession: CS202106160_238
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Car3
+    cell_set_accession: CS202106160_525
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 238
+- id: CTX-HPF:CS202106160_239
+  name: 239_L5 PT CTX
+  cell_set_accession: CS202106160_239
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 239
+- id: CTX-HPF:CS202106160_24
+  name: 24_Sncg
+  cell_set_accession: CS202106160_24
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 024
+- id: CTX-HPF:CS202106160_240
+  name: 240_L5 PT CTX
+  cell_set_accession: CS202106160_240
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 240
+- id: CTX-HPF:CS202106160_241
+  name: 241_L5 PT CTX
+  cell_set_accession: CS202106160_241
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 241
+- id: CTX-HPF:CS202106160_242
+  name: 242_L5 PT CTX
+  cell_set_accession: CS202106160_242
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 242
+- id: CTX-HPF:CS202106160_243
+  name: 243_L5 PT CTX
+  cell_set_accession: CS202106160_243
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 243
+- id: CTX-HPF:CS202106160_244
+  name: 244_L5 PT CTX
+  cell_set_accession: CS202106160_244
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 244
+- id: CTX-HPF:CS202106160_245
+  name: 245_L5 PT CTX
+  cell_set_accession: CS202106160_245
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 245
+- id: CTX-HPF:CS202106160_246
+  name: 246_L5 PT CTX
+  cell_set_accession: CS202106160_246
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 246
+- id: CTX-HPF:CS202106160_247
+  name: 247_L5 PT CTX
+  cell_set_accession: CS202106160_247
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 247
+- id: CTX-HPF:CS202106160_248
+  name: 248_L5 PT CTX
+  cell_set_accession: CS202106160_248
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 248
+- id: CTX-HPF:CS202106160_249
+  name: 249_L5 PT CTX
+  cell_set_accession: CS202106160_249
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 249
+- id: CTX-HPF:CS202106160_25
+  name: 25_Sncg
+  cell_set_accession: CS202106160_25
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 025
+- id: CTX-HPF:CS202106160_250
+  name: 250_L5 PT CTX
+  cell_set_accession: CS202106160_250
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 250
+- id: CTX-HPF:CS202106160_251
+  name: 251_L5 PT CTX
+  cell_set_accession: CS202106160_251
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 251
+- id: CTX-HPF:CS202106160_252
+  name: 252_L5 PT CTX
+  cell_set_accession: CS202106160_252
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 252
+- id: CTX-HPF:CS202106160_253
+  name: 253_L5 PT CTX
+  cell_set_accession: CS202106160_253
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 253
+- id: CTX-HPF:CS202106160_254
+  name: 254_L5 PT CTX
+  cell_set_accession: CS202106160_254
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 254
+- id: CTX-HPF:CS202106160_255
+  name: 255_L5 PT CTX
+  cell_set_accession: CS202106160_255
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 255
+- id: CTX-HPF:CS202106160_256
+  name: 256_L5 PT CTX
+  cell_set_accession: CS202106160_256
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 256
+- id: CTX-HPF:CS202106160_257
+  name: 257_L5 PT CTX
+  cell_set_accession: CS202106160_257
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 257
+- id: CTX-HPF:CS202106160_258
+  name: 258_L5 PT CTX
+  cell_set_accession: CS202106160_258
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 258
+- id: CTX-HPF:CS202106160_259
+  name: 259_L5 PT CTX
+  cell_set_accession: CS202106160_259
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 259
+- id: CTX-HPF:CS202106160_26
+  name: 26_Ntng1 HPF
+  cell_set_accession: CS202106160_26
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 026
+- id: CTX-HPF:CS202106160_260
+  name: 260_L5 PT CTX
+  cell_set_accession: CS202106160_260
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PT CTX
+    cell_set_accession: CS202106160_528
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 260
+- id: CTX-HPF:CS202106160_261
+  name: 261_L4 RSP-ACA
+  cell_set_accession: CS202106160_261
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4 RSP-ACA
+    cell_set_accession: CS202106160_535
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 261
+- id: CTX-HPF:CS202106160_262
+  name: 262_L4 RSP-ACA
+  cell_set_accession: CS202106160_262
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L4 RSP-ACA
+    cell_set_accession: CS202106160_535
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 262
+- id: CTX-HPF:CS202106160_263
+  name: 263_L5 PPP
+  cell_set_accession: CS202106160_263
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5 PPP
+    cell_set_accession: subclass_label:bbf0716163
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 263
+- id: CTX-HPF:CS202106160_264
+  name: 264_L5/6 NP CTX
+  cell_set_accession: CS202106160_264
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 NP CTX
+    cell_set_accession: CS202106160_538
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 264
+- id: CTX-HPF:CS202106160_265
+  name: 265_L5/6 NP CTX
+  cell_set_accession: CS202106160_265
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 NP CTX
+    cell_set_accession: CS202106160_538
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 265
+- id: CTX-HPF:CS202106160_266
+  name: 266_L5/6 NP CTX
+  cell_set_accession: CS202106160_266
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 NP CTX
+    cell_set_accession: CS202106160_538
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 266
+- id: CTX-HPF:CS202106160_267
+  name: 267_L5/6 NP CTX
+  cell_set_accession: CS202106160_267
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 NP CTX
+    cell_set_accession: CS202106160_538
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 267
+- id: CTX-HPF:CS202106160_268
+  name: 268_L5/6 NP CTX
+  cell_set_accession: CS202106160_268
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 NP CTX
+    cell_set_accession: CS202106160_538
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 268
+- id: CTX-HPF:CS202106160_269
+  name: 269_L5/6 NP CTX
+  cell_set_accession: CS202106160_269
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 NP CTX
+    cell_set_accession: CS202106160_538
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 269
+- id: CTX-HPF:CS202106160_27
+  name: 27_Ntng1 HPF
+  cell_set_accession: CS202106160_27
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 027
+- id: CTX-HPF:CS202106160_270
+  name: 270_L5/6 NP CT CTX
+  cell_set_accession: CS202106160_270
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L5/6 NP CTX
+    cell_set_accession: CS202106160_538
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 270
+- id: CTX-HPF:CS202106160_271
+  name: 271_NP SUB
+  cell_set_accession: CS202106160_271
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: NP SUB
+    cell_set_accession: CS202106160_541
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 271
+- id: CTX-HPF:CS202106160_272
+  name: 272_NP SUB
+  cell_set_accession: CS202106160_272
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: NP SUB
+    cell_set_accession: CS202106160_541
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 272
+- id: CTX-HPF:CS202106160_273
+  name: 273_NP SUB
+  cell_set_accession: CS202106160_273
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: NP SUB
+    cell_set_accession: CS202106160_541
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 273
+- id: CTX-HPF:CS202106160_274
+  name: 274_NP SUB
+  cell_set_accession: CS202106160_274
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: NP SUB
+    cell_set_accession: CS202106160_541
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 274
+- id: CTX-HPF:CS202106160_275
+  name: 275_NP PPP
+  cell_set_accession: CS202106160_275
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: NP PPP
+    cell_set_accession: CS202106160_544
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 275
+- id: CTX-HPF:CS202106160_276
+  name: 276_NP PPP
+  cell_set_accession: CS202106160_276
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: NP PPP
+    cell_set_accession: CS202106160_544
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 276
+- id: CTX-HPF:CS202106160_277
+  name: 277_NP PPP
+  cell_set_accession: CS202106160_277
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: NP PPP
+    cell_set_accession: CS202106160_544
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 277
+- id: CTX-HPF:CS202106160_278
+  name: 278_L6 CT CTX
+  cell_set_accession: CS202106160_278
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 278
+- id: CTX-HPF:CS202106160_279
+  name: 279_L6 CT CTX
+  cell_set_accession: CS202106160_279
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 279
+- id: CTX-HPF:CS202106160_28
+  name: 28_Ntng1 HPF
+  cell_set_accession: CS202106160_28
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 028
+- id: CTX-HPF:CS202106160_280
+  name: 280_L6 CT CTX
+  cell_set_accession: CS202106160_280
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 280
+- id: CTX-HPF:CS202106160_281
+  name: 281_L6 CT CTX
+  cell_set_accession: CS202106160_281
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 281
+- id: CTX-HPF:CS202106160_282
+  name: 282_L6 CT CTX
+  cell_set_accession: CS202106160_282
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 282
+- id: CTX-HPF:CS202106160_283
+  name: 283_L6 CT CTX
+  cell_set_accession: CS202106160_283
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 283
+- id: CTX-HPF:CS202106160_284
+  name: 284_L6 CT CTX
+  cell_set_accession: CS202106160_284
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 284
+- id: CTX-HPF:CS202106160_285
+  name: 285_L6 CT CTX
+  cell_set_accession: CS202106160_285
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 285
+- id: CTX-HPF:CS202106160_286
+  name: 286_L6 CT CTX
+  cell_set_accession: CS202106160_286
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 286
+- id: CTX-HPF:CS202106160_287
+  name: 287_L6 CT CTX
+  cell_set_accession: CS202106160_287
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 287
+- id: CTX-HPF:CS202106160_288
+  name: 288_L6 CT CTX
+  cell_set_accession: CS202106160_288
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 288
+- id: CTX-HPF:CS202106160_289
+  name: 289_L6 CT CTX
+  cell_set_accession: CS202106160_289
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 289
+- id: CTX-HPF:CS202106160_29
+  name: 29_Ntng1 HPF
+  cell_set_accession: CS202106160_29
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 029
+- id: CTX-HPF:CS202106160_290
+  name: 290_L6 CT CTX
+  cell_set_accession: CS202106160_290
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 290
+- id: CTX-HPF:CS202106160_291
+  name: 291_L6 CT CTX
+  cell_set_accession: CS202106160_291
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 291
+- id: CTX-HPF:CS202106160_292
+  name: 292_L6 CT CTX
+  cell_set_accession: CS202106160_292
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 292
+- id: CTX-HPF:CS202106160_293
+  name: 293_L6 CT CTX
+  cell_set_accession: CS202106160_293
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6 CT CTX
+    cell_set_accession: CS202106160_548
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 293
+- id: CTX-HPF:CS202106160_294
+  name: 294_CT SUB
+  cell_set_accession: CS202106160_294
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CT SUB
+    cell_set_accession: CS202106160_551
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 294
+- id: CTX-HPF:CS202106160_295
+  name: 295_CT SUB
+  cell_set_accession: CS202106160_295
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CT SUB
+    cell_set_accession: CS202106160_551
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 295
+- id: CTX-HPF:CS202106160_296
+  name: 296_CT SUB
+  cell_set_accession: CS202106160_296
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CT SUB
+    cell_set_accession: CS202106160_551
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 296
+- id: CTX-HPF:CS202106160_297
+  name: 297_CT SUB
+  cell_set_accession: CS202106160_297
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CT SUB
+    cell_set_accession: CS202106160_551
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 297
+- id: CTX-HPF:CS202106160_298
+  name: 298_L6 CT ENT
+  cell_set_accession: CS202106160_298
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b/CT ENT
+    cell_set_accession: subclass_label:d636443977
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 298
+- id: CTX-HPF:CS202106160_299
+  name: 299_L6 CT ENT
+  cell_set_accession: CS202106160_299
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b/CT ENT
+    cell_set_accession: subclass_label:d636443977
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 299
+- id: CTX-HPF:CS202106160_3
+  name: 3_Meis2
+  cell_set_accession: CS202106160_3
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Meis2
+    cell_set_accession: CS202106160_396
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 003
+- id: CTX-HPF:CS202106160_30
+  name: 30_Ntng1 HPF
+  cell_set_accession: CS202106160_30
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 030
+- id: CTX-HPF:CS202106160_300
+  name: 300_L6b ENT
+  cell_set_accession: CS202106160_300
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b/CT ENT
+    cell_set_accession: subclass_label:d636443977
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 300
+- id: CTX-HPF:CS202106160_301
+  name: 301_L6b ENT
+  cell_set_accession: CS202106160_301
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b/CT ENT
+    cell_set_accession: subclass_label:d636443977
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 301
+- id: CTX-HPF:CS202106160_302
+  name: 302_L6b ENT
+  cell_set_accession: CS202106160_302
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b/CT ENT
+    cell_set_accession: subclass_label:d636443977
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 302
+- id: CTX-HPF:CS202106160_303
+  name: 303_L6b CTX
+  cell_set_accession: CS202106160_303
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 303
+- id: CTX-HPF:CS202106160_304
+  name: 304_L6b CTX
+  cell_set_accession: CS202106160_304
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 304
+- id: CTX-HPF:CS202106160_305
+  name: 305_L6b CTX
+  cell_set_accession: CS202106160_305
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 305
+- id: CTX-HPF:CS202106160_306
+  name: 306_L6b CTX
+  cell_set_accession: CS202106160_306
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 306
+- id: CTX-HPF:CS202106160_307
+  name: 307_L6b CTX
+  cell_set_accession: CS202106160_307
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 307
+- id: CTX-HPF:CS202106160_308
+  name: 308_L6b RHP
+  cell_set_accession: CS202106160_308
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 308
+- id: CTX-HPF:CS202106160_309
+  name: 309_L6b RHP
+  cell_set_accession: CS202106160_309
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 309
+- id: CTX-HPF:CS202106160_31
+  name: 31_Sncg
+  cell_set_accession: CS202106160_31
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 031
+- id: CTX-HPF:CS202106160_310
+  name: 310_L6b RHP
+  cell_set_accession: CS202106160_310
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 310
+- id: CTX-HPF:CS202106160_311
+  name: 311_L6b CTX
+  cell_set_accession: CS202106160_311
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 311
+- id: CTX-HPF:CS202106160_312
+  name: 312_L6b CTX
+  cell_set_accession: CS202106160_312
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 312
+- id: CTX-HPF:CS202106160_313
+  name: 313_L6b CTX
+  cell_set_accession: CS202106160_313
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 313
+- id: CTX-HPF:CS202106160_314
+  name: 314_L6b CTX
+  cell_set_accession: CS202106160_314
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 314
+- id: CTX-HPF:CS202106160_315
+  name: 315_L6b CTX
+  cell_set_accession: CS202106160_315
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 315
+- id: CTX-HPF:CS202106160_316
+  name: 316_L6b CTX
+  cell_set_accession: CS202106160_316
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 316
+- id: CTX-HPF:CS202106160_317
+  name: 317_L6b CTX
+  cell_set_accession: CS202106160_317
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: L6b CTX
+    cell_set_accession: subclass_label:8fb647662f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 317
+- id: CTX-HPF:CS202106160_318
+  name: 318_SUB
+  cell_set_accession: CS202106160_318
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SUB-ProS
+    cell_set_accession: subclass_label:a416c5553f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 318
+- id: CTX-HPF:CS202106160_319
+  name: 319_SUB
+  cell_set_accession: CS202106160_319
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SUB-ProS
+    cell_set_accession: subclass_label:a416c5553f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 319
+- id: CTX-HPF:CS202106160_32
+  name: 32_Sncg
+  cell_set_accession: CS202106160_32
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 032
+- id: CTX-HPF:CS202106160_320
+  name: 320_SUB
+  cell_set_accession: CS202106160_320
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SUB-ProS
+    cell_set_accession: subclass_label:a416c5553f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 320
+- id: CTX-HPF:CS202106160_321
+  name: 321_SUB
+  cell_set_accession: CS202106160_321
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SUB-ProS
+    cell_set_accession: subclass_label:a416c5553f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 321
+- id: CTX-HPF:CS202106160_322
+  name: 322_ProS
+  cell_set_accession: CS202106160_322
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SUB-ProS
+    cell_set_accession: subclass_label:a416c5553f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 322
+- id: CTX-HPF:CS202106160_323
+  name: 323_ProS
+  cell_set_accession: CS202106160_323
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SUB-ProS
+    cell_set_accession: subclass_label:a416c5553f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 323
+- id: CTX-HPF:CS202106160_324
+  name: 324_ProS
+  cell_set_accession: CS202106160_324
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SUB-ProS
+    cell_set_accession: subclass_label:a416c5553f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 324
+- id: CTX-HPF:CS202106160_325
+  name: 325_ProS
+  cell_set_accession: CS202106160_325
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SUB-ProS
+    cell_set_accession: subclass_label:a416c5553f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 325
+- id: CTX-HPF:CS202106160_326
+  name: 326_ProS
+  cell_set_accession: CS202106160_326
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SUB-ProS
+    cell_set_accession: subclass_label:a416c5553f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 326
+- id: CTX-HPF:CS202106160_327
+  name: 327_ProS
+  cell_set_accession: CS202106160_327
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SUB-ProS
+    cell_set_accession: subclass_label:a416c5553f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 327
+- id: CTX-HPF:CS202106160_328
+  name: 328_ProS
+  cell_set_accession: CS202106160_328
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SUB-ProS
+    cell_set_accession: subclass_label:a416c5553f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 328
+- id: CTX-HPF:CS202106160_329
+  name: 329_CA1-ProS
+  cell_set_accession: CS202106160_329
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 329
+- id: CTX-HPF:CS202106160_33
+  name: 33_Sncg
+  cell_set_accession: CS202106160_33
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 033
+- id: CTX-HPF:CS202106160_330
+  name: 330_CA1-ProS
+  cell_set_accession: CS202106160_330
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 330
+- id: CTX-HPF:CS202106160_331
+  name: 331_CA1-ProS
+  cell_set_accession: CS202106160_331
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 331
+- id: CTX-HPF:CS202106160_332
+  name: 332_CA1-ProS
+  cell_set_accession: CS202106160_332
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 332
+- id: CTX-HPF:CS202106160_333
+  name: 333_CA1-ProS
+  cell_set_accession: CS202106160_333
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 333
+- id: CTX-HPF:CS202106160_334
+  name: 334_CA1-ve
+  cell_set_accession: CS202106160_334
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 334
+- id: CTX-HPF:CS202106160_335
+  name: 335_CA1-ve
+  cell_set_accession: CS202106160_335
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 335
+- id: CTX-HPF:CS202106160_336
+  name: 336_CA1-ve
+  cell_set_accession: CS202106160_336
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 336
+- id: CTX-HPF:CS202106160_337
+  name: 337_CA1
+  cell_set_accession: CS202106160_337
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 337
+- id: CTX-HPF:CS202106160_338
+  name: 338_CA1
+  cell_set_accession: CS202106160_338
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 338
+- id: CTX-HPF:CS202106160_339
+  name: 339_CA1
+  cell_set_accession: CS202106160_339
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 339
+- id: CTX-HPF:CS202106160_34
+  name: 34_Sncg
+  cell_set_accession: CS202106160_34
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 034
+- id: CTX-HPF:CS202106160_340
+  name: 340_CA1
+  cell_set_accession: CS202106160_340
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 340
+- id: CTX-HPF:CS202106160_341
+  name: 341_CA1
+  cell_set_accession: CS202106160_341
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 341
+- id: CTX-HPF:CS202106160_342
+  name: 342_CA1
+  cell_set_accession: CS202106160_342
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 342
+- id: CTX-HPF:CS202106160_343
+  name: 343_CA1
+  cell_set_accession: CS202106160_343
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 343
+- id: CTX-HPF:CS202106160_344
+  name: 344_CA1
+  cell_set_accession: CS202106160_344
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 344
+- id: CTX-HPF:CS202106160_345
+  name: 345_CA1
+  cell_set_accession: CS202106160_345
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 345
+- id: CTX-HPF:CS202106160_346
+  name: 346_CA1-do
+  cell_set_accession: CS202106160_346
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 346
+- id: CTX-HPF:CS202106160_347
+  name: 347_CA1-do
+  cell_set_accession: CS202106160_347
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 347
+- id: CTX-HPF:CS202106160_348
+  name: 348_CA1-do
+  cell_set_accession: CS202106160_348
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA1-ProS
+    cell_set_accession: subclass_label:5c6ec72876
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 348
+- id: CTX-HPF:CS202106160_349
+  name: 349_Mossy
+  cell_set_accession: CS202106160_349
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA3
+    cell_set_accession: CS202106160_578
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 349
+- id: CTX-HPF:CS202106160_35
+  name: 35_Sncg
+  cell_set_accession: CS202106160_35
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 035
+- id: CTX-HPF:CS202106160_350
+  name: 350_Mossy
+  cell_set_accession: CS202106160_350
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA3
+    cell_set_accession: CS202106160_578
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 350
+- id: CTX-HPF:CS202106160_351
+  name: 351_CA3-ve
+  cell_set_accession: CS202106160_351
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA3
+    cell_set_accession: CS202106160_578
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 351
+- id: CTX-HPF:CS202106160_352
+  name: 352_CA3-ve
+  cell_set_accession: CS202106160_352
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA3
+    cell_set_accession: CS202106160_578
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 352
+- id: CTX-HPF:CS202106160_353
+  name: 353_CA3-ve
+  cell_set_accession: CS202106160_353
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA3
+    cell_set_accession: CS202106160_578
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 353
+- id: CTX-HPF:CS202106160_354
+  name: 354_CA3-ve
+  cell_set_accession: CS202106160_354
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA3
+    cell_set_accession: CS202106160_578
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 354
+- id: CTX-HPF:CS202106160_355
+  name: 355_CA3-ve
+  cell_set_accession: CS202106160_355
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA3
+    cell_set_accession: CS202106160_578
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 355
+- id: CTX-HPF:CS202106160_356
+  name: 356_CA3-do
+  cell_set_accession: CS202106160_356
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA3
+    cell_set_accession: CS202106160_578
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 356
+- id: CTX-HPF:CS202106160_357
+  name: 357_CA3-do
+  cell_set_accession: CS202106160_357
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA3
+    cell_set_accession: CS202106160_578
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 357
+- id: CTX-HPF:CS202106160_358
+  name: 358_CA3-do
+  cell_set_accession: CS202106160_358
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA3
+    cell_set_accession: CS202106160_578
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 358
+- id: CTX-HPF:CS202106160_359
+  name: 359_CA2-IG-FC
+  cell_set_accession: CS202106160_359
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA2-IG-FC
+    cell_set_accession: CS202106160_585
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 359
+- id: CTX-HPF:CS202106160_36
+  name: 36_Sncg
+  cell_set_accession: CS202106160_36
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 036
+- id: CTX-HPF:CS202106160_360
+  name: 360_CA2-IG-FC
+  cell_set_accession: CS202106160_360
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: CA2-IG-FC
+    cell_set_accession: CS202106160_585
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 360
+- id: CTX-HPF:CS202106160_361
+  name: 361_DG
+  cell_set_accession: CS202106160_361
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: DG
+    cell_set_accession: CS202106160_586
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 361
+- id: CTX-HPF:CS202106160_362
+  name: 362_DG
+  cell_set_accession: CS202106160_362
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: DG
+    cell_set_accession: CS202106160_586
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 362
+- id: CTX-HPF:CS202106160_363
+  name: 363_DG
+  cell_set_accession: CS202106160_363
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: DG
+    cell_set_accession: CS202106160_586
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 363
+- id: CTX-HPF:CS202106160_364
+  name: 364_DG
+  cell_set_accession: CS202106160_364
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: DG
+    cell_set_accession: CS202106160_586
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 364
+- id: CTX-HPF:CS202106160_365
+  name: 365_Oligo
+  cell_set_accession: CS202106160_365
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Oligo
+    cell_set_accession: subclass_label:3deb6c773a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 365
+- id: CTX-HPF:CS202106160_366
+  name: 366_Oligo
+  cell_set_accession: CS202106160_366
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Oligo
+    cell_set_accession: subclass_label:3deb6c773a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 366
+- id: CTX-HPF:CS202106160_367
+  name: 367_Oligo
+  cell_set_accession: CS202106160_367
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Oligo
+    cell_set_accession: subclass_label:3deb6c773a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 367
+- id: CTX-HPF:CS202106160_368
+  name: 368_Oligo
+  cell_set_accession: CS202106160_368
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Oligo
+    cell_set_accession: subclass_label:3deb6c773a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 368
+- id: CTX-HPF:CS202106160_369
+  name: 369_Oligo
+  cell_set_accession: CS202106160_369
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Oligo
+    cell_set_accession: subclass_label:3deb6c773a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 369
+- id: CTX-HPF:CS202106160_37
+  name: 37_Sncg
+  cell_set_accession: CS202106160_37
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 037
+- id: CTX-HPF:CS202106160_370
+  name: 370_Oligo
+  cell_set_accession: CS202106160_370
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Oligo
+    cell_set_accession: subclass_label:3deb6c773a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 370
+- id: CTX-HPF:CS202106160_371
+  name: 371_Oligo
+  cell_set_accession: CS202106160_371
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Oligo
+    cell_set_accession: subclass_label:3deb6c773a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 371
+- id: CTX-HPF:CS202106160_372
+  name: 372_Oligo
+  cell_set_accession: CS202106160_372
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Oligo
+    cell_set_accession: subclass_label:3deb6c773a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 372
+- id: CTX-HPF:CS202106160_373
+  name: 373_Oligo
+  cell_set_accession: CS202106160_373
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Oligo
+    cell_set_accession: subclass_label:3deb6c773a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 373
+- id: CTX-HPF:CS202106160_374
+  name: 374_Oligo
+  cell_set_accession: CS202106160_374
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Oligo
+    cell_set_accession: subclass_label:3deb6c773a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 374
+- id: CTX-HPF:CS202106160_375
+  name: 375_Oligo
+  cell_set_accession: CS202106160_375
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Oligo
+    cell_set_accession: subclass_label:3deb6c773a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 375
+- id: CTX-HPF:CS202106160_376
+  name: 376_Astro
+  cell_set_accession: CS202106160_376
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Astro
+    cell_set_accession: subclass_label:ae2c9ed8f1
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 376
+- id: CTX-HPF:CS202106160_377
+  name: 377_Astro
+  cell_set_accession: CS202106160_377
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Astro
+    cell_set_accession: subclass_label:ae2c9ed8f1
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 377
+- id: CTX-HPF:CS202106160_378
+  name: 378_Astro
+  cell_set_accession: CS202106160_378
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Astro
+    cell_set_accession: subclass_label:ae2c9ed8f1
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 378
+- id: CTX-HPF:CS202106160_379
+  name: 379_Endo
+  cell_set_accession: CS202106160_379
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Endo
+    cell_set_accession: subclass_label:f5fad7e30c
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 379
+- id: CTX-HPF:CS202106160_38
+  name: 38_Sncg
+  cell_set_accession: CS202106160_38
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 038
+- id: CTX-HPF:CS202106160_380
+  name: 380_SMC-Peri
+  cell_set_accession: CS202106160_380
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SMC-Peri
+    cell_set_accession: CS202106160_604
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 380
+- id: CTX-HPF:CS202106160_382
+  name: 382_SMC-Peri
+  cell_set_accession: CS202106160_382
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: SMC-Peri
+    cell_set_accession: CS202106160_604
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 382
+- id: CTX-HPF:CS202106160_383
+  name: 383_VLMC
+  cell_set_accession: CS202106160_383
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: VLMC
+    cell_set_accession: CS202106160_606
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 383
+- id: CTX-HPF:CS202106160_384
+  name: 384_VLMC
+  cell_set_accession: CS202106160_384
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: VLMC
+    cell_set_accession: CS202106160_606
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 384
+- id: CTX-HPF:CS202106160_385
+  name: 385_VLMC
+  cell_set_accession: CS202106160_385
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: VLMC
+    cell_set_accession: CS202106160_606
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 385
+- id: CTX-HPF:CS202106160_386
+  name: 386_Micro-PVM
+  cell_set_accession: CS202106160_386
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Micro-PVM
+    cell_set_accession: CS202106160_608
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 386
+- id: CTX-HPF:CS202106160_387
+  name: 387_Micro-PVM
+  cell_set_accession: CS202106160_387
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Micro-PVM
+    cell_set_accession: CS202106160_608
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 387
+- id: CTX-HPF:CS202106160_388
+  name: 388_Micro-PVM
+  cell_set_accession: CS202106160_388
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Micro-PVM
+    cell_set_accession: CS202106160_608
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 388
+- id: CTX-HPF:CS202106160_39
+  name: 39_Sncg
+  cell_set_accession: CS202106160_39
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 039
+- id: CTX-HPF:CS202106160_4
+  name: 4_Meis2 HPF
+  cell_set_accession: CS202106160_4
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 004
+- id: CTX-HPF:CS202106160_40
+  name: 40_Vip
+  cell_set_accession: CS202106160_40
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 040
+- id: CTX-HPF:CS202106160_41
+  name: 41_Vip
+  cell_set_accession: CS202106160_41
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sncg
+    cell_set_accession: subclass_label:86d5f48b05
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 041
+- id: CTX-HPF:CS202106160_42
+  name: 42_Vip
+  cell_set_accession: CS202106160_42
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 042
+- id: CTX-HPF:CS202106160_43
+  name: 43_Vip
+  cell_set_accession: CS202106160_43
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 043
+- id: CTX-HPF:CS202106160_44
+  name: 44_Vip
+  cell_set_accession: CS202106160_44
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 044
+- id: CTX-HPF:CS202106160_45
+  name: 45_Vip
+  cell_set_accession: CS202106160_45
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 045
+- id: CTX-HPF:CS202106160_46
+  name: 46_Vip
+  cell_set_accession: CS202106160_46
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 046
+- id: CTX-HPF:CS202106160_47
+  name: 47_Vip
+  cell_set_accession: CS202106160_47
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 047
+- id: CTX-HPF:CS202106160_48
+  name: 48_Vip
+  cell_set_accession: CS202106160_48
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 048
+- id: CTX-HPF:CS202106160_49
+  name: 49_Vip
+  cell_set_accession: CS202106160_49
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 049
+- id: CTX-HPF:CS202106160_5
+  name: 5_Lamp5 Lhx6
+  cell_set_accession: CS202106160_5
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 005
+- id: CTX-HPF:CS202106160_50
+  name: 50_Vip
+  cell_set_accession: CS202106160_50
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 050
+- id: CTX-HPF:CS202106160_51
+  name: 51_Vip
+  cell_set_accession: CS202106160_51
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 051
+- id: CTX-HPF:CS202106160_52
+  name: 52_Vip
+  cell_set_accession: CS202106160_52
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 052
+- id: CTX-HPF:CS202106160_53
+  name: 53_Vip
+  cell_set_accession: CS202106160_53
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 053
+- id: CTX-HPF:CS202106160_54
+  name: 54_Vip HPF
+  cell_set_accession: CS202106160_54
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 054
+- id: CTX-HPF:CS202106160_55
+  name: 55_Vip HPF
+  cell_set_accession: CS202106160_55
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 055
+- id: CTX-HPF:CS202106160_56
+  name: 56_Vip HPF
+  cell_set_accession: CS202106160_56
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 056
+- id: CTX-HPF:CS202106160_57
+  name: 57_Vip Igfbp6
+  cell_set_accession: CS202106160_57
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 057
+- id: CTX-HPF:CS202106160_58
+  name: 58_Vip Igfbp6
+  cell_set_accession: CS202106160_58
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 058
+- id: CTX-HPF:CS202106160_59
+  name: 59_Vip Igfbp6
+  cell_set_accession: CS202106160_59
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 059
+- id: CTX-HPF:CS202106160_6
+  name: 6_Lamp5 Lhx6
+  cell_set_accession: CS202106160_6
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 006
+- id: CTX-HPF:CS202106160_60
+  name: 60_Vip Igfbp6
+  cell_set_accession: CS202106160_60
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 060
+- id: CTX-HPF:CS202106160_61
+  name: 61_Vip Igfbp6
+  cell_set_accession: CS202106160_61
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 061
+- id: CTX-HPF:CS202106160_62
+  name: 62_Vip Igfbp6
+  cell_set_accession: CS202106160_62
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Vip
+    cell_set_accession: subclass_label:a547e761cb
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 062
+- id: CTX-HPF:CS202106160_63
+  name: 63_Sst Chodl
+  cell_set_accession: CS202106160_63
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst Chodl
+    cell_set_accession: CS202106160_441
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 063
+- id: CTX-HPF:CS202106160_64
+  name: 64_Sst Chodl
+  cell_set_accession: CS202106160_64
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst Chodl
+    cell_set_accession: CS202106160_441
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 064
+- id: CTX-HPF:CS202106160_65
+  name: 65_Sst Chodl
+  cell_set_accession: CS202106160_65
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst Chodl
+    cell_set_accession: CS202106160_441
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 065
+- id: CTX-HPF:CS202106160_66
+  name: 66_Sst
+  cell_set_accession: CS202106160_66
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 066
+- id: CTX-HPF:CS202106160_67
+  name: 67_Sst
+  cell_set_accession: CS202106160_67
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 067
+- id: CTX-HPF:CS202106160_68
+  name: 68_Sst
+  cell_set_accession: CS202106160_68
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 068
+- id: CTX-HPF:CS202106160_69
+  name: 69_Sst
+  cell_set_accession: CS202106160_69
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 069
+- id: CTX-HPF:CS202106160_7
+  name: 7_Lamp5 Lhx6
+  cell_set_accession: CS202106160_7
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 007
+- id: CTX-HPF:CS202106160_70
+  name: 70_Sst
+  cell_set_accession: CS202106160_70
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 070
+- id: CTX-HPF:CS202106160_71
+  name: 71_Sst
+  cell_set_accession: CS202106160_71
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 071
+- id: CTX-HPF:CS202106160_72
+  name: 72_Sst
+  cell_set_accession: CS202106160_72
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 072
+- id: CTX-HPF:CS202106160_73
+  name: 73_Sst
+  cell_set_accession: CS202106160_73
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 073
+- id: CTX-HPF:CS202106160_74
+  name: 74_Sst
+  cell_set_accession: CS202106160_74
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 074
+- id: CTX-HPF:CS202106160_75
+  name: 75_Sst
+  cell_set_accession: CS202106160_75
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 075
+- id: CTX-HPF:CS202106160_76
+  name: 76_Sst
+  cell_set_accession: CS202106160_76
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 076
+- id: CTX-HPF:CS202106160_77
+  name: 77_Sst HPF
+  cell_set_accession: CS202106160_77
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 077
+- id: CTX-HPF:CS202106160_78
+  name: 78_Sst HPF
+  cell_set_accession: CS202106160_78
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 078
+- id: CTX-HPF:CS202106160_79
+  name: 79_Sst
+  cell_set_accession: CS202106160_79
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 079
+- id: CTX-HPF:CS202106160_8
+  name: 8_Lamp5 Lhx6
+  cell_set_accession: CS202106160_8
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 008
+- id: CTX-HPF:CS202106160_80
+  name: 80_Sst
+  cell_set_accession: CS202106160_80
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 080
+- id: CTX-HPF:CS202106160_81
+  name: 81_Sst
+  cell_set_accession: CS202106160_81
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 081
+- id: CTX-HPF:CS202106160_82
+  name: 82_Sst
+  cell_set_accession: CS202106160_82
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 082
+- id: CTX-HPF:CS202106160_83
+  name: 83_Sst
+  cell_set_accession: CS202106160_83
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 083
+- id: CTX-HPF:CS202106160_84
+  name: 84_Sst
+  cell_set_accession: CS202106160_84
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 084
+- id: CTX-HPF:CS202106160_85
+  name: 85_Sst
+  cell_set_accession: CS202106160_85
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 085
+- id: CTX-HPF:CS202106160_86
+  name: 86_Sst
+  cell_set_accession: CS202106160_86
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 086
+- id: CTX-HPF:CS202106160_87
+  name: 87_Sst
+  cell_set_accession: CS202106160_87
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 087
+- id: CTX-HPF:CS202106160_88
+  name: 88_Sst
+  cell_set_accession: CS202106160_88
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 088
+- id: CTX-HPF:CS202106160_89
+  name: 89_Sst
+  cell_set_accession: CS202106160_89
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 089
+- id: CTX-HPF:CS202106160_9
+  name: 9_Lamp5 Lhx6
+  cell_set_accession: CS202106160_9
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Lamp5
+    cell_set_accession: subclass_label:e40986e2c0
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 009
+- id: CTX-HPF:CS202106160_90
+  name: 90_Sst
+  cell_set_accession: CS202106160_90
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 090
+- id: CTX-HPF:CS202106160_91
+  name: 91_Sst
+  cell_set_accession: CS202106160_91
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 091
+- id: CTX-HPF:CS202106160_92
+  name: 92_Sst
+  cell_set_accession: CS202106160_92
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 092
+- id: CTX-HPF:CS202106160_93
+  name: 93_Sst
+  cell_set_accession: CS202106160_93
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 093
+- id: CTX-HPF:CS202106160_94
+  name: 94_Sst
+  cell_set_accession: CS202106160_94
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 094
+- id: CTX-HPF:CS202106160_95
+  name: 95_Sst
+  cell_set_accession: CS202106160_95
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 095
+- id: CTX-HPF:CS202106160_96
+  name: 96_Sst
+  cell_set_accession: CS202106160_96
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 096
+- id: CTX-HPF:CS202106160_97
+  name: 97_Sst
+  cell_set_accession: CS202106160_97
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 097
+- id: CTX-HPF:CS202106160_98
+  name: 98_Sst
+  cell_set_accession: CS202106160_98
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 098
+- id: CTX-HPF:CS202106160_99
+  name: 99_Sst
+  cell_set_accession: CS202106160_99
+  taxonomy_id: CS202106160
+  taxonomy_level: CLUSTER
+  taxonomy_rank: 0
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: true
+  parent_hierarchy:
+  - level: SUBCLASS
+    name: Sst
+    cell_set_accession: CS202106160_444
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 099

--- a/kb/taxonomy/CS202106160/subclass.yaml
+++ b/kb/taxonomy/CS202106160/subclass.yaml
@@ -1,0 +1,619 @@
+taxonomy_id: CS202106160
+taxonomy_level: SUBCLASS
+taxonomy_rank: 1
+nodes:
+- id: CTX-HPF:CS202106160_396
+  name: Meis2
+  cell_set_accession: CS202106160_396
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: GABAergic
+    cell_set_accession: class_label:0ecf35ea0b
+  species: &id001
+    id: NCBITaxon:10090
+    label: Mus musculus
+    name_in_source: Mus musculus
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 002-003
+- id: CTX-HPF:CS202106160_441
+  name: Sst Chodl
+  cell_set_accession: CS202106160_441
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: GABAergic
+    cell_set_accession: class_label:0ecf35ea0b
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 063-065
+- id: CTX-HPF:CS202106160_444
+  name: Sst
+  cell_set_accession: CS202106160_444
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: GABAergic
+    cell_set_accession: class_label:0ecf35ea0b
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 066-107
+- id: CTX-HPF:CS202106160_463
+  name: Pvalb
+  cell_set_accession: CS202106160_463
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: GABAergic
+    cell_set_accession: class_label:0ecf35ea0b
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 108-123
+- id: CTX-HPF:CS202106160_480
+  name: L3 IT ENT
+  cell_set_accession: CS202106160_480
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 135-140
+- id: CTX-HPF:CS202106160_486
+  name: L2 IT ENTm
+  cell_set_accession: CS202106160_486
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 146-150
+- id: CTX-HPF:CS202106160_494
+  name: L2/3 IT CTX
+  cell_set_accession: CS202106160_494
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 162-171
+- id: CTX-HPF:CS202106160_498
+  name: L2/3 IT RHP
+  cell_set_accession: CS202106160_498
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 172-177
+- id: CTX-HPF:CS202106160_525
+  name: Car3
+  cell_set_accession: CS202106160_525
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 236-238
+- id: CTX-HPF:CS202106160_528
+  name: L5 PT CTX
+  cell_set_accession: CS202106160_528
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 239-260
+- id: CTX-HPF:CS202106160_535
+  name: L4 RSP-ACA
+  cell_set_accession: CS202106160_535
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 261-262
+- id: CTX-HPF:CS202106160_538
+  name: L5/6 NP CTX
+  cell_set_accession: CS202106160_538
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 264-270
+- id: CTX-HPF:CS202106160_541
+  name: NP SUB
+  cell_set_accession: CS202106160_541
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 271-274
+- id: CTX-HPF:CS202106160_544
+  name: NP PPP
+  cell_set_accession: CS202106160_544
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 275-277
+- id: CTX-HPF:CS202106160_548
+  name: L6 CT CTX
+  cell_set_accession: CS202106160_548
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 278-293
+- id: CTX-HPF:CS202106160_551
+  name: CT SUB
+  cell_set_accession: CS202106160_551
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 294-297
+- id: CTX-HPF:CS202106160_578
+  name: CA3
+  cell_set_accession: CS202106160_578
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 349-358
+- id: CTX-HPF:CS202106160_585
+  name: CA2-IG-FC
+  cell_set_accession: CS202106160_585
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 359-360
+- id: CTX-HPF:CS202106160_586
+  name: DG
+  cell_set_accession: CS202106160_586
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 361-364
+- id: CTX-HPF:CS202106160_604
+  name: SMC-Peri
+  cell_set_accession: CS202106160_604
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Non-Neuronal
+    cell_set_accession: class_label:b7c6ca690a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 380-382
+- id: CTX-HPF:CS202106160_606
+  name: VLMC
+  cell_set_accession: CS202106160_606
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Non-Neuronal
+    cell_set_accession: class_label:b7c6ca690a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 383-385
+- id: CTX-HPF:CS202106160_608
+  name: Micro-PVM
+  cell_set_accession: CS202106160_608
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Non-Neuronal
+    cell_set_accession: class_label:b7c6ca690a
+  species: *id001
+  rationale_dois:
+  - https://doi.org/10.1016/j.cell.2021.04.021
+  cell_set_designation: CTX-HPF 386-388
+- id: CTX-HPF:subclass_label:10db4e9506
+  name: L6 IT CTX
+  cell_set_accession: subclass_label:10db4e9506
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:3deb6c773a
+  name: Oligo
+  cell_set_accession: subclass_label:3deb6c773a
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Non-Neuronal
+    cell_set_accession: class_label:b7c6ca690a
+  species: *id001
+- id: CTX-HPF:subclass_label:40ec201664
+  name: L4/5 IT CTX
+  cell_set_accession: subclass_label:40ec201664
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:5c6ec72876
+  name: CA1-ProS
+  cell_set_accession: subclass_label:5c6ec72876
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:5d7a3b937f
+  name: L2/3 IT PPP
+  cell_set_accession: subclass_label:5d7a3b937f
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:753888bc28
+  name: L5/6 IT TPE-ENT
+  cell_set_accession: subclass_label:753888bc28
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:7ec93c83f4
+  name: L6 IT ENTl
+  cell_set_accession: subclass_label:7ec93c83f4
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:86d5f48b05
+  name: Sncg
+  cell_set_accession: subclass_label:86d5f48b05
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: GABAergic
+    cell_set_accession: class_label:0ecf35ea0b
+  species: *id001
+- id: CTX-HPF:subclass_label:8fb647662f
+  name: L6b CTX
+  cell_set_accession: subclass_label:8fb647662f
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:9c706e279e
+  name: L2/3 IT ENTl
+  cell_set_accession: subclass_label:9c706e279e
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:a416c5553f
+  name: SUB-ProS
+  cell_set_accession: subclass_label:a416c5553f
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:a547e761cb
+  name: Vip
+  cell_set_accession: subclass_label:a547e761cb
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: GABAergic
+    cell_set_accession: class_label:0ecf35ea0b
+  species: *id001
+- id: CTX-HPF:subclass_label:ad2ac45237
+  name: L2 IT ENTl
+  cell_set_accession: subclass_label:ad2ac45237
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:ae2c9ed8f1
+  name: Astro
+  cell_set_accession: subclass_label:ae2c9ed8f1
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Non-Neuronal
+    cell_set_accession: class_label:b7c6ca690a
+  species: *id001
+- id: CTX-HPF:subclass_label:bbf0716163
+  name: L5 PPP
+  cell_set_accession: subclass_label:bbf0716163
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:d636443977
+  name: L6b/CT ENT
+  cell_set_accession: subclass_label:d636443977
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:d88cf82cba
+  name: L5 IT CTX
+  cell_set_accession: subclass_label:d88cf82cba
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:da99a9426c
+  name: CR
+  cell_set_accession: subclass_label:da99a9426c
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Glutamatergic
+    cell_set_accession: class_label:de8ed2ce0f
+  species: *id001
+- id: CTX-HPF:subclass_label:e40986e2c0
+  name: Lamp5
+  cell_set_accession: subclass_label:e40986e2c0
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: GABAergic
+    cell_set_accession: class_label:0ecf35ea0b
+  species: *id001
+- id: CTX-HPF:subclass_label:f5fad7e30c
+  name: Endo
+  cell_set_accession: subclass_label:f5fad7e30c
+  taxonomy_id: CS202106160
+  taxonomy_level: SUBCLASS
+  taxonomy_rank: 1
+  definition_basis: ATLAS_TRANSCRIPTOMIC
+  is_terminal: false
+  parent_hierarchy:
+  - level: CLASS
+    name: Non-Neuronal
+    cell_set_accession: class_label:b7c6ca690a
+  species: *id001

--- a/kb/taxonomy/CS202106160/taxonomy_meta.yaml
+++ b/kb/taxonomy/CS202106160/taxonomy_meta.yaml
@@ -1,0 +1,12 @@
+taxonomy_id: CS202106160
+taxonomy_name: CTX-HPF (Mouse Cortex + Hippocampal Formation, Yao 2021)
+species_id: NCBITaxon:10090
+species_label: Mus musculus
+tissue_id: UBERON:0000956
+tissue_label: cerebral cortex
+source_file: CS202106160.json
+ingest_date: '2026-04-22'
+level_counts:
+  CLASS: 3
+  CLUSTER: 387
+  SUBCLASS: 42

--- a/reports/hippocampus/ctx_hpf_taxonomy_reconciliation.md
+++ b/reports/hippocampus/ctx_hpf_taxonomy_reconciliation.md
@@ -1,0 +1,226 @@
+# CTX-HPF Taxonomy Reconciliation Report
+
+**Taxonomy:** CS202106160 / CCN202106160 — Mouse Cortex + Hippocampal Formation
+**Paper:** Yao et al. 2021 (doi:10.1016/j.cell.2021.04.021)
+**Date:** 2026-04-22
+**Purpose:** Reconcile three representations of the same taxonomy to assess reliability
+of cross-taxonomy annotation transfer (AT) edges between WMBv1 and CTX-HPF.
+
+---
+
+## 1. Sources examined
+
+| Source | Format | Origin | Clusters | Supertypes | Subclasses | Classes |
+|--------|--------|--------|----------|------------|------------|---------|
+| CAS JSON | CAS v5.3.0 | Allen structure graph (official) | 387 | -- | 42 | 3 |
+| Table S3 | XLSX | Paper supplementary (Yao 2021) | 391 (+ 608 empty rows) | 105 | 43 | 4 |
+| WMB CTX_* | JSON fields | WMBv1 KG node properties | 29 (hippocampus slice) | 12 | 5 | -- |
+
+**Table S3 ref.cluster_label** column contains labels from an **older clustering version**
+(pre-publication), providing a fourth implicit version.
+
+## 2. Accession and ID systems
+
+### Cluster level
+
+| Source | ID format | Example |
+|--------|-----------|---------|
+| CAS | `CS202106160_<N>` | CS202106160_79 |
+| S3 | numeric `cluster_id` | 79 |
+| S3 | old CCN accession `cell_type_accession_label` | CCN19103010000079 |
+| WMB | `CTX_cluster_id` (numeric) | 79.0 |
+
+**Finding:** All three sources share the same numeric cluster ID space. CAS accession
+terminal numbers = S3 cluster_id = WMB CTX_cluster_id. **The numeric IDs are the reliable
+join key.**
+
+### Subclass level
+
+| Source | ID format | Example |
+|--------|-----------|---------|
+| CAS | mixed: `CS202106160_<N>` (22) or `subclass_label:<HASH>` (20) | CS202106160_444 / subclass_label:86d5f48b05 |
+| S3 | numeric `subclass_id` (1-43) | 7 |
+| WMB | `CTX_subclass_id` (numeric) | 4.0 |
+
+**Finding:** CAS and S3 use **completely different numbering** for subclasses. CAS terminal
+numbers (e.g. 444) do not correspond to S3 subclass_id (e.g. 7). All 22 CS-format
+subclass accessions have terminal numbers in the 396-608 range, while S3 uses 1-43. They
+can only be joined by **label matching**, which succeeds for all 42 shared subclasses.
+
+20 CAS subclass accessions use hash-based format (`subclass_label:HASH`) with no numeric
+ID at all.
+
+### Supertype level
+
+Supertypes exist **only in S3** (105 types with numeric IDs 1-105). CAS has no supertype
+labelset. WMB carries `CTX_supertype_id` and `CTX_supertype_label` but these use a
+**different numbering and different names** from S3 (see Section 4).
+
+### Class level
+
+S3 has 4 classes (GABAergic, Glutamatergic, Non-Neuronal, Low Quality). CAS has 3 (no
+Low Quality). Class accessions in CAS are all hash-based (`class_label:HASH`).
+
+## 3. Cluster-level label agreement
+
+### CAS vs S3 (published)
+
+**387/387 shared clusters: 100% label match.** The 4 S3-only clusters are:
+- 381_SMC-Peri (minor non-neuronal type)
+- 389, 390, 391 (Low Quality — correctly excluded from CAS)
+
+CAS and S3 cluster labels are perfectly synchronised.
+
+### CAS/S3 vs WMB CTX_cluster_label
+
+**Only 6/29 hippocampal clusters match.** WMB labels carry `_N` suffixes
+(e.g. `78_Sst_2`) that don't appear in CAS/S3 (`78_Sst HPF`), and some gene names
+differ (WMB: `Ndnf HPF`, CAS/S3: `Ntng1 HPF`).
+
+### S3 ref.cluster_label vs published cluster_label
+
+**372/388 clusters (96%) were renumbered** between the ref (older) and published versions.
+Only 16 retained the same numeric prefix. The ref version uses a completely different
+cluster numbering scheme.
+
+### WMB CTX_cluster_label vs S3 ref.cluster_label
+
+**WMB labels match neither the published labels nor the ref labels.** WMB appears to
+reference a **third, intermediate version** of the taxonomy that was loaded into the WMB
+knowledge graph. It uses the published numeric IDs but with modified label strings.
+
+## 4. Hierarchy membership
+
+### Cluster -> Subclass
+
+| Comparison | Agreement |
+|------------|-----------|
+| CAS vs S3 | 387/387 (100%) |
+| WMB CTX_subclass vs CAS/S3 | 49/49 (100%, hippocampus slice) |
+
+**Cluster-to-subclass membership is fully consistent** across all three sources.
+
+### Cluster -> Supertype
+
+| Comparison | Agreement |
+|------------|-----------|
+| WMB CTX_supertype vs S3 supertype (label) | 6/29 (21%) |
+| WMB CTX_supertype vs S3 supertype (ID) | 6/29 (21%) |
+
+**Supertype assignments are deeply inconsistent.** The mismatches fall into three patterns:
+
+1. **WMB abbreviated** (missing subclass prefix): WMB "Ctsc" vs S3 "Sst Ctsc HPF",
+   WMB "Lpl" vs S3 "Pvalb Lpl". These may be the same supertype with the subclass
+   prefix stripped — 10 cases.
+
+2. **Different gene names**: WMB "Ndnf HPF" vs S3 "Ntng1 HPF", WMB "Car10" vs S3
+   "Vip Cp Rspo1", WMB "Ptprk" vs S3 "Vip Cbln4 HPF". These suggest genuinely
+   different supertype definitions or a rename — 11 cases.
+
+3. **Different supertype assignment**: cluster #30 is WMB "Krt73" (supertype 8) but
+   S3 "Ntng1 HPF" (supertype 10) — different supertypes entirely. Cluster #77 is
+   WMB "Th" but S3 "Sst Lmo1 HPF". Cluster #78 is WMB "Myh8 HPF" but S3
+   "Sst Lmo1 HPF". These indicate the **supertype groupings themselves changed** — 7 cases.
+
+Since supertype IDs also disagree (WMB sup_id != S3 supertype_id for 23/29 clusters),
+the WMB is referencing a different supertype classification entirely.
+
+### Supertype -> Subclass (S3 only)
+
+Within S3, every supertype maps to exactly one subclass (105/105 single-parent). The
+supertype level fits cleanly between cluster and subclass in the published hierarchy.
+
+### ref.cluster_label grouping vs published subclass
+
+6 ref-version cluster groups span multiple published subclasses:
+- `197_L4/5 IT CTX` -> {L4/5 IT CTX, L5 IT CTX}
+- `207_L5 IT CTX` -> {L4/5 IT CTX, L5 IT CTX}
+- `211_L5 IT TPE-ENT` -> {L5/6 IT TPE-ENT, L2/3 IT RHP}
+- `227_L6 IT CTX` -> {L6 IT CTX, L5 IT CTX}
+- `311_L6 NP CT CTX*` -> {L6 CT CTX, L5/6 NP CTX}
+- `323_L6 CT CTX` -> {L6 CT CTX, L6b CTX}
+
+This confirms the older clustering had **different subclass boundaries** from the
+published version.
+
+## 5. Version timeline (inferred)
+
+```
+ref version (pre-publication)
+  - Different cluster numbering (372/388 clusters renumbered)
+  - Different subclass boundaries (6 groups span multiple published subclasses)
+  - Labels in S3 ref.cluster_label column
+       |
+       v
+WMB intermediate version
+  - Adopted published cluster numeric IDs
+  - But carries modified labels (_N suffixes, gene name changes)
+  - Different supertype IDs and labels from published S3
+  - This is what WMB CTX_* fields reference
+       |
+       v
+Published version (Yao 2021 / CAS)
+  - CAS JSON = S3 cluster labels (387/387 match)
+  - CAS cluster->subclass = S3 cluster->subclass (387/387 match)
+  - S3 has supertypes, regional proportions, cell counts not in CAS
+  - S3 has ref.cluster_label showing the older version
+```
+
+## 6. Implications for evidencell
+
+### Cross-taxonomy annotation transfer edges (WMB -> CTX)
+
+The 49 AT edges we built join WMB clusters to CTX clusters via `CTX_cluster_id`. The
+**numeric cluster IDs are reliable** — they match across all three sources. However:
+
+- The AT algorithm in WMB was likely run against the **intermediate version**, not the
+  published taxonomy. Cell set composition may have shifted between versions.
+- Supertype-level cross-references from WMB (`CTX_supertype_label`) are unreliable —
+  they reference a different supertype classification.
+- Subclass-level cross-references from WMB (`CTX_subclass_label`) are reliable —
+  they match CAS/S3 for all 49 hippocampus clusters.
+
+**Recommendation:** Treat AT edges as **approximate cross-references** (confidence: LOW,
+relationship: OVERLAPS). The cluster-level join is solid; supertype-level should not be
+used. Record WMB-side labels in `name_in_source` for audit trail.
+
+### CTX taxonomy enrichment from Table S3
+
+S3 is synchronised with CAS at cluster level (100% agreement). Safe to enrich CTX
+taxonomy nodes with:
+- **Regional cell proportions** (HIP, RHP columns) — properties of the published clusters
+- **Cell counts** (10X, Smart-seq) — properties of the published clusters  
+- **Sex ratios** — properties of the published clusters
+- **Supertype names as descriptive metadata** on cluster nodes (not as hierarchy nodes)
+
+**Not safe:** Inserting supertypes as hierarchy nodes with synthetic accessions, or
+treating S3 supertype assignments as matching the AT version.
+
+### Re-running annotation transfer
+
+For definitive cross-taxonomy AT with proper F1 scores, the cleanest path would be to
+re-run MapMyCells using the published CAS taxonomy. This requires:
+- The CellxGene dataset (matrix_file_id: `CellXGene_dataset:ece4094a-8f3d-430d-babe-467fb6fd5feb`)
+- Or asking Allen for a version-matched taxonomy + reference data
+
+This would produce clean, version-matched AT results without the three-version ambiguity.
+
+## 7. Summary table
+
+| Question | Answer |
+|----------|--------|
+| Do cluster numeric IDs match across sources? | Yes (all three) |
+| Do cluster labels match? | CAS=S3 (100%), WMB differs (21%) |
+| Do subclass IDs match? | No — CAS and S3 use different numbering |
+| Do subclass labels match? | Yes (all 42 shared) |
+| Do subclass memberships match? | Yes (387/387 CAS=S3, 49/49 WMB=CAS/S3) |
+| Do supertype IDs/labels match? | No — WMB vs S3 disagree (79%) |
+| Do supertype memberships match? | Cannot verify (WMB supertypes are different entities) |
+| How many taxonomy versions exist? | At least 3 (ref, WMB intermediate, published) |
+| Is the CAS authoritative? | Yes, for the published taxonomy |
+| Is S3 compatible with CAS? | Yes, for clusters and subclasses |
+| Are WMB CTX_* AT edges trustworthy? | Cluster IDs: yes. Labels/supertypes: no |
+
+---
+
+*Generated by evidencell taxonomy reconciliation analysis, 2026-04-22.*

--- a/schema/celltype_mapping.yaml
+++ b/schema/celltype_mapping.yaml
@@ -34,6 +34,7 @@
 #                               Taxonomy nodes in KB graphs should be minimal stubs (id, name,
 #                               definition_basis, taxonomy_id, cell_set_accession); full data
 #                               lives in kb/taxonomy/{taxonomy_id}/*.yaml
+# Version: 0.7.1 (2026-04-23) — ADDITIVE: CellTypeNode.male_female_ratio (M/F cell count ratio from taxonomy)
 # Version: 0.7.0 (2026-04-22) — ADDITIVE: MarkerCategory enum; GeneDescriptor.category + expression_score;
 #                               AnatomicalLocation.cell_count; CellTypeNode.markers + neighborhood;
 #                               TaxonomyNodeList container; WMB: prefix for atlas node CURIEs
@@ -1134,6 +1135,13 @@ classes:
           Atlas-assigned neighborhood or supergroup label (e.g. "Subpallium-GABA").
           Populated from atlas metadata; provides coarser grouping above taxonomy
           class level. Leave absent for non-atlas nodes.
+      male_female_ratio:
+        range: float
+        description: >
+          Male/Female cell count ratio from source taxonomy (>1 = male-biased,
+          <1 = female-biased). Stored to 2 dp. Null when balanced or data
+          unavailable. Computed from Male and Female fraction properties in
+          the source taxonomy metadata.
       ccf_distribution:
         description: >
           CCF region distribution from atlas, e.g. "CB:0.72,NA:0.25" (from CCF_broad.freq column)

--- a/src/evidencell/taxonomy_db.py
+++ b/src/evidencell/taxonomy_db.py
@@ -59,6 +59,7 @@ class TaxonomyMeta:
     source_file: str | None = None       # JSON/CSV/XLSX path for ad hoc taxonomies
     ingest_date: str | None = None
     level_counts: dict[str, int] = field(default_factory=dict)
+    level_hierarchy: list[dict] = field(default_factory=list)  # [{level_name, rank, count, is_terminal}]
     mapmycells: MapMyCellsMeta = field(default_factory=MapMyCellsMeta)
 
 
@@ -104,6 +105,7 @@ def read_taxonomy_meta(taxonomy_id: str) -> TaxonomyMeta:
         source_file=d.get("source_file"),
         ingest_date=d.get("ingest_date"),
         level_counts=d.get("level_counts", {}),
+        level_hierarchy=d.get("level_hierarchy", []),
         mapmycells=MapMyCellsMeta(
             at_taxonomy_id=mmc_raw.get("at_taxonomy_id"),
             stats_s3_url=mmc_raw.get("stats_s3_url"),
@@ -130,6 +132,8 @@ def _meta_to_dict(meta: TaxonomyMeta) -> dict[str, Any]:
         v = getattr(meta, k)
         if v is not None:
             d[k] = v
+    if meta.level_hierarchy:
+        d["level_hierarchy"] = meta.level_hierarchy
     if meta.level_counts:
         d["level_counts"] = meta.level_counts
     if mmc_dict:
@@ -212,7 +216,7 @@ class TaxonomyNode:
     anat: list[dict] = field(default_factory=list)
     rationale: str | None = None
     rationale_dois: list[str] = field(default_factory=list)
-    sex_bias: str | None = None
+    male_female_ratio: float | None = None  # Male/Female cell count ratio, 2 dp
     # class-level extras
     neuronal: bool | None = None
     glial: bool | None = None
@@ -318,6 +322,25 @@ def _circadian(light: str | None) -> float | None:
     return val if (val > 0.7 or val < 0.3) else None
 
 
+def _male_female_ratio(props: dict, fc: dict[str, list[str]]) -> float | None:
+    """Compute Male/Female cell count ratio from source fractions.
+
+    Returns ratio rounded to 2 dp, or None when either fraction is 0 or absent.
+    """
+    male_raw = _scalar(_first_prop(props, fc.get("male_fraction", ["Male"])))
+    female_raw = _scalar(_first_prop(props, fc.get("female_fraction", ["Female"])))
+    if male_raw is None or female_raw is None:
+        return None
+    try:
+        male = float(male_raw)
+        female = float(female_raw)
+    except (ValueError, TypeError):
+        return None
+    if female == 0.0 or male == 0.0:
+        return None
+    return round(male / female, 2)
+
+
 def _extract_node(row: dict, taxonomy_id: str, fc: dict[str, list[str]]) -> TaxonomyNode:
     """Extract a TaxonomyNode from a raw VFB graph export row.
 
@@ -409,13 +432,99 @@ def _extract_node(row: dict, taxonomy_id: str, fc: dict[str, list[str]]) -> Taxo
         anat=anat_entries,
         rationale=rationale,
         rationale_dois=rationale_dois,
-        sex_bias=_scalar(_first_prop(
-            props,
-            fc.get("sex_bias", ["sex_bias", "CCN20230722_sex_bias"]),
-        )),
+        male_female_ratio=_male_female_ratio(props, fc),
         neuronal=neuronal,
         glial=glial,
     )
+
+
+def _compute_level_hierarchy(
+    nodes: list[TaxonomyNode],
+) -> tuple[list[dict], dict[str, int]]:
+    """Derive rank assignments from parent relationships.
+
+    Returns (level_hierarchy, level_to_rank) where level_hierarchy is the
+    list for taxonomy_meta.yaml and level_to_rank maps level name → int rank.
+
+    Algorithm: build a directed graph of level→parent_level edges from the
+    nodes' parent relationships.  Leaf levels (no children) get rank 0,
+    then increment toward root.  Levels that appear only as parents of
+    themselves (e.g. NEUROTRANSMITTER with no parent) and have no children
+    from other levels are excluded (orthogonal annotations).
+    """
+    # Build {node_id: level} and {level: set(parent_levels)}
+    id_to_level: dict[str, str] = {}
+    levels: set[str] = set()
+    for n in nodes:
+        lev = n.taxonomy_level.upper()
+        id_to_level[n.node_id] = lev
+        levels.add(lev)
+
+    # child_level → set of parent_levels
+    parent_of: dict[str, set[str]] = {lev: set() for lev in levels}
+    for n in nodes:
+        if n.parent_id:
+            parent_lev = id_to_level.get(n.parent_id)
+            if parent_lev:
+                child_lev = n.taxonomy_level.upper()
+                if parent_lev != child_lev:
+                    parent_of[child_lev].add(parent_lev)
+
+    # Find hierarchical levels: those that appear as child or parent of another level
+    hierarchical: set[str] = set()
+    for child, parents in parent_of.items():
+        if parents:
+            hierarchical.add(child)
+            hierarchical.update(parents)
+
+    # Topological sort: leaf (no children pointing to it as parent) → root
+    # "children" of a level = levels whose parent_of set contains this level
+    children_of: dict[str, set[str]] = {lev: set() for lev in hierarchical}
+    for child in hierarchical:
+        for parent in parent_of.get(child, set()):
+            if parent in hierarchical:
+                children_of[parent].add(child)
+
+    # Assign ranks bottom-up: leaves first
+    level_to_rank: dict[str, int] = {}
+    assigned: set[str] = set()
+
+    def _assign(lev: str) -> int:
+        if lev in level_to_rank:
+            return level_to_rank[lev]
+        kids = children_of.get(lev, set())
+        if not kids:
+            level_to_rank[lev] = 0
+            assigned.add(lev)
+            return 0
+        max_child_rank = max(_assign(c) for c in kids)
+        rank = max_child_rank + 1
+        level_to_rank[lev] = rank
+        assigned.add(lev)
+        return rank
+
+    for lev in hierarchical:
+        _assign(lev)
+
+    # Count nodes per level
+    level_count: dict[str, int] = {}
+    for n in nodes:
+        lev = n.taxonomy_level.upper()
+        level_count[lev] = level_count.get(lev, 0) + 1
+
+    # Build hierarchy list sorted by rank
+    hierarchy: list[dict] = []
+    for lev, rank in sorted(level_to_rank.items(), key=lambda x: x[1]):
+        entry: dict = {
+            "level_name": lev,
+            "rank": rank,
+            "count": level_count.get(lev, 0),
+        }
+        if rank == 0:
+            entry["is_terminal"] = True
+        hierarchy.append(entry)
+
+    return hierarchy, level_to_rank
 
 
 # ── YAML generation ────────────────────────────────────────────────────────────
@@ -568,6 +677,8 @@ def _node_to_dict(n: TaxonomyNode, meta: TaxonomyMeta, name_lookup: dict[str, st
         d["anatomical_location"] = anat_locs
     if n.neighborhood:
         d["neighborhood"] = n.neighborhood
+    if n.male_female_ratio is not None:
+        d["male_female_ratio"] = n.male_female_ratio
     if species:
         d["species"] = species
     return d
@@ -637,24 +748,35 @@ def ingest_to_yaml(source: Path, taxonomy_id: str, output_dir: Path) -> dict[str
         if n.node_id:
             name_lookup[n.node_id] = clean_name
 
+    # Compute level hierarchy and assign ranks to nodes
+    level_hierarchy, level_to_rank = _compute_level_hierarchy(all_nodes)
+
     # Second pass: convert to CellTypeNode dicts grouped by level
     by_level: dict[str, list[dict]] = {}
     for n in all_nodes:
-        by_level.setdefault(n.taxonomy_level, []).append(
-            _node_to_dict(n, meta, name_lookup)
-        )
+        d = _node_to_dict(n, meta, name_lookup)
+        lev_upper = n.taxonomy_level.upper()
+        rank = level_to_rank.get(lev_upper)
+        if rank is not None:
+            d["taxonomy_rank"] = rank
+        by_level.setdefault(n.taxonomy_level, []).append(d)
 
     # Write one TaxonomyNodeList YAML per level
     counts: dict[str, int] = {}
     for level, nodes in sorted(by_level.items()):
+        lev_upper = level.upper()
+        header: dict[str, Any] = {
+            "taxonomy_id": taxonomy_id,
+            "taxonomy_level": lev_upper,
+        }
+        rank = level_to_rank.get(lev_upper)
+        if rank is not None:
+            header["taxonomy_rank"] = rank
+        header["nodes"] = nodes
         out_file = output_dir / f"{level}.yaml"
         with out_file.open("w", encoding="utf-8") as fh:
             yaml.dump(
-                {
-                    "taxonomy_id": taxonomy_id,
-                    "taxonomy_level": level.upper(),
-                    "nodes": nodes,
-                },
+                header,
                 fh,
                 allow_unicode=True,
                 sort_keys=False,
@@ -663,6 +785,7 @@ def ingest_to_yaml(source: Path, taxonomy_id: str, output_dir: Path) -> dict[str
         counts[level] = len(nodes)
 
     meta.level_counts = counts
+    meta.level_hierarchy = level_hierarchy
     meta_file = output_dir / "taxonomy_meta.yaml"
     with meta_file.open("w", encoding="utf-8") as fh:
         yaml.dump(_meta_to_dict(meta), fh, allow_unicode=True, sort_keys=False)
@@ -731,11 +854,12 @@ def ingest_cas_to_yaml(
         )
 
     # Extract reference DOI from first annotation that has one
-    ref_doi = None
+    # (currently unused — retained for future taxonomy-level citation)
+    _ref_doi = None  # noqa: F841
     for ann in data["annotations"]:
         dois = ann.get("rationale_dois", [])
         if dois:
-            ref_doi = dois[0]
+            _ref_doi = dois[0]  # noqa: F841
             break
 
     mmc_raw = meta_input.get("mapmycells") or {}
@@ -869,6 +993,16 @@ def ingest_cas_to_yaml(
         counts[level] = len(nodes)
 
     meta.level_counts = counts
+    # Build level_hierarchy from labelset_rank + counts
+    cas_hierarchy: list[dict] = []
+    for ls_name, ls_rank in sorted(labelset_rank.items(), key=lambda x: x[1]):
+        level = _cas_level_name(ls_name)
+        if level in counts:
+            entry: dict = {"level_name": level, "rank": ls_rank, "count": counts[level]}
+            if ls_rank == 0:
+                entry["is_terminal"] = True
+            cas_hierarchy.append(entry)
+    meta.level_hierarchy = cas_hierarchy
     meta_file = output_dir / "taxonomy_meta.yaml"
     with meta_file.open("w", encoding="utf-8") as fh:
         yaml.dump(_meta_to_dict(meta), fh, allow_unicode=True, sort_keys=False)
@@ -900,7 +1034,7 @@ CREATE TABLE IF NOT EXISTS nodes (
   circadian_ratio        REAL,
   rationale              TEXT,
   rationale_dois         TEXT,
-  sex_bias               TEXT
+  male_female_ratio      REAL
 );
 
 CREATE TABLE IF NOT EXISTS anat (
@@ -1135,7 +1269,7 @@ class TaxonomyDB:
                :cell_ontology_term, :nt_type,
                :defining_markers_scoped, :defining_markers, :tf_markers,
                :merfish_markers, :np_markers, :neighborhood, :circadian_ratio,
-               :rationale, :rationale_dois, :sex_bias
+               :rationale, :rationale_dois, :male_female_ratio
             )""",
             {
                 "node_id": node_id,
@@ -1160,7 +1294,7 @@ class TaxonomyDB:
                 "circadian_ratio": None,  # not in CellTypeNode schema
                 "rationale": None,        # not in CellTypeNode schema
                 "rationale_dois": None,   # not in CellTypeNode schema
-                "sex_bias": None,         # not in CellTypeNode schema
+                "male_female_ratio": nd.get("male_female_ratio"),
             },
         )
         for a in nd.get("anatomical_location") or []:
@@ -1881,6 +2015,8 @@ def _cmd_find_candidates(
                 "score": c["_score"],
                 "nt_type": c.get("nt_type"),
                 "parent_id": c.get("parent_id"),
+                **({"male_female_ratio": c["male_female_ratio"]}
+                   if c.get("male_female_ratio") is not None else {}),
             }
             for c in candidates
         ],

--- a/src/evidencell/taxonomy_db.py
+++ b/src/evidencell/taxonomy_db.py
@@ -670,6 +670,212 @@ def ingest_to_yaml(source: Path, taxonomy_id: str, output_dir: Path) -> dict[str
     return counts
 
 
+# ── CAS (Cell Annotation Schema) ingest ──────────────────────────────────────
+
+
+def _is_cas_format(data: dict | list) -> bool:
+    """Return True if the JSON data looks like CAS v5+ format."""
+    return isinstance(data, dict) and "annotations" in data and "labelsets" in data
+
+
+def _cas_level_name(labelset_name: str) -> str:
+    """Normalise a CAS labelset name to a taxonomy level string.
+
+    CAS labelset names are arbitrary (e.g. "cluster_label", "subclass_label").
+    Strip common suffixes to produce a cleaner level name for YAML output.
+    """
+    # Strip _label suffix if present (common CAS convention)
+    name = labelset_name
+    if name.endswith("_label"):
+        name = name[: -len("_label")]
+    return name.upper()
+
+
+def ingest_cas_to_yaml(
+    source: Path, taxonomy_id: str, output_dir: Path
+) -> dict[str, int]:
+    """Generate per-level TaxonomyNodeList YAML files from CAS-format JSON.
+
+    CAS (Cell Annotation Schema) v5+ format stores annotations as a flat list
+    with ``labelset`` indicating the taxonomy level.  Labelset names are
+    arbitrary — the ``rank`` field on each labelset definition provides the
+    canonical ordering (0 = leaf / most specific).
+
+    Produces the same per-level YAML + taxonomy_meta.yaml output as
+    ``ingest_to_yaml()``.
+
+    Returns {level: node_count}.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with source.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    if not _is_cas_format(data):
+        raise ValueError(
+            f"{source} is not CAS format (expected top-level 'annotations' + 'labelsets')"
+        )
+
+    # Build labelset → rank mapping
+    labelset_rank: dict[str, int] = {}
+    for ls in data["labelsets"]:
+        labelset_rank[ls["name"]] = ls.get("rank", 0)
+
+    # Read optional metadata input
+    meta_input = _read_meta_input(taxonomy_id)
+    if not meta_input:
+        print(
+            f"  [info] No metadata input found at inputs/taxonomies/{taxonomy_id}_meta.yaml. "
+            "Name, species, tissue fields will be null in taxonomy_meta.yaml.",
+            file=sys.stderr,
+        )
+
+    # Extract reference DOI from first annotation that has one
+    ref_doi = None
+    for ann in data["annotations"]:
+        dois = ann.get("rationale_dois", [])
+        if dois:
+            ref_doi = dois[0]
+            break
+
+    mmc_raw = meta_input.get("mapmycells") or {}
+    meta = TaxonomyMeta(
+        taxonomy_id=taxonomy_id,
+        taxonomy_name=meta_input.get("taxonomy_name") or data.get("title"),
+        species_id=meta_input.get("species_id"),
+        species_label=meta_input.get("species_label"),
+        tissue_id=meta_input.get("tissue_id"),
+        tissue_label=meta_input.get("tissue_label"),
+        anatomy_ontology=meta_input.get("anatomy_ontology"),
+        source_file=source.name,
+        ingest_date=str(date.today()),
+        level_counts={},
+        mapmycells=MapMyCellsMeta(
+            at_taxonomy_id=mmc_raw.get("at_taxonomy_id"),
+            stats_s3_url=mmc_raw.get("stats_s3_url"),
+            markers_s3_url=mmc_raw.get("markers_s3_url"),
+            local_stats_path=mmc_raw.get("local_stats_path"),
+            local_markers_path=mmc_raw.get("local_markers_path"),
+        ),
+    )
+
+    # Species dict from metadata
+    species: dict | None = None
+    if meta.species_id or meta.species_label:
+        species = {}
+        if meta.species_id:
+            species["id"] = meta.species_id
+        if meta.species_label:
+            species["label"] = meta.species_label
+            species["name_in_source"] = meta.species_label
+
+    # Build name lookup for parent_hierarchy resolution
+    name_lookup: dict[str, str] = {}
+    for ann in data["annotations"]:
+        acc = ann.get("cell_set_accession", "")
+        label = ann.get("cell_label", "")
+        if acc and label:
+            name_lookup[acc] = label
+
+    # Convert annotations to CellTypeNode dicts grouped by level
+    by_level: dict[str, list[dict]] = {}
+    for ann in data["annotations"]:
+        labelset = ann.get("labelset", "")
+        level = _cas_level_name(labelset)
+        rank = labelset_rank.get(labelset, 0)
+        acc = ann.get("cell_set_accession", "")
+        label = ann.get("cell_label", "")
+        parent_acc = ann.get("parent_cell_set_accession")
+
+        # Build node CURIE: taxonomy_id prefix + accession
+        # CAS accessions are already prefixed (e.g. CS202106160_79)
+        # but some use hash-based format (e.g. subclass_label:HASH)
+        node_id = f"CTX-HPF:{acc}" if acc else ""
+
+        # Determine if terminal (leaf level = rank 0)
+        is_terminal = rank == 0
+
+        # Parent hierarchy
+        parent_hierarchy: list[dict] = []
+        if parent_acc:
+            parent_name = name_lookup.get(parent_acc, parent_acc)
+            # Infer parent level from its labelset (look up in annotations)
+            parent_level = "UNKNOWN"
+            for other in data["annotations"]:
+                if other.get("cell_set_accession") == parent_acc:
+                    parent_level = _cas_level_name(other.get("labelset", ""))
+                    break
+            parent_hierarchy.append({
+                "level": parent_level,
+                "name": parent_name,
+                "cell_set_accession": parent_acc,
+            })
+
+        # Author annotation fields
+        aaf = ann.get("author_annotation_fields", {})
+
+        d: dict = {
+            "id": node_id,
+            "name": label,
+            "cell_set_accession": acc,
+            "taxonomy_id": taxonomy_id,
+            "taxonomy_level": level,
+            "taxonomy_rank": rank,
+            "definition_basis": "ATLAS_TRANSCRIPTOMIC",
+            "is_terminal": is_terminal,
+        }
+        if parent_hierarchy:
+            d["parent_hierarchy"] = parent_hierarchy
+        if species:
+            d["species"] = species
+        # Preserve rationale DOIs as-is
+        dois = ann.get("rationale_dois", [])
+        if dois:
+            d["rationale_dois"] = dois
+        # Preserve designation from author_annotation_fields
+        designation = aaf.get("cell_set_designation")
+        if designation:
+            d["cell_set_designation"] = designation
+
+        by_level.setdefault(level, []).append(d)
+
+    # Write one TaxonomyNodeList YAML per level
+    counts: dict[str, int] = {}
+    for level, nodes in sorted(by_level.items()):
+        # Use rank from first node for filename (levels are arbitrary names)
+        safe_name = level.lower().replace("/", "_").replace(" ", "_")
+        out_file = output_dir / f"{safe_name}.yaml"
+        # Sort nodes by accession for stable output
+        nodes.sort(key=lambda n: n.get("cell_set_accession", ""))
+        with out_file.open("w", encoding="utf-8") as fh:
+            yaml.dump(
+                {
+                    "taxonomy_id": taxonomy_id,
+                    "taxonomy_level": level,
+                    "taxonomy_rank": labelset_rank.get(
+                        next(
+                            (ls for ls in labelset_rank if _cas_level_name(ls) == level),
+                            "",
+                        ),
+                        0,
+                    ),
+                    "nodes": nodes,
+                },
+                fh,
+                allow_unicode=True,
+                sort_keys=False,
+                default_flow_style=False,
+            )
+        counts[level] = len(nodes)
+
+    meta.level_counts = counts
+    meta_file = output_dir / "taxonomy_meta.yaml"
+    with meta_file.open("w", encoding="utf-8") as fh:
+        yaml.dump(_meta_to_dict(meta), fh, allow_unicode=True, sort_keys=False)
+
+    return counts
+
+
 # ── SQLite backend ─────────────────────────────────────────────────────────────
 
 _DDL = """\
@@ -1264,11 +1470,28 @@ class TaxonomyDB:
 
 # ── CLI entry point ────────────────────────────────────────────────────────────
 
+def _detect_cas_format(source: Path) -> bool:
+    """Peek at a JSON file to check if it's CAS format (has annotations + labelsets)."""
+    with source.open(encoding="utf-8") as fh:
+        # Read enough to find top-level keys without loading the whole file
+        try:
+            data = json.load(fh)
+        except json.JSONDecodeError:
+            return False
+    return _is_cas_format(data)
+
+
 def _cmd_ingest(source: str, taxonomy_id: str) -> None:
     from evidencell.paths import taxonomy_dir
     out = taxonomy_dir(taxonomy_id)
-    print(f"Ingesting {source} → {out}/")
-    counts = ingest_to_yaml(Path(source), taxonomy_id, out)
+    src = Path(source)
+    is_cas = _detect_cas_format(src)
+    fmt = "CAS" if is_cas else "VFB graph export"
+    print(f"Ingesting {source} ({fmt} format) → {out}/")
+    if is_cas:
+        counts = ingest_cas_to_yaml(src, taxonomy_id, out)
+    else:
+        counts = ingest_to_yaml(src, taxonomy_id, out)
     total = sum(counts.values())
     for lvl, n in sorted(counts.items()):
         print(f"  {lvl}: {n:,} nodes")

--- a/src/evidencell/taxonomy_db.py
+++ b/src/evidencell/taxonomy_db.py
@@ -59,6 +59,7 @@ class TaxonomyMeta:
     source_file: str | None = None       # JSON/CSV/XLSX path for ad hoc taxonomies
     ingest_date: str | None = None
     level_counts: dict[str, int] = field(default_factory=dict)
+    level_hierarchy: list[dict] = field(default_factory=list)  # [{level_name, rank, count, is_terminal}]
     mapmycells: MapMyCellsMeta = field(default_factory=MapMyCellsMeta)
 
 
@@ -104,6 +105,7 @@ def read_taxonomy_meta(taxonomy_id: str) -> TaxonomyMeta:
         source_file=d.get("source_file"),
         ingest_date=d.get("ingest_date"),
         level_counts=d.get("level_counts", {}),
+        level_hierarchy=d.get("level_hierarchy", []),
         mapmycells=MapMyCellsMeta(
             at_taxonomy_id=mmc_raw.get("at_taxonomy_id"),
             stats_s3_url=mmc_raw.get("stats_s3_url"),
@@ -130,6 +132,8 @@ def _meta_to_dict(meta: TaxonomyMeta) -> dict[str, Any]:
         v = getattr(meta, k)
         if v is not None:
             d[k] = v
+    if meta.level_hierarchy:
+        d["level_hierarchy"] = meta.level_hierarchy
     if meta.level_counts:
         d["level_counts"] = meta.level_counts
     if mmc_dict:
@@ -212,7 +216,7 @@ class TaxonomyNode:
     anat: list[dict] = field(default_factory=list)
     rationale: str | None = None
     rationale_dois: list[str] = field(default_factory=list)
-    sex_bias: str | None = None
+    male_female_ratio: float | None = None  # Male/Female cell count ratio, 2 dp
     # class-level extras
     neuronal: bool | None = None
     glial: bool | None = None
@@ -318,6 +322,25 @@ def _circadian(light: str | None) -> float | None:
     return val if (val > 0.7 or val < 0.3) else None
 
 
+def _male_female_ratio(props: dict, fc: dict[str, list[str]]) -> float | None:
+    """Compute Male/Female cell count ratio from source fractions.
+
+    Returns ratio rounded to 2 dp, or None when either fraction is 0 or absent.
+    """
+    male_raw = _scalar(_first_prop(props, fc.get("male_fraction", ["Male"])))
+    female_raw = _scalar(_first_prop(props, fc.get("female_fraction", ["Female"])))
+    if male_raw is None or female_raw is None:
+        return None
+    try:
+        male = float(male_raw)
+        female = float(female_raw)
+    except (ValueError, TypeError):
+        return None
+    if female == 0.0 or male == 0.0:
+        return None
+    return round(male / female, 2)
+
+
 def _extract_node(row: dict, taxonomy_id: str, fc: dict[str, list[str]]) -> TaxonomyNode:
     """Extract a TaxonomyNode from a raw VFB graph export row.
 
@@ -409,13 +432,99 @@ def _extract_node(row: dict, taxonomy_id: str, fc: dict[str, list[str]]) -> Taxo
         anat=anat_entries,
         rationale=rationale,
         rationale_dois=rationale_dois,
-        sex_bias=_scalar(_first_prop(
-            props,
-            fc.get("sex_bias", ["sex_bias", "CCN20230722_sex_bias"]),
-        )),
+        male_female_ratio=_male_female_ratio(props, fc),
         neuronal=neuronal,
         glial=glial,
     )
+
+
+def _compute_level_hierarchy(
+    nodes: list[TaxonomyNode],
+) -> tuple[list[dict], dict[str, int]]:
+    """Derive rank assignments from parent relationships.
+
+    Returns (level_hierarchy, level_to_rank) where level_hierarchy is the
+    list for taxonomy_meta.yaml and level_to_rank maps level name → int rank.
+
+    Algorithm: build a directed graph of level→parent_level edges from the
+    nodes' parent relationships.  Leaf levels (no children) get rank 0,
+    then increment toward root.  Levels that appear only as parents of
+    themselves (e.g. NEUROTRANSMITTER with no parent) and have no children
+    from other levels are excluded (orthogonal annotations).
+    """
+    # Build {node_id: level} and {level: set(parent_levels)}
+    id_to_level: dict[str, str] = {}
+    levels: set[str] = set()
+    for n in nodes:
+        lev = n.taxonomy_level.upper()
+        id_to_level[n.node_id] = lev
+        levels.add(lev)
+
+    # child_level → set of parent_levels
+    parent_of: dict[str, set[str]] = {lev: set() for lev in levels}
+    for n in nodes:
+        if n.parent_id:
+            parent_lev = id_to_level.get(n.parent_id)
+            if parent_lev:
+                child_lev = n.taxonomy_level.upper()
+                if parent_lev != child_lev:
+                    parent_of[child_lev].add(parent_lev)
+
+    # Find hierarchical levels: those that appear as child or parent of another level
+    hierarchical: set[str] = set()
+    for child, parents in parent_of.items():
+        if parents:
+            hierarchical.add(child)
+            hierarchical.update(parents)
+
+    # Topological sort: leaf (no children pointing to it as parent) → root
+    # "children" of a level = levels whose parent_of set contains this level
+    children_of: dict[str, set[str]] = {lev: set() for lev in hierarchical}
+    for child in hierarchical:
+        for parent in parent_of.get(child, set()):
+            if parent in hierarchical:
+                children_of[parent].add(child)
+
+    # Assign ranks bottom-up: leaves first
+    level_to_rank: dict[str, int] = {}
+    assigned: set[str] = set()
+
+    def _assign(lev: str) -> int:
+        if lev in level_to_rank:
+            return level_to_rank[lev]
+        kids = children_of.get(lev, set())
+        if not kids:
+            level_to_rank[lev] = 0
+            assigned.add(lev)
+            return 0
+        max_child_rank = max(_assign(c) for c in kids)
+        rank = max_child_rank + 1
+        level_to_rank[lev] = rank
+        assigned.add(lev)
+        return rank
+
+    for lev in hierarchical:
+        _assign(lev)
+
+    # Count nodes per level
+    level_count: dict[str, int] = {}
+    for n in nodes:
+        lev = n.taxonomy_level.upper()
+        level_count[lev] = level_count.get(lev, 0) + 1
+
+    # Build hierarchy list sorted by rank
+    hierarchy: list[dict] = []
+    for lev, rank in sorted(level_to_rank.items(), key=lambda x: x[1]):
+        entry: dict = {
+            "level_name": lev,
+            "rank": rank,
+            "count": level_count.get(lev, 0),
+        }
+        if rank == 0:
+            entry["is_terminal"] = True
+        hierarchy.append(entry)
+
+    return hierarchy, level_to_rank
 
 
 # ── YAML generation ────────────────────────────────────────────────────────────
@@ -568,6 +677,8 @@ def _node_to_dict(n: TaxonomyNode, meta: TaxonomyMeta, name_lookup: dict[str, st
         d["anatomical_location"] = anat_locs
     if n.neighborhood:
         d["neighborhood"] = n.neighborhood
+    if n.male_female_ratio is not None:
+        d["male_female_ratio"] = n.male_female_ratio
     if species:
         d["species"] = species
     return d
@@ -637,24 +748,35 @@ def ingest_to_yaml(source: Path, taxonomy_id: str, output_dir: Path) -> dict[str
         if n.node_id:
             name_lookup[n.node_id] = clean_name
 
+    # Compute level hierarchy and assign ranks to nodes
+    level_hierarchy, level_to_rank = _compute_level_hierarchy(all_nodes)
+
     # Second pass: convert to CellTypeNode dicts grouped by level
     by_level: dict[str, list[dict]] = {}
     for n in all_nodes:
-        by_level.setdefault(n.taxonomy_level, []).append(
-            _node_to_dict(n, meta, name_lookup)
-        )
+        d = _node_to_dict(n, meta, name_lookup)
+        lev_upper = n.taxonomy_level.upper()
+        rank = level_to_rank.get(lev_upper)
+        if rank is not None:
+            d["taxonomy_rank"] = rank
+        by_level.setdefault(n.taxonomy_level, []).append(d)
 
     # Write one TaxonomyNodeList YAML per level
     counts: dict[str, int] = {}
     for level, nodes in sorted(by_level.items()):
+        lev_upper = level.upper()
+        header: dict[str, Any] = {
+            "taxonomy_id": taxonomy_id,
+            "taxonomy_level": lev_upper,
+        }
+        rank = level_to_rank.get(lev_upper)
+        if rank is not None:
+            header["taxonomy_rank"] = rank
+        header["nodes"] = nodes
         out_file = output_dir / f"{level}.yaml"
         with out_file.open("w", encoding="utf-8") as fh:
             yaml.dump(
-                {
-                    "taxonomy_id": taxonomy_id,
-                    "taxonomy_level": level.upper(),
-                    "nodes": nodes,
-                },
+                header,
                 fh,
                 allow_unicode=True,
                 sort_keys=False,
@@ -663,6 +785,7 @@ def ingest_to_yaml(source: Path, taxonomy_id: str, output_dir: Path) -> dict[str
         counts[level] = len(nodes)
 
     meta.level_counts = counts
+    meta.level_hierarchy = level_hierarchy
     meta_file = output_dir / "taxonomy_meta.yaml"
     with meta_file.open("w", encoding="utf-8") as fh:
         yaml.dump(_meta_to_dict(meta), fh, allow_unicode=True, sort_keys=False)
@@ -869,6 +992,16 @@ def ingest_cas_to_yaml(
         counts[level] = len(nodes)
 
     meta.level_counts = counts
+    # Build level_hierarchy from labelset_rank + counts
+    cas_hierarchy: list[dict] = []
+    for ls_name, ls_rank in sorted(labelset_rank.items(), key=lambda x: x[1]):
+        level = _cas_level_name(ls_name)
+        if level in counts:
+            entry: dict = {"level_name": level, "rank": ls_rank, "count": counts[level]}
+            if ls_rank == 0:
+                entry["is_terminal"] = True
+            cas_hierarchy.append(entry)
+    meta.level_hierarchy = cas_hierarchy
     meta_file = output_dir / "taxonomy_meta.yaml"
     with meta_file.open("w", encoding="utf-8") as fh:
         yaml.dump(_meta_to_dict(meta), fh, allow_unicode=True, sort_keys=False)
@@ -900,7 +1033,7 @@ CREATE TABLE IF NOT EXISTS nodes (
   circadian_ratio        REAL,
   rationale              TEXT,
   rationale_dois         TEXT,
-  sex_bias               TEXT
+  male_female_ratio      REAL
 );
 
 CREATE TABLE IF NOT EXISTS anat (
@@ -1135,7 +1268,7 @@ class TaxonomyDB:
                :cell_ontology_term, :nt_type,
                :defining_markers_scoped, :defining_markers, :tf_markers,
                :merfish_markers, :np_markers, :neighborhood, :circadian_ratio,
-               :rationale, :rationale_dois, :sex_bias
+               :rationale, :rationale_dois, :male_female_ratio
             )""",
             {
                 "node_id": node_id,
@@ -1160,7 +1293,7 @@ class TaxonomyDB:
                 "circadian_ratio": None,  # not in CellTypeNode schema
                 "rationale": None,        # not in CellTypeNode schema
                 "rationale_dois": None,   # not in CellTypeNode schema
-                "sex_bias": None,         # not in CellTypeNode schema
+                "male_female_ratio": nd.get("male_female_ratio"),
             },
         )
         for a in nd.get("anatomical_location") or []:
@@ -1881,6 +2014,8 @@ def _cmd_find_candidates(
                 "score": c["_score"],
                 "nt_type": c.get("nt_type"),
                 "parent_id": c.get("parent_id"),
+                **({"male_female_ratio": c["male_female_ratio"]}
+                   if c.get("male_female_ratio") is not None else {}),
             }
             for c in candidates
         ],

--- a/tests/test_taxonomy_db.py
+++ b/tests/test_taxonomy_db.py
@@ -16,14 +16,17 @@ from evidencell.taxonomy_db import (
     TaxonomyDB,
     TaxonomyMeta,
     clean_taxonomy_json,
+    ingest_cas_to_yaml,
     ingest_to_yaml,
     iter_taxonomy_rows,
     read_taxonomy_meta,
+    _is_cas_format,
     _meta_to_dict,
 )
 
 FIXTURE_DIR = Path(__file__).parent.parent / "inputs" / "taxonomies"
 SINGLE_ROW = FIXTURE_DIR / "test_single_row.json"
+CAS_FIXTURE = FIXTURE_DIR / "test_cas_fixture.json"
 
 
 # ── clean_taxonomy_json ────────────────────────────────────────────────────────
@@ -156,6 +159,86 @@ def test_anat_cell_count(tmp_path):
 def test_ingest_to_yaml_idempotent(tmp_path):
     counts1 = ingest_to_yaml(SINGLE_ROW, "TEST_TAX", tmp_path)
     counts2 = ingest_to_yaml(SINGLE_ROW, "TEST_TAX", tmp_path)
+    assert counts1 == counts2
+
+
+# ── CAS-format ingest ────────────────────────────────────────────────────────
+
+
+def test_is_cas_format_detection():
+    """_is_cas_format correctly identifies CAS vs VFB graph export."""
+    cas = {"annotations": [], "labelsets": []}
+    assert _is_cas_format(cas) is True
+    vfb = [{"wmb": {}, "cl": None}]
+    assert _is_cas_format(vfb) is False
+    assert _is_cas_format({"annotations": []}) is False  # missing labelsets
+
+
+def test_cas_ingest_creates_files(tmp_path):
+    counts = ingest_cas_to_yaml(CAS_FIXTURE, "TEST_CAS", tmp_path)
+    assert sum(counts.values()) == 4  # 1 class + 1 subclass + 2 clusters
+    assert (tmp_path / "taxonomy_meta.yaml").exists()
+    assert (tmp_path / "cluster.yaml").exists()
+    assert (tmp_path / "subclass.yaml").exists()
+    assert (tmp_path / "class.yaml").exists()
+
+
+def test_cas_ingest_meta(tmp_path):
+    ingest_cas_to_yaml(CAS_FIXTURE, "TEST_CAS", tmp_path)
+    meta = yaml.safe_load((tmp_path / "taxonomy_meta.yaml").read_text())
+    assert meta["taxonomy_id"] == "TEST_CAS"
+    assert meta["source_file"] == "test_cas_fixture.json"
+    assert meta["level_counts"]["CLUSTER"] == 2
+    assert meta["level_counts"]["SUBCLASS"] == 1
+    assert meta["level_counts"]["CLASS"] == 1
+    # CAS ingest picks up title as taxonomy_name when no meta input
+    assert meta["taxonomy_name"] == "Test CAS Taxonomy"
+
+
+def test_cas_ingest_node_fields(tmp_path):
+    ingest_cas_to_yaml(CAS_FIXTURE, "TEST_CAS", tmp_path)
+    data = yaml.safe_load((tmp_path / "cluster.yaml").read_text())
+    assert data["taxonomy_level"] == "CLUSTER"
+    assert data["taxonomy_rank"] == 0
+    nodes = data["nodes"]
+    assert len(nodes) == 2
+    node = nodes[0]  # sorted by accession
+    assert node["cell_set_accession"].startswith("TEST_CAS_")
+    assert node["taxonomy_level"] == "CLUSTER"
+    assert node["taxonomy_rank"] == 0
+    assert node["definition_basis"] == "ATLAS_TRANSCRIPTOMIC"
+    assert node["is_terminal"] is True
+
+
+def test_cas_ingest_parent_hierarchy(tmp_path):
+    ingest_cas_to_yaml(CAS_FIXTURE, "TEST_CAS", tmp_path)
+    data = yaml.safe_load((tmp_path / "cluster.yaml").read_text())
+    node = data["nodes"][0]
+    ph = node.get("parent_hierarchy", [])
+    assert len(ph) == 1
+    assert ph[0]["level"] == "SUBCLASS"
+    assert ph[0]["name"] == "Sst"
+    assert ph[0]["cell_set_accession"] == "TEST_CAS_444"
+
+
+def test_cas_ingest_rationale_dois(tmp_path):
+    ingest_cas_to_yaml(CAS_FIXTURE, "TEST_CAS", tmp_path)
+    data = yaml.safe_load((tmp_path / "cluster.yaml").read_text())
+    node = data["nodes"][0]
+    assert "rationale_dois" in node
+    assert "https://doi.org/10.1016/j.cell.2021.04.021" in node["rationale_dois"]
+
+
+def test_cas_ingest_designation(tmp_path):
+    ingest_cas_to_yaml(CAS_FIXTURE, "TEST_CAS", tmp_path)
+    data = yaml.safe_load((tmp_path / "cluster.yaml").read_text())
+    node = data["nodes"][0]
+    assert "cell_set_designation" in node
+
+
+def test_cas_ingest_idempotent(tmp_path):
+    counts1 = ingest_cas_to_yaml(CAS_FIXTURE, "TEST_CAS", tmp_path)
+    counts2 = ingest_cas_to_yaml(CAS_FIXTURE, "TEST_CAS", tmp_path)
     assert counts1 == counts2
 
 

--- a/tests/test_taxonomy_db.py
+++ b/tests/test_taxonomy_db.py
@@ -415,6 +415,15 @@ def test_full_wmbv1_ingest(tmp_path):
     assert any("1145" in nd["label"] for nd in lugaro)
 
     # Hippocampus GABA query
-    hipp_gaba = db.find_candidates(anat_ids=["MBA:399"], nt_type="GABA")
+    hipp_gaba = db.find_candidates(anat_ids=["MBA:399"], nt_type="GABA", level="cluster")
     assert len(hipp_gaba) > 0
     assert all(nd["_score"] > 0 for nd in hipp_gaba)
+
+    # male_female_ratio: most clusters should have values; check YAML + DB round-trip
+    nodes_with_ratio = [n for n in cluster_yaml["nodes"] if n.get("male_female_ratio") is not None]
+    assert len(nodes_with_ratio) > 5000  # 5317 expected
+    with db._connect() as con:
+        db_count = con.execute(
+            "SELECT COUNT(*) FROM nodes WHERE male_female_ratio IS NOT NULL"
+        ).fetchone()[0]
+    assert db_count > 5000

--- a/workflows/map-cell-type.md
+++ b/workflows/map-cell-type.md
@@ -102,6 +102,11 @@ TASK:
    PARENT HIERARCHY: Note the parent lineage of each candidate. Candidates
    from the same parent are related.
 
+   SEX RATIO: If male_female_ratio is present in the candidate data, note it.
+   Values >3 or <0.33 indicate strong sex bias — relevant for sexually dimorphic
+   nuclei (e.g. hypothalamic BNST, VMH, MPN clusters). Can help confirm or
+   exclude candidates when the classical type has known sex-specific expression.
+
 4. Produce a refined ranking for each rank level. For each candidate include:
    cell_set_accession, name, taxonomy_rank, DB score, your assessment
    (STRONG / PLAUSIBLE / WEAK / EXCLUDE), and brief rationale.


### PR DESCRIPTION
## Summary

- CAS-format taxonomy ingest: Auto-detection of CAS v5+ format (Cell Annotation Schema) alongside existing VFB graph export format. ingest_cas_to_yaml() handles labelset→rank mapping, parent hierarchy resolution, and marker extraction.

- CTX-HPF taxonomy (CS202106160): Ingested from CAS-format JSON. Cross-taxonomy annotation transfer edges (WMB→CTX-HPF) and reconciliation report for hippocampal types.

- Precomputed stats expression enrichment: 18 classical marker genes queried against precomputed_stats HDF5 for 9 target atlas types. Expression profiles added to atlas stub nodes in the hippocampus mapping graph; edge property_comparisons upgraded with quantitative values. (Note: expression data currently lives on mapping graph stubs — should migrate to taxonomy reference store in a future PR.)

- male_female_ratio field: Schema v0.7.1. Computed from source Male/Female cell count fractions (ratio to 2 dp). 5,317 of 5,322 WMB clusters now have ratios, enabling sex-dimorphic cluster screening for mapping targets. Surfaced in find_candidates output and map-cell-type refinement prompt.

- Rank emission fix: Ingest now automatically derives taxonomy_rank and level_hierarchy from parent relationships. Previously added manually in S1 and lost on re-ingest.

- Test fixes: Pre-existing find_candidates regression from S1 (missing rank/level parameter); male_female_ratio round-trip assertion; CAS ingest test suite.

## Test plan
-  just test-fast — 279 passed
- ruff check — clean
- just validate-all — schema validation passes
-  WMB re-ingest: DB + YAML round-trip verified (male_female_ratio, taxonomy_rank)
-  Verify CTX-HPF taxonomy renders correctly from rebuilt DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)