### PR TITLE
Restore pre-commit hook accidentally deleted by sandbox artifact

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Git pre-commit hook: validate staged kb/**/*.yaml files against the LinkML schema.
+# Install with: just install-hooks
+set -euo pipefail
+
+SCHEMA="schema/celltype_mapping.yaml"
+
+# Collect staged kb YAML files (mappings + draft)
+kb_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^kb/.*\.yaml$' || true)
+
+# If the schema itself changed, also validate all KB files
+schema_changed=$(git diff --cached --name-only --diff-filter=ACM | grep -qxF "$SCHEMA" && echo "yes" || true)
+
+if [ "$schema_changed" = "yes" ]; then
+    echo "Schema changed — also validating all KB files..."
+    all_kb=$(find kb -name "*.yaml" 2>/dev/null || true)
+    if [ -n "$all_kb" ]; then
+        kb_files=$(printf '%s\n%s' "$kb_files" "$all_kb" | sort -u)
+    fi
+fi
+
+if [ -z "$kb_files" ]; then
+    exit 0
+fi
+
+failed=0
+for f in $kb_files; do
+    [ -f "$f" ] || continue
+
+    # Skip non-graph config files
+    case "$f" in
+        */taxonomy_meta.yaml|*/field_mapping.yaml) continue ;;
+    esac
+
+    # Determine target class based on path
+    if echo "$f" | grep -q '^kb/taxonomy/'; then
+        target_class="TaxonomyNodeList"
+    else
+        target_class="CellTypeMappingGraph"
+    fi
+
+    echo "Validating $f ($target_class)..."
+    if ! uv run linkml-validate -s "$SCHEMA" -C "$target_class" "$f"; then
+        failed=1
+    fi
+done
+
+if [ $failed -ne 0 ]; then
+    echo ""
+    echo "Pre-commit: KB schema validation failed. Fix errors before committing."
+    echo "Run 'just validate <file>' to debug individual files."
+    exit 1
+fi


### PR DESCRIPTION
The hooks/pre-commit file was created in the provenance-schema-unify PR but the Claude Code sandbox kept removing the hooks/ directory between shell invocations. The deletion was committed inadvertently. This restores the strict version (validates all KB files, not warn-only for drafts).