### PR TITLE
CI + hook: ontology-term validation via OAK

### DIFF
--- a/.claude/anti-hallucination-hooks.md
+++ b/.claude/anti-hallucination-hooks.md
@@ -57,10 +57,19 @@ name_in_source: "oriens layer of hippocampus CA1"   # verbatim from source docum
 - `name_in_source` is a known label or synonym for `id` — catches substitution of a
   plausible-sounding name for a different concept.
 
-**Verification source:** OAK local DB snapshots (`~/.data/oaklib/`).
+**Verification source:** OAK semsql DB snapshots (`~/.data/semsql/sqlite/`,
+managed by pystow).
 
-**Status:** `name_in_source` storage is implemented in schema. OAK lookup in hook —
-*not yet implemented*; currently checked interactively via `just qc` (linkml-term-validator).
+**Status:** Implemented. The pre-edit hook calls
+`evidencell.validate.validate_terms`, which subprocess-invokes
+`linkml-term-validator validate` against `conf/oak_config.yaml`. Fresh clones
+without OAK DBs are soft-skipped — the hook prints `[term check skipped: OAK
+semsql DB missing for {names}; run `just fetch-oak-dbs` to enable]` and lets
+the write through. Set `EVIDENCELL_SKIP_TERM_CHECK=1` for an explicit
+emergency bypass (e.g. mid-session OAK corruption); the bypass logs to
+stderr so it's visible in transcripts. CI runs the same check via the
+`kb-validate` job in `.github/workflows/ci.yml` with the OAK cache restored
+from a `actions/cache@v4` step keyed on `conf/oak_config.yaml`.
 
 ---
 

--- a/.claude/hooks/validate_mapping_hook.py
+++ b/.claude/hooks/validate_mapping_hook.py
@@ -38,6 +38,7 @@ from evidencell.validate import (  # noqa: E402
     check_ref_pmids,
     check_run_refs,
     linkml_validate,
+    validate_terms,
     parse_md_annotations,
     check_md_ids,
 )
@@ -272,6 +273,20 @@ def main():
             print(output.strip(), file=sys.stderr)
         if not ok:
             errors_found = True
+
+        # 5. Ontology-term reference validation (linkml-term-validator + OAK).
+        # Soft-skips when OAK DBs aren't cached yet (fresh-clone case);
+        # explicit bypass via EVIDENCELL_SKIP_TERM_CHECK=1.
+        if os.environ.get("EVIDENCELL_SKIP_TERM_CHECK"):
+            print("Term check bypassed via EVIDENCELL_SKIP_TERM_CHECK=1", file=sys.stderr)
+        else:
+            ok_terms, term_output = validate_terms(
+                simulated, schema_path, file_path.name, file_path=file_path
+            )
+            if term_output.strip():
+                print(term_output.strip(), file=sys.stderr)
+            if not ok_terms:
+                errors_found = True
 
     if errors_found:
         print("=" * 60, file=sys.stderr)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,44 @@ jobs:
 
       - name: Run fast tests (no OAK DB / network)
         run: uv run pytest -m "not integration" --no-cov -q
+
+  kb-validate:
+    # Schema + ontology-term validation across every KB YAML. Uses an
+    # actions/cache step keyed on conf/oak_config.yaml so the OAK semsql
+    # SQLite DBs (CL, UBERON, NCBITaxon — ~hundreds of MB, gitignored) are
+    # restored across runs. Cold-cache runs fall back to fetching DBs via
+    # runoak; warm-cache runs are ~5 s restore + ~10 s validate.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Restore OAK semsql cache
+        id: cache-oak
+        uses: actions/cache@v4
+        with:
+          path: ~/.data/semsql
+          key: oak-semsql-${{ hashFiles('conf/oak_config.yaml') }}-v1
+          restore-keys: |
+            oak-semsql-
+
+      - name: Pre-cache OAK DBs (on cache miss)
+        if: steps.cache-oak.outputs.cache-hit != 'true'
+        run: |
+          uv run runoak -i sqlite:obo:cl info CL:0000000 >/dev/null
+          uv run runoak -i sqlite:obo:uberon info UBERON:0000955 >/dev/null
+          uv run runoak -i sqlite:obo:ncbitaxon info NCBITaxon:9606 >/dev/null
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Validate KB schema + term references
+        run: just validate-all && just validate-terms

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,11 @@ KB writes regardless of which workflow is running.
 **KB YAML** (`kb/**/*.yaml`) — blocks writes with: YAML parse errors, structural
 integrity failures (dangling edges, duplicate IDs, placeholder snippets), `quote_key`
 values absent from `references.json`, `PMID:`/`DOI:` citations absent from
-`references.json`, LinkML schema non-conformance.
+`references.json`, LinkML schema non-conformance, and ontology-term references
+(CL/UBERON/NCBITaxon CURIEs) that don't resolve via the OAK semsql DBs. The
+term check is soft-skipped on fresh clones where OAK DBs aren't cached yet
+(run `just fetch-oak-dbs`); `EVIDENCELL_SKIP_TERM_CHECK=1` provides an
+explicit emergency bypass. CI runs the same check on every push/PR.
 
 **Markdown reports** (`reports/{region}/*.md`) — blocks writes with: blockquote blocks
 missing a `<!-- quote_key: X -->` attribution annotation, quote keys or PMIDs absent

--- a/src/evidencell/validate.py
+++ b/src/evidencell/validate.py
@@ -392,6 +392,110 @@ def linkml_validate(
         return result.returncode == 0, output
 
 
+# ── Term-reference validation (linkml-term-validator + OAK) ────────────────────
+
+_SQLITE_OBO_PREFIX = "sqlite:obo:"
+
+
+def _semsql_db_path(adapter_name: str) -> Path:
+    """Return the on-disk path of an OAK semsql sqlite DB for `adapter_name`.
+
+    OAK uses pystow to cache semsql DBs under `~/.data/semsql/sqlite/{name}.db`
+    (overridable via PYSTOW_HOME). Returning the path without checking
+    existence; callers test `.exists()`.
+    """
+    try:
+        import pystow  # local import — pystow is an oaklib dependency
+        return pystow.join("semsql", "sqlite", name=f"{adapter_name}.db")
+    except ImportError:
+        # Fallback for environments without pystow on the import path
+        return Path.home() / ".data" / "semsql" / "sqlite" / f"{adapter_name}.db"
+
+
+def oak_dbs_available(oak_config_path: Path) -> tuple[bool, list[str]]:
+    """Return (all_present, missing_db_names).
+
+    Reads `conf/oak_config.yaml`, collects adapter strings of the form
+    `sqlite:obo:<name>` (skipping entries whose value is empty), and checks
+    whether the corresponding semsql DB file exists for each.
+
+    Adapters whose value does not start with `sqlite:obo:` are ignored — we
+    cannot offline-check them.
+    """
+    if not oak_config_path.exists():
+        # No config means no terms to validate — report as available.
+        return True, []
+    try:
+        cfg = yaml.safe_load(oak_config_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        return True, []
+
+    adapters = (cfg.get("ontology_adapters") or {})
+    missing: list[str] = []
+    for prefix, adapter in adapters.items():
+        if not isinstance(adapter, str) or not adapter.startswith(_SQLITE_OBO_PREFIX):
+            continue
+        name = adapter[len(_SQLITE_OBO_PREFIX):]
+        if not _semsql_db_path(name).exists():
+            missing.append(name)
+    return (not missing), missing
+
+
+def validate_terms(
+    content: str,
+    schema_path: Path,
+    original_name: str = "input.yaml",
+    file_path: Path | None = None,
+) -> tuple[bool, str]:
+    """
+    Validate ontology-term CURIEs in YAML content via linkml-term-validator.
+
+    Subprocess-based, mirroring `linkml_validate`. Writes the simulated
+    post-edit content to a tempfile, then invokes the `validate` subcommand of
+    linkml-term-validator with the project's `conf/oak_config.yaml`.
+
+    Soft-skip behaviour: if `conf/oak_config.yaml` is missing, or if any
+    required OAK semsql DB is not yet cached, returns
+    `(True, "[skipped: …]")` so the hook does not block fresh-clone writes.
+    Curators see the message in stderr and can run `just fetch-oak-dbs`.
+
+    Returns (passed: bool, output_text: str).
+    """
+    project_root = schema_path.parent.parent
+    oak_config_path = project_root / "conf" / "oak_config.yaml"
+
+    if not oak_config_path.exists():
+        return True, f"(oak_config not found at {oak_config_path} — term check skipped)"
+
+    available, missing = oak_dbs_available(oak_config_path)
+    if not available:
+        joined = ", ".join(sorted(missing))
+        return (
+            True,
+            f"[term check skipped: OAK semsql DB missing for {joined}; "
+            f"run `just fetch-oak-dbs` to enable]",
+        )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir) / original_name
+        tmp.write_text(content, encoding="utf-8")
+
+        result = subprocess.run(
+            [
+                "uv", "run", "linkml-term-validator",
+                "validate",
+                "--config", str(oak_config_path),
+                "--schema", str(schema_path),
+                str(tmp),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+        )
+        output = (result.stdout + result.stderr).strip()
+        return result.returncode == 0, output
+
+
 # ── Markdown annotation parsing ────────────────────────────────────────────────
 
 # Blockquote attribution line: starts with `> —` (em-dash)

--- a/tests/test_hook_integration.py
+++ b/tests/test_hook_integration.py
@@ -456,3 +456,91 @@ def test_valid_kb_file_passes():
     assert r.returncode == 0, (
         f"Expected exit 0 for valid KB file, got {r.returncode}\n{r.stderr}"
     )
+
+
+# ── Term-reference validation ──────────────────────────────────────────────────
+
+
+def _run_hook_with_env(
+    payload: dict,
+    extra_env: dict[str, str],
+    user: str | None = "dosumis@gmail.com",
+) -> subprocess.CompletedProcess:
+    """Run the hook with extra env vars (e.g. EVIDENCELL_SKIP_TERM_CHECK=1)."""
+    env = os.environ.copy()
+    if user is not None:
+        env["EVIDENCELL_HOOK_USER"] = user
+    env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_term_check_bypass_env_short_circuits():
+    """EVIDENCELL_SKIP_TERM_CHECK=1 prints a bypass notice and skips term validation.
+
+    Structural checks still run, so a structurally-valid YAML should pass even
+    if the term check would have rejected it.
+    """
+    payload = _write_payload(_MINIMAL_VALID_YAML)
+    r = _run_hook_with_env(payload, {"EVIDENCELL_SKIP_TERM_CHECK": "1"})
+    # Hook should print the bypass notice
+    assert "bypassed" in r.stderr.lower() or "term check" in r.stderr.lower()
+    # And should not have invoked validate_terms (no "term check skipped: OAK" message)
+    # We do *not* assert exit code here because LinkML schema check may still
+    # fire and either pass or skip; this test isolates the bypass path.
+
+
+def test_term_check_skipped_when_oak_dbs_missing(tmp_path: Path, monkeypatch):
+    """Soft-skip path: when no OAK DBs are cached, the hook still allows the
+    write but emits the informational `[term check skipped: ...]` message.
+
+    Exercised by pointing PYSTOW_HOME at an empty tmp dir so the semsql
+    lookup finds no DB files.
+    """
+    payload = _write_payload(_MINIMAL_VALID_YAML)
+    # Empty pystow home → no .data/semsql/sqlite/*.db files
+    fake_home = tmp_path / "pystow_home"
+    fake_home.mkdir()
+    r = _run_hook_with_env(payload, {"PYSTOW_HOME": str(fake_home)})
+    # The skipped message should appear (assuming conf/oak_config.yaml is
+    # present in the project — it is, so the function gets past the first
+    # short-circuit and into the missing-DB branch).
+    assert (
+        "term check skipped" in r.stderr.lower()
+        or "fetch-oak-dbs" in r.stderr.lower()
+    )
+
+
+@pytest.mark.integration
+def test_term_check_rejects_bad_curie(tmp_path: Path):
+    """End-to-end: when OAK DBs are warm and YAML contains an unresolvable
+    CURIE, the hook blocks. Marked integration because it requires the OAK
+    semsql DBs to be cached locally.
+    """
+    if not SCHEMA.exists():
+        pytest.skip("Schema file not found — run from evidencell/ root")
+    # Skip unless OAK DBs are actually cached locally
+    import pystow
+    cl_db = pystow.join("semsql", "sqlite", name="cl.db")
+    if not cl_db.exists():
+        pytest.skip(f"OAK CL DB not cached at {cl_db}; run `just fetch-oak-dbs`")
+
+    bad_yaml = """\
+nodes:
+  - id: type_a
+    name: Type A
+    cl_term: "CL:9999999999"
+edges: []
+"""
+    r = _run_hook(_write_payload(bad_yaml))
+    # Hook must block (exit code 2) when the CURIE doesn't resolve. We
+    # allow either the LinkML schema check or the term check to be the
+    # failing check, but stderr should mention the bad CURIE or term.
+    assert r.returncode == 2, (
+        f"Expected exit 2 for bad CURIE, got {r.returncode}\n{r.stderr}"
+    )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -14,9 +14,11 @@ from evidencell.validate import (
     check_quote_keys,
     check_ref_pmids,
     linkml_validate,
+    oak_dbs_available,
     parse_md_annotations,
     simulate_edit,
     structural_checks,
+    validate_terms,
 )
 
 
@@ -703,3 +705,146 @@ def test_check_md_no_caches_no_errors():
     }
     errors = check_md_ids(annotations, Path("/nonexistent/references.json"), kb_nodes=None)
     assert errors == []
+
+
+# ── oak_dbs_available + validate_terms ─────────────────────────────────────────
+
+
+def _write_oak_config(tmp_path: Path, adapters: dict[str, str]) -> Path:
+    """Write a minimal conf/oak_config.yaml under tmp_path/conf/."""
+    cfg_dir = tmp_path / "conf"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg_path = cfg_dir / "oak_config.yaml"
+    body = "ontology_adapters:\n"
+    for k, v in adapters.items():
+        body += f"  {k}: \"{v}\"\n" if v else f"  {k}: \"\"\n"
+    cfg_path.write_text(body, encoding="utf-8")
+    return cfg_path
+
+
+def test_oak_dbs_available_missing_config_returns_true(tmp_path: Path):
+    """Missing oak_config.yaml means nothing to validate → all-present."""
+    ok, missing = oak_dbs_available(tmp_path / "no_config.yaml")
+    assert ok is True
+    assert missing == []
+
+
+def test_oak_dbs_available_skips_empty_adapters(tmp_path: Path):
+    """Adapters with empty-string value are ignored (linkml/schema/xsd/rdf/etc)."""
+    cfg = _write_oak_config(
+        tmp_path,
+        {"linkml": "", "schema": "", "MYAPP": "http://example.org"},
+    )
+    # No sqlite:obo:* adapters → no DBs required → all-present.
+    ok, missing = oak_dbs_available(cfg)
+    assert ok is True
+    assert missing == []
+
+
+def test_oak_dbs_available_reports_missing(tmp_path: Path):
+    """sqlite:obo:<name> adapters without a corresponding DB file are flagged."""
+    cfg = _write_oak_config(
+        tmp_path,
+        {"CL": "sqlite:obo:cl", "UBERON": "sqlite:obo:uberon"},
+    )
+    # Point pystow at an empty tmp dir so no DB files exist.
+    fake_semsql = tmp_path / "semsql_home"
+    fake_semsql.mkdir()
+    with patch(
+        "evidencell.validate._semsql_db_path",
+        side_effect=lambda name: fake_semsql / f"{name}.db",
+    ):
+        ok, missing = oak_dbs_available(cfg)
+    assert ok is False
+    assert sorted(missing) == ["cl", "uberon"]
+
+
+def test_oak_dbs_available_all_present(tmp_path: Path):
+    """When DB files exist on disk, returns (True, [])."""
+    cfg = _write_oak_config(tmp_path, {"CL": "sqlite:obo:cl"})
+    fake_semsql = tmp_path / "semsql_home"
+    fake_semsql.mkdir()
+    (fake_semsql / "cl.db").write_bytes(b"")  # marker file
+    with patch(
+        "evidencell.validate._semsql_db_path",
+        side_effect=lambda name: fake_semsql / f"{name}.db",
+    ):
+        ok, missing = oak_dbs_available(cfg)
+    assert ok is True
+    assert missing == []
+
+
+def test_validate_terms_skips_when_config_missing(tmp_path: Path):
+    """If conf/oak_config.yaml is missing, term check returns soft-success."""
+    # schema_path.parent.parent is the project root; oak_config lives at
+    # project_root/conf/oak_config.yaml. Don't create it.
+    schema = tmp_path / "schema" / "celltype_mapping.yaml"
+    schema.parent.mkdir(parents=True)
+    schema.write_text("id: fake")
+    ok, msg = validate_terms("id: x", schema)
+    assert ok is True
+    assert "term check skipped" in msg.lower() or "oak_config not found" in msg.lower()
+
+
+def test_validate_terms_skips_when_oak_dbs_missing(tmp_path: Path):
+    """If oak_config exists but DB files are absent, soft-skip with informative msg."""
+    schema = tmp_path / "schema" / "celltype_mapping.yaml"
+    schema.parent.mkdir(parents=True)
+    schema.write_text("id: fake")
+    _write_oak_config(tmp_path, {"CL": "sqlite:obo:cl"})
+    fake_semsql = tmp_path / "semsql_home"
+    fake_semsql.mkdir()
+    with patch(
+        "evidencell.validate._semsql_db_path",
+        side_effect=lambda name: fake_semsql / f"{name}.db",
+    ):
+        ok, msg = validate_terms("id: x", schema)
+    assert ok is True
+    assert "term check skipped" in msg.lower()
+    assert "cl" in msg.lower()
+    assert "just fetch-oak-dbs" in msg
+
+
+def test_validate_terms_returns_true_on_success(tmp_path: Path):
+    """When subprocess returns 0, validate_terms reports (True, output)."""
+    schema = tmp_path / "schema" / "celltype_mapping.yaml"
+    schema.parent.mkdir(parents=True)
+    schema.write_text("id: fake")
+    _write_oak_config(tmp_path, {"CL": "sqlite:obo:cl"})
+    # Pretend the OAK DB is present
+    fake_semsql = tmp_path / "semsql_home"
+    fake_semsql.mkdir()
+    (fake_semsql / "cl.db").write_bytes(b"")
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "All terms resolved"
+    mock_result.stderr = ""
+    with patch(
+        "evidencell.validate._semsql_db_path",
+        side_effect=lambda name: fake_semsql / f"{name}.db",
+    ), patch("evidencell.validate.subprocess.run", return_value=mock_result):
+        ok, output = validate_terms("nodes: []", schema)
+    assert ok is True
+    assert "All terms resolved" in output
+
+
+def test_validate_terms_returns_false_on_failure(tmp_path: Path):
+    """When subprocess returns non-zero, validate_terms reports (False, output)."""
+    schema = tmp_path / "schema" / "celltype_mapping.yaml"
+    schema.parent.mkdir(parents=True)
+    schema.write_text("id: fake")
+    _write_oak_config(tmp_path, {"CL": "sqlite:obo:cl"})
+    fake_semsql = tmp_path / "semsql_home"
+    fake_semsql.mkdir()
+    (fake_semsql / "cl.db").write_bytes(b"")
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+    mock_result.stderr = "ERROR: unresolved term CL:9999999999"
+    with patch(
+        "evidencell.validate._semsql_db_path",
+        side_effect=lambda name: fake_semsql / f"{name}.db",
+    ), patch("evidencell.validate.subprocess.run", return_value=mock_result):
+        ok, output = validate_terms("nodes: [{id: x, cl_term: CL:9999999999}]", schema)
+    assert ok is False
+    assert "CL:9999999999" in output


### PR DESCRIPTION
Adds linkml-term-validator coverage to two layers so CL/UBERON/NCBITaxon CURIEs in KB YAML are checked continuously, not only on `just qc`:

- Pre-edit hook (.claude/hooks/validate_mapping_hook.py) calls a new validate_terms() after the LinkML schema check. Soft-skips with an informational stderr line when OAK semsql DBs aren't cached yet (fresh-clone case); EVIDENCELL_SKIP_TERM_CHECK=1 is the explicit bypass.
- CI gains a kb-validate job (.github/workflows/ci.yml) that restores ~/.data/semsql via actions/cache@v4 keyed on conf/oak_config.yaml, falls back to runoak warmup on cache miss, then runs `just validate-all && just validate-terms`.

src/evidencell/validate.py adds validate_terms() (subprocess to linkml-term-validator, mirrors linkml_validate) plus oak_dbs_available() and _semsql_db_path() helpers (pystow-aware DB discovery so PYSTOW_HOME overrides are honoured).

Tests: 8 unit cases for oak_dbs_available + validate_terms (mocked subprocess + fake semsql paths), plus 2 fast hook-integration cases (bypass-env, soft-skip via PYSTOW_HOME) and one integration-marked test for warm-cache rejection of CL:9999999999 that auto-skips when cl.db isn't cached locally.

Docs: anti-hallucination-hooks.md flips the term-check status from "not yet implemented" to implemented; CLAUDE.md anti-hallucination section names the new check and the skip/bypass behaviour.