### PR TITLE
CI: bump astral-sh/setup-uv v5 → v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 


### PR DESCRIPTION
GitHub Actions runners cached a v5 SHA that no longer exists in the setup-uv repo, causing 404s on tarball download for both the test and kb-validate jobs. v8.1.0 is the current major; same `enable-cache: true` API.