### PR TITLE
Regenerate 10 reports illustrating Phase 2/3 schema features

### DIFF
--- a/reports/BG/classical_gpi_shell_summary.md
+++ b/reports/BG/classical_gpi_shell_summary.md
@@ -1,0 +1,109 @@
+# GPi shell neuron (internal globus pallidus shell projection neuron) — HMBA_BG_Consensus Mapping Report
+*2026-02-25 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/BG/GPi_shell_neuron.yaml`*
+
+---
+
+> **Location note.** WMBv1 location data derives from MERFISH spatial
+> registration and records **soma position** only. Axonal and dendritic
+> projection targets are not reflected in atlas cluster location fields and
+> are not used in mapping assessments.
+
+---
+
+## Classical type
+
+| Property | Value | References |
+|---|---|---|
+| CL term | internal globus pallidus shell projection neuron (CL:4310096) | |
+| Soma location | Internal segment of globus pallidus, shell region [HBA:12898] |  |
+| NT | GABA-Glut (dual) | [1] |
+| Markers | SST+, TBR1+, SLC17A6+ |  |
+| Negative | PVALB− | |
+| Neuropeptides | SST |  |
+
+---
+
+## Cell Ontology mapping
+
+GPi shell neuron (internal globus pallidus shell projection neuron) is mapped to **internal globus pallidus shell projection neuron (CL:4310096)** as an **exact match** in the Cell Ontology (skos:exactMatch); the existing CL term covers this type.
+
+*Mapping notes:* CL:4310096 was created specifically for this type; this node IS that term.
+
+**Proposed CL term:** *internal globus pallidus shell projection neuron* (ACCEPTED)
+
+> A internal globus pallidus shell projection neuron of the Primates brain. These cells are located in the striatum, external segment of globus pallidus, internal segment of globus pallidus. Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:GPi Shell.
+
+---
+
+## Mapping candidates
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
+|---|---|---|---|---|---|
+| — | Group:GPi Shell (HMBA Basal Ganglia Consensus Taxonomy) [CS20250428_GROUP_0016] |  | — |  |  |
+
+All edges: `skos:exactMatch`
+
+---
+
+## Group:GPi Shell (HMBA Basal Ganglia Consensus Taxonomy) · 
+
+*`CS20250428_GROUP_0016`*
+
+**Supporting evidence:**
+
+- HMBA atlas metadata provides MERFISH-derived soma location (GPi and surrounding GPi core region), neurotransmitter type (dual GABA-Glut), and defining marker expression (Sst+, Tbr1+, Slc17a6+, Pvalb-). All features are consistent with the classical GPi shell neuron description. [Atlas metadata]
+- Establishes three molecularly distinct neuron classes in human GPi by triple FISH: SST+/SLC17A6+/SLC32A1+ dual-transmitter neurons at the GPi border (shell), and PVALB+ pure GABAergic neurons in the center (core). Directly supports dual GABA-Glut, SST+/Pvalb- marker profile and shell vs core anatomical organisation in primates. [Literature] [1]
+- Establishes shell/core anatomical subregion structure of the mouse EPN (= rodent GPi equivalent) using SP and CB1R immunoreactivity: SOM (somatostatin) neurons concentrate in the shell, PV neurons in the core. Directly supports the anatomical shell/core distinction and differential SOM vs Pvalb distribution. Note: mouse data; Tbr1 and Slc17a6 are not described in this study — those markers come from the HMBA atlas (ATLAS_METADATA evidence above). [Literature] [2]
+
+**Concerns:**
+
+- Anatomical location (GPi shell) is inferred from MERFISH CCF registration. Registration may be inaccurate, potentially misassigning cells to adjacent regions (GPe, striatum). This is explicitly noted in CL:4310096.
+- The target cell set is at "Group" level in the HMBA BG taxonomy (hierarchy: Class > Group). Group is a substructure within Class and sits above Subclass/Supertype/Cluster, so this is a moderately coarse mapping. The Group may encompass multiple more finely-resolved clusters that have not yet been individually characterised.
+
+**What would upgrade confidence:**
+
+- *Unresolved:* Are there finer-grained HMBA clusters within the GPi Shell group (CS20250428_GROUP_0016) that correspond to distinct sub-populations (e.g. by projection target or co-transmission ratio)?
+
+- *Proposed:* Re-examine HMBA data at cluster level within Group:GPi Shell to determine if additional transcriptomic heterogeneity is present within this group.
+
+- *Proposed:* MERFISH with probes for Sst, Tbr1, Slc17a6 and Pvalb in GPi to validate location and marker profile with higher spatial precision.
+
+
+---
+
+## Proposed experiments
+
+### 1 — Other
+
+- Re-examine HMBA data at cluster level within Group:GPi Shell to determine if additional transcriptomic heterogeneity is present within this group.
+*Resolves: edge_gpi_shell_to_hmba*
+
+### 2 — MERFISH / spatial transcriptomics
+
+- MERFISH with probes for Sst, Tbr1, Slc17a6 and Pvalb in GPi to validate location and marker profile with higher spatial precision.
+*Resolves: edge_gpi_shell_to_hmba*
+
+---
+
+## Open questions
+
+1. Are there finer-grained HMBA clusters within the GPi Shell group (CS20250428_GROUP_0016) that correspond to distinct sub-populations (e.g. by projection target or co-transmission ratio)?
+
+---
+
+## Evidence base
+
+| Edge | Evidence types | Supports |
+|---|---|---|
+| edge_gpi_shell_to_hmba | Atlas metadata | SUPPORT |
+| edge_gpi_shell_to_hmba | Literature [1] | SUPPORT |
+| edge_gpi_shell_to_hmba | Literature [2] | SUPPORT |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | https://doi.org/10.1016/j.neuron.2017.03.017 | — | neurotransmitter type |
+| [2] | https://doi.org/10.1523/ENEURO.0208-22.2022 | — | Establishes shell/core anatomical subregion structure of the mouse EPN (= rodent |

--- a/reports/cerebellum/classical_basket_summary.md
+++ b/reports/cerebellum/classical_basket_summary.md
@@ -1,0 +1,57 @@
+# Cerebellar basket cell — WMBv1 Mapping Report
+*2026-02-25 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/cerebellum/CB_MLI_types.yaml`*
+
+---
+
+## Classical type
+
+| Property | Value | References |
+|---|---|---|
+| CL term | cerebellar basket cell (CL:2000027) | |
+| Soma location | Cerebellar cortex, molecular layer (inner third) [MBA:1144] |  |
+| NT | GABA |  |
+| Markers |  |  |
+
+---
+
+## Cell Ontology mapping
+
+Cerebellar basket cell is mapped to **cerebellar basket cell (CL:2000027)** as an **exact match** in the Cell Ontology (skos:exactMatch); the existing CL term covers this type.
+
+*Mapping notes:* CL:2000027 (cerebellar basket cell) is the exact CL term for this type. The cross-cutting relationship with MLI1 means the classical definition (morphology + location) and the transcriptomic definition (MLI1) do not align — the CL term captures the classical morphological type.
+
+---
+
+## Mapping candidates
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
+|---|---|---|---|---|---|
+| — | MLI1 (Kozareva 2021) |  | — |  |  |
+
+All edges: `evidencell:CrossCuttingMatch`
+
+---
+
+## MLI1 (Kozareva 2021) · 
+
+**Supporting evidence:**
+
+- Kozareva 2021 explicitly states that MLI1/MLI2 do not map to the classical basket/stellate boundary. MLI1 cells near the PC layer have basket morphology but MLI1 is not equivalent to basket cells — it also contains distally-located cells with stellate morphology. CROSS_CUTTING is the correct relationship: MLI1 draws from both classical types. [Literature] [1]
+- Direct morphological characterisation of MLI1: proximal (inner ML) MLI1 cells have basket morphology, distal MLI1 cells have stellate morphology. This confirms CROSS_CUTTING — the classical basket type is a positional subset of MLI1, not a distinct transcriptomic entity. [Literature] [1]
+
+---
+
+## Evidence base
+
+| Edge | Evidence types | Supports |
+|---|---|---|
+| edge_basket_to_mli1 | Literature [1] | SUPPORT |
+| edge_basket_to_mli1 | Literature [1] | SUPPORT |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | PMID:34616064 | [34616064](https://pubmed.ncbi.nlm.nih.gov/34616064/) | Kozareva 2021 explicitly states that MLI1/MLI2 do not map to the classical baske |

--- a/reports/cerebellum/classical_globular_summary.md
+++ b/reports/cerebellum/classical_globular_summary.md
@@ -1,0 +1,77 @@
+# Globular cell — WMBv1 Mapping Report
+*2026-02-25 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/cerebellum/CB_PLI_types.yaml`*
+
+---
+
+> **Location note.** WMBv1 location data derives from MERFISH spatial
+> registration and records **soma position** only. Axonal and dendritic
+> projection targets are not reflected in atlas cluster location fields and
+> are not used in mapping assessments.
+
+---
+
+## Classical type
+
+| Property | Value | References |
+|---|---|---|
+| CL term | Purkinje layer interneuron (CL:4072102) | |
+| Soma location | Cerebellar cortex, Purkinje layer [MBA:1145] |  |
+| NT | GABA-Glyc |  |
+| Markers |  |  |
+
+---
+
+## Cell Ontology mapping
+
+Globular cell is a **broad match** to **Purkinje layer interneuron (CL:4072102)** in the Cell Ontology — i.e. **Purkinje layer interneuron (CL:4072102)** is the closest existing CL term (an ancestor) but does not fully cover this type. A new child term is a candidate for submission to CL.
+
+*Mapping notes:* No specific CL term yet for Globular cell. CL:4072102 (Purkinje layer interneuron) is the appropriate broad ancestor — this is also the direct parent of CL:4042030 (candelabrum cell) and CL:0011006 (Lugaro cell). A new term for Globular cell would be placed as a sibling of candelabrum cell within this parent.
+
+**Proposed CL term** (DRAFT)
+
+> A GABAergic/glycinergic interneuron of the cerebellar cortex Purkinje layer with a globular soma morphology, distinct from Lugaro and Candelabrum cells. Reference transcriptomic data for this type can be found in WMBv1 in cell set CS20230722_CLUS_5177 (best mapping) and neighbouring PLI clusters.
+
+---
+
+## Mapping candidates
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
+|---|---|---|---|---|---|
+| — | PLI2 (Osorno 2022 / Globular) |  | — |  |  |
+
+All edges: `skos:exactMatch`
+
+---
+
+## PLI2 (Osorno 2022 / Globular) · 
+
+**Supporting evidence:**
+
+- Osorno 2022 defines PLI2 as globular cells based on soma morphology, providing the primary classical-to-T-type correspondence. [Literature] [1]
+
+**What would upgrade confidence:**
+
+- *Unresolved:* The Globular cell type has limited prior classical characterisation compared to Lugaro and Candelabrum. The PLI2 definition is largely Osorno 2022's own contribution — prior classical literature may not have this type explicitly named.
+
+
+---
+
+## Open questions
+
+1. The Globular cell type has limited prior classical characterisation compared to Lugaro and Candelabrum. The PLI2 definition is largely Osorno 2022's own contribution — prior classical literature may not have this type explicitly named.
+
+---
+
+## Evidence base
+
+| Edge | Evidence types | Supports |
+|---|---|---|
+| edge_globular_to_pli2 | Literature [1] | SUPPORT |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | PMID:35578131 | [35578131](https://pubmed.ncbi.nlm.nih.gov/35578131/) | Osorno 2022 defines PLI2 as globular cells based on soma morphology, providing t |

--- a/reports/cerebellum/classical_lugaro_summary.md
+++ b/reports/cerebellum/classical_lugaro_summary.md
@@ -1,0 +1,66 @@
+# Lugaro cell — WMBv1 Mapping Report
+*2026-02-25 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/cerebellum/CB_PLI_types.yaml`*
+
+---
+
+> **Location note.** WMBv1 location data derives from MERFISH spatial
+> registration and records **soma position** only. Axonal and dendritic
+> projection targets are not reflected in atlas cluster location fields and
+> are not used in mapping assessments.
+
+---
+
+## Classical type
+
+| Property | Value | References |
+|---|---|---|
+| CL term | Lugaro cell (CL:0011006) | |
+| Soma location | Cerebellar cortex, Purkinje layer / granule layer border [MBA:1145] |  |
+| NT | GABA-Glyc |  |
+| Markers |  |  |
+
+---
+
+## Cell Ontology mapping
+
+Lugaro cell is mapped to **Lugaro cell (CL:0011006)** as an **exact match** in the Cell Ontology (skos:exactMatch); the existing CL term covers this type.
+
+*Mapping notes:* CL:0011006 (Lugaro cell) is the exact CL term for this type. The CL definition describes "a spindle-shaped or triangular soma, parasagittally oriented and located at the border between the granular layer and the Purkinje cell layer... capable of co-releasing GABA and glycine." This matches the classical description.
+
+**Proposed CL term:** *Lugaro cell* (ACCEPTED)
+
+> A cerebellar interneuron characterized by a spindle-shaped or triangular soma, parasagittally oriented and located at the border between the granular layer and the Purkinje cell layer. The Lugaro cell extends dendrites predominantly in the parasagittal plane, forming synaptic interactions with basket, stellate, and Golgi cells. Its axonal projections extend upward into the molecular layer, where they form a parasagittal plexus and emit long transverse collaterals that run parallel to the long axis of the cerebellar folia. The Lugaro cell is capable of co-releasing GABA and glycine, as evidenced by the expression of glutamate decarboxylase (GAD65/67) and the glycine transporter GlyT2.
+
+---
+
+## Mapping candidates
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
+|---|---|---|---|---|---|
+| — | PLI3 (Osorno 2022 / Lugaro) |  | — |  |  |
+
+All edges: `skos:exactMatch`
+
+---
+
+## PLI3 (Osorno 2022 / Lugaro) · 
+
+**Supporting evidence:**
+
+- Osorno 2022 directly maps PLI3 to the classical Lugaro cell type based on soma location, axon morphology, and co-transmission of GABA + glycine. The correspondence is supported by multiple independent features. [Literature] [1]
+
+---
+
+## Evidence base
+
+| Edge | Evidence types | Supports |
+|---|---|---|
+| edge_lugaro_to_pli3 | Literature [1] | SUPPORT |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | PMID:35578131 | [35578131](https://pubmed.ncbi.nlm.nih.gov/35578131/) | Osorno 2022 directly maps PLI3 to the classical Lugaro cell type based on soma l |

--- a/reports/cerebellum/classical_stellate_summary.md
+++ b/reports/cerebellum/classical_stellate_summary.md
@@ -1,0 +1,69 @@
+# Cerebellar stellate cell — WMBv1 Mapping Report
+*2026-02-25 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/cerebellum/CB_MLI_types.yaml`*
+
+---
+
+## Classical type
+
+| Property | Value | References |
+|---|---|---|
+| CL term | cerebellar stellate cell (CL:0010010) | |
+| Soma location | Cerebellar cortex, molecular layer (outer third) [MBA:1144] |  |
+| NT | GABA |  |
+| Markers |  |  |
+
+---
+
+## Cell Ontology mapping
+
+Cerebellar stellate cell is mapped to **cerebellar stellate cell (CL:0010010)** as an **exact match** in the Cell Ontology (skos:exactMatch); the existing CL term covers this type.
+
+*Mapping notes:* CL:0010010 (cerebellar stellate cell) is the exact CL term for this type. Kozareva 2021 shows that distal MLI1 and distal MLI2 both have stellate morphology, so both transcriptomic types partially correspond to the classical stellate definition. The CL term captures the morphological type without implying transcriptomic uniformity.
+
+---
+
+## Mapping candidates
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
+|---|---|---|---|---|---|
+| — | MLI1 (Kozareva 2021) |  | — |  |  |
+| — | MLI2 (Kozareva 2021) |  | — |  |  |
+
+All edges: `evidencell:PartialOverlapMatch`
+
+---
+
+## MLI1 (Kozareva 2021) · 
+
+**Supporting evidence:**
+
+- Distal MLI1 cells have stellate morphology, meaning classical stellate cells (defined by outer ML location + star-shaped morphology) partially overlap with MLI1. However, distal MLI2 cells also have stellate morphology, so stellate → PARTIAL_OVERLAP with both MLI1 and MLI2. [Literature] [1]
+
+**Concerns:**
+
+- The fraction of classical stellate cells in MLI1 vs MLI2 is not precisely quantified by Kozareva 2021 — the split is described qualitatively as location-dependent. Quantitative spatial analysis needed.
+
+---
+
+## MLI2 (Kozareva 2021) · 
+
+**Supporting evidence:**
+
+- Distal MLI2 cells have stellate morphology, confirming partial overlap with the classical stellate type. MLI2 near the PC layer has a distinct morphology (not basket). Together with edge_stellate_to_mli1, this means the classical stellate type is distributed across both MLI1 and MLI2 transcriptomic types. [Literature] [1]
+
+---
+
+## Evidence base
+
+| Edge | Evidence types | Supports |
+|---|---|---|
+| edge_stellate_to_mli1 | Literature [1] | SUPPORT |
+| edge_stellate_to_mli2 | Literature [1] | SUPPORT |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | PMID:34616064 | [34616064](https://pubmed.ncbi.nlm.nih.gov/34616064/) | Distal MLI1 cells have stellate morphology, meaning classical stellate cells (de |

--- a/reports/cerebellum/pli2_osorno_summary.md
+++ b/reports/cerebellum/pli2_osorno_summary.md
@@ -1,0 +1,81 @@
+# PLI2 (Osorno 2022 / Globular) — WMBv1 Mapping Report
+*2026-02-25 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/cerebellum/CB_PLI_types.yaml`*
+
+---
+
+> **Location note.** WMBv1 location data derives from MERFISH spatial
+> registration and records **soma position** only. Axonal and dendritic
+> projection targets are not reflected in atlas cluster location fields and
+> are not used in mapping assessments.
+
+---
+
+## Classical type
+
+| Property | Value | References |
+|---|---|---|
+| CL term | — | |
+| Soma location |  |  |
+| NT | GABA-Glyc |  |
+| Markers |  |  |
+
+---
+
+## Mapping candidates
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
+|---|---|---|---|---|---|
+| — | 5177 CB PLI Gly-Gaba_1 [CS20230722_CLUS_5177] |  | 535 |  |  |
+
+All edges: `evidencell:PartialOverlapMatch`
+
+---
+
+## 5177 CB PLI Gly-Gaba_1 · 
+
+*`CS20230722_CLUS_5177` · 535 cells (10x)*
+
+**Supporting evidence:**
+
+- MapMyCells transfer of PLI2 (Globular) cells to WMBv1 shows strongest mapping to cluster 5177 with good precision (83%) but limited recall (93% at cluster level, but only 30% at subclass and 38% at supertype), indicating PLI2 cells distribute across multiple clusters. NT prediction (GABA-Glyc) is consistent with co-transmitting Globular cells. [Annotation transfer]
+
+**Concerns:**
+
+- PLI2 (Globular) cells distribute across multiple WMBv1 clusters within the CB PLI Gly-Gaba subclass (subclass-level purity only 30%), suggesting either transcriptomic heterogeneity within the Globular type or that the classical morphological Globular definition encompasses multiple transcriptomic subtypes.
+
+**What would upgrade confidence:**
+
+- *Unresolved:* Do the PLI2 cells mapping to clusters other than 5177 represent a distinct Globular subtype, or is this noise in the annotation transfer?
+
+- *Proposed:* Re-analyse PLI2 cells from SCP795 at higher resolution to determine if the cluster-level heterogeneity reflects a biologically meaningful split.
+
+
+---
+
+## Proposed experiments
+
+### 1 — Other
+
+- Re-analyse PLI2 cells from SCP795 at higher resolution to determine if the cluster-level heterogeneity reflects a biologically meaningful split.
+*Resolves: edge_pli2_to_wmb5177*
+
+---
+
+## Open questions
+
+1. Do the PLI2 cells mapping to clusters other than 5177 represent a distinct Globular subtype, or is this noise in the annotation transfer?
+
+---
+
+## Evidence base
+
+| Edge | Evidence types | Supports |
+|---|---|---|
+| edge_pli2_to_wmb5177 | Annotation transfer | PARTIAL |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|

--- a/reports/dentate_gyrus/dg_immature_granule_neuron_summary.md
+++ b/reports/dentate_gyrus/dg_immature_granule_neuron_summary.md
@@ -1,8 +1,5 @@
 # Dentate Gyrus Immature Granule Neuron — Allen Brain Cell Atlas CCN202307220 Mapping Report
-*Draft · 2026-04-14 · Source: `/Users/ar38/Documents/GitHub/evidencell/kb/draft/dentate_gyrus/20260414_dentate_gyrus_report_ingest.yaml`*
-
-> ⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted.
-> All edges require expert review before use.
+*2026-04-14 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/dentate_gyrus/20260414_dentate_gyrus_report_ingest.yaml`*
 
 ---
 
@@ -11,32 +8,42 @@
 | Property | Value | References |
 |---|---|---|
 | CL term | immature dentate gyrus granule neuron (CL:9900002) | |
-| Soma location | inner granule cell layer (GCL) [UBERON:0005381] | [1] [2] |
-| NT | glutamatergic | [3] [4] |
-| Markers | DCX+, NeuN+, PSA-NCAM+, Tis21+ | [5] [6] [7] |
+| Soma location | inner granule cell layer (GCL) [UBERON:0005381] |  |
+| NT | glutamatergic | [1] [2] |
+| Markers | DCX+, NeuN+, PSA-NCAM+, Tis21+ | [3] [4] [5] |
 | Negative | Calbindin− | |
+
+---
+
+## Cell Ontology mapping
+
+Dentate Gyrus Immature Granule Neuron is mapped to **immature dentate gyrus granule neuron (CL:9900002)** as an **exact match** in the Cell Ontology (skos:exactMatch); the existing CL term covers this type.
+
+*Mapping notes:* CL:9900002 (immature dentate gyrus granule neuron, child of CL:4042028 immature neuron) is an exact match — defined as the postmitotic, synaptically integrating stage marked by DCX+/NeuN+/Tbr1+ prior to calbindin acquisition. Atlas clusters 0514 and 0515 (Tbr1+/Prox1+/ Igfbpl1+) provide the transcriptomic evidence for this term.
 
 ---
 
 ## Mapping candidates
 
-| Rank | WMBv1 cluster | Supertype | Cells | Confidence | Verdict |
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
 |---|---|---|---|---|---|
-| 1 | 0514 DG-PIR Ex IMN_2 [CS20230722_CLUS_0514] |  | — | 🔴 LOW | Speculative |
-| 2 | 0515 DG-PIR Ex IMN_2 [CS20230722_CLUS_0515] |  | — | 🔴 LOW | Speculative |
+| — | 0514 DG-PIR Ex IMN_2 [CS20230722_CLUS_0514] |  | — |  |  |
+| — | 0515 DG-PIR Ex IMN_2 [CS20230722_CLUS_0515] |  | — |  |  |
 
-All edges: `TYPE_A_SPLITS`
+All edges: `skos:broadMatch`
 
 ---
 
-## 0514 DG-PIR Ex IMN_2 · 🔴 LOW
+## 0514 DG-PIR Ex IMN_2 · 
+
+*`CS20230722_CLUS_0514`*
 
 **Supporting evidence:**
 
 - EXACT CL:9900002 (immature dentate gyrus granule neuron) in atlas; curator annotation 'late neuroblast/immature granule cell'. TF markers: Tbr1 (canonical postmitotic TF; Hodge et al. 2008), Prox1, Emx2 (MERFISH), Igfbpl1 (MERFISH), Ccbe1 (scoped). Anatomy: DGdo,me HIP:0.98. NT: Glut. No Calbindin (Calb1) — consistent with immature (not mature) stage. Discovery composite score 0.82. [Atlas metadata]
-- Establishes stage-5 definition (DCX+/NeuN+/Calbindin−). Absence of Calbindin from cluster defining_markers is consistent with pre-terminal immature identity. [Literature] [5]
-- Tbr1 onset marks postmitotic transition from neuroblast to immature granule neuron. Tbr1 present as TF marker; bridges atlas TF evidence to classical postmitotic immature granule neuron stage. [Literature] [8]
-- Confirms Tis21 re-expression in postmitotic adult DG neurons. Consistent with postmitotic Tbr1+ identity of this cluster. [Literature] [7]
+- Establishes stage-5 definition (DCX+/NeuN+/Calbindin−). Absence of Calbindin from cluster defining_markers is consistent with pre-terminal immature identity. [Literature] [3]
+- Tbr1 onset marks postmitotic transition from neuroblast to immature granule neuron. Tbr1 present as TF marker; bridges atlas TF evidence to classical postmitotic immature granule neuron stage. [Literature] [6]
+- Confirms Tis21 re-expression in postmitotic adult DG neurons. Consistent with postmitotic Tbr1+ identity of this cluster. [Literature] [5]
 - MapMyCells transfer of Hochgerner 2018 Granule-immature cells (n=1333; GSE95315) to WMBv1. The majority map to 037 DG Glut (F1=0.566 subclass) and best cluster 0507 DG Glut_2 (F1=0.510), consistent with an immature granule neuron identity. A minority (27 cells, 2%) map to cluster 0514 DG-PIR Ex IMN_2 (F1=0.211), suggesting overlap with a transitional neuroblast-like population. Weak PARTIAL support for 0514; the dominant atlas representation is the DG Glut lineage (0506/0507). [Annotation transfer]
 
 **Concerns:**
@@ -57,14 +64,16 @@ All edges: `TYPE_A_SPLITS`
 
 ---
 
-## 0515 DG-PIR Ex IMN_2 · 🔴 LOW
+## 0515 DG-PIR Ex IMN_2 · 
+
+*`CS20230722_CLUS_0515`*
 
 **Supporting evidence:**
 
 - EXACT CL:9900002 in atlas; curator annotation 'late neuroblast'. Core TF profile identical to cluster 0514 (Tbr1+/Prox1+/Emx2+/Igfbpl1+). Scoped marker Rarb (distinctive within subclass). Additional MERFISH markers: Bcl11b, Cd24a, Fam163a. Anatomy: DGdo,me HIP:1.0 (perfect hippocampal allocation). NT: NA at cluster level, Glut by parent-class inheritance. Discovery composite score 0.82. [Atlas metadata]
-- Establishes stage-5 definition (DCX+/NeuN+/Calbindin−). Absence of Calbindin from cluster defining_markers is consistent with pre-terminal immature identity. [Literature] [5]
-- Tbr1 onset marks postmitotic transition from neuroblast to immature granule neuron. Tbr1 present as TF marker; bridges atlas TF evidence to classical postmitotic immature granule neuron stage. [Literature] [8]
-- Confirms Tis21 re-expression in postmitotic adult DG neurons. Consistent with postmitotic Tbr1+ identity of this cluster. [Literature] [7]
+- Establishes stage-5 definition (DCX+/NeuN+/Calbindin−). Absence of Calbindin from cluster defining_markers is consistent with pre-terminal immature identity. [Literature] [3]
+- Tbr1 onset marks postmitotic transition from neuroblast to immature granule neuron. Tbr1 present as TF marker; bridges atlas TF evidence to classical postmitotic immature granule neuron stage. [Literature] [6]
+- Confirms Tis21 re-expression in postmitotic adult DG neurons. Consistent with postmitotic Tbr1+ identity of this cluster. [Literature] [5]
 
 **Concerns:**
 
@@ -110,14 +119,14 @@ All edges: `TYPE_A_SPLITS`
 | Edge | Evidence types | Supports |
 |---|---|---|
 | edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0514 | Atlas metadata | SUPPORT |
+| edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0514 | Literature [3] | SUPPORT |
+| edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0514 | Literature [6] | SUPPORT |
 | edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0514 | Literature [5] | SUPPORT |
-| edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0514 | Literature [8] | SUPPORT |
-| edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0514 | Literature [7] | SUPPORT |
 | edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0514 | Annotation transfer | PARTIAL |
 | edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0515 | Atlas metadata | SUPPORT |
+| edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0515 | Literature [3] | SUPPORT |
+| edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0515 | Literature [6] | SUPPORT |
 | edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0515 | Literature [5] | SUPPORT |
-| edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0515 | Literature [8] | SUPPORT |
-| edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0515 | Literature [7] | SUPPORT |
 | edge_dg_immature_granule_neuron_to_CS20230722_CLUS_0515 | Annotation transfer | NO_EVIDENCE |
 
 ---
@@ -126,11 +135,9 @@ All edges: `TYPE_A_SPLITS`
 
 | # | Citation | PMID | Used for |
 |---|---|---|---|
-| [1] | PMID:28168008 | [28168008](https://pubmed.ncbi.nlm.nih.gov/28168008/) | soma location |
-| [2] | PMID:26880934 | [26880934](https://pubmed.ncbi.nlm.nih.gov/26880934/) | soma location |
-| [3] | PMID:26056581 | [26056581](https://pubmed.ncbi.nlm.nih.gov/26056581/) | neurotransmitter type |
-| [4] | PMID:25954142 | [25954142](https://pubmed.ncbi.nlm.nih.gov/25954142/) | neurotransmitter type |
-| [5] | PMID:40519263 | [40519263](https://pubmed.ncbi.nlm.nih.gov/40519263/) | DCX marker |
-| [6] | PMID:37082558 | [37082558](https://pubmed.ncbi.nlm.nih.gov/37082558/) | DCX marker |
-| [7] | PMID:19482889 | [19482889](https://pubmed.ncbi.nlm.nih.gov/19482889/) | Tis21 marker |
-| [8] | PMID:18385329 | [18385329](https://pubmed.ncbi.nlm.nih.gov/18385329/) | Tbr1 onset marks postmitotic transition from neuroblast to immature granule neur |
+| [1] | Stoll 2014 · PMID:26056581 | [26056581](https://pubmed.ncbi.nlm.nih.gov/26056581/) | neurotransmitter type |
+| [2] | Vangeneugden 2015 · PMID:25954142 | [25954142](https://pubmed.ncbi.nlm.nih.gov/25954142/) | neurotransmitter type |
+| [3] | Micheli 2025 · PMID:40519263 | [40519263](https://pubmed.ncbi.nlm.nih.gov/40519263/) | DCX marker |
+| [4] | Stepień 2021 · PMID:37082558 | [37082558](https://pubmed.ncbi.nlm.nih.gov/37082558/) | DCX marker |
+| [5] | Attardo 2009 · PMID:19482889 | [19482889](https://pubmed.ncbi.nlm.nih.gov/19482889/) | Tis21 marker |
+| [6] | Hodge 2008 · PMID:18385329 | [18385329](https://pubmed.ncbi.nlm.nih.gov/18385329/) | Tbr1 onset marks postmitotic transition from neuroblast to immature granule neur |

--- a/reports/hippocampus/chrna2_olm_subfamily_chamberland_summary.md
+++ b/reports/hippocampus/chrna2_olm_subfamily_chamberland_summary.md
@@ -1,0 +1,53 @@
+# Chrna2-IN (Chrna2-OLM, Chamberland 2024) — WMBv1 Mapping Report
+*2026-05-12 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/hippocampus/hippocampus_chamberland_subfamilies.yaml`*
+
+---
+
+## Classical type
+
+| Property | Value | References |
+|---|---|---|
+| CL term | — | |
+| Soma location | CA1 stratum oriens [UBERON:0005371] | [1] |
+| NT | GABAergic | [1] |
+| Markers | Sst+, Chrna2+ | [1] |
+
+---
+
+## Mapping candidates
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
+|---|---|---|---|---|---|
+| — | 0771 Sst Gaba_3 [CS20230722_CLUS_0771] | 0216 Sst Gaba_3 | 394 |  |  |
+
+All edges: `evidencell:PartialOverlapMatch`
+
+---
+
+## 0771 Sst Gaba_3 · 
+
+*`CS20230722_CLUS_0771` · 394 cells (10x) · supertype: 0216 Sst Gaba_3*
+
+**Supporting evidence:**
+
+- Chamberland Chrna2-IN cells (Harris 2018 cells satisfying the per-cluster Sst+/Chrna2+ rule, n=153) concentrate in CLUS_0771 Sst Gaba_3 (F1=0.65, recall 0.81, precision 0.54). At supertype the population scatters into SUPT_0216 Sst Gaba_3 with high recall (0.95) but low precision (0.20), consistent with multiple Sst types being grouped at this supertype. Cluster-level resolution is the right summary — F1 rises with finer aggregation (rises_with_resolution monotonicity). [Annotation transfer]
+
+**Concerns:**
+
+- **marker_Chrna2** (APPROXIMATE): A=Chrna2 — defining marker / B=scattered Chrna2 in Sst Gaba_3 cluster. Chrna2 expression is sparse but enriched in CLUS_0771 relative to siblings.
+
+---
+
+## Evidence base
+
+| Edge | Evidence types | Supports |
+|---|---|---|
+| edge_chrna2_olm_to_CS20230722_CLUS_0771 | Annotation transfer | SUPPORT |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | Chamberland et al. 2024 · PMID:38640347 | [38640347](https://pubmed.ncbi.nlm.nih.gov/38640347/) | soma location |

--- a/reports/hippocampus/ndnf_nkx2_1_olm_subfamily_chamberland_summary.md
+++ b/reports/hippocampus/ndnf_nkx2_1_olm_subfamily_chamberland_summary.md
@@ -1,0 +1,54 @@
+# Ndnf::Nkx2-1-IN (Ndnf-OLM, Chamberland 2024) — WMBv1 Mapping Report
+*2026-05-12 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/hippocampus/hippocampus_chamberland_subfamilies.yaml`*
+
+---
+
+## Classical type
+
+| Property | Value | References |
+|---|---|---|
+| CL term | — | |
+| Soma location | CA1 stratum oriens [UBERON:0005371] | [1] |
+| NT | GABAergic | [1] |
+| Markers | Sst+, Ndnf+, Nkx2-1+ | [1] |
+
+---
+
+## Mapping candidates
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
+|---|---|---|---|---|---|
+| — | 0216 Sst Gaba_3 [CS20230722_SUPT_0216] |  | 2,712 |  |  |
+
+All edges: `evidencell:UncertainRelationship`
+
+---
+
+## 0216 Sst Gaba_3 · 
+
+*`CS20230722_SUPT_0216` · 2,712 cells (10x)*
+
+**Supporting evidence:**
+
+- Chamberland Ndnf::Nkx2-1-IN cells (n=19 in this Harris re-labelling) do NOT concentrate at any single WMBv1 cluster or supertype — the population is fragmented across Lamp5, Sncg, and Sst types with F1 below 0.1 everywhere. The per-cluster Ndnf threshold qualified only one Harris Class, so the source pool is small and noisy. Cannot make a confident WMBv1 assignment from this AT evidence alone. UNCERTAIN; await targeted Ndnf::Nkx2-1 patch-seq. [Annotation transfer]
+
+**Concerns:**
+
+- **marker_Sst** (APPROXIMATE): A=Sst — defining (subset) / B=Sst expressed in Sst Gaba_3 supertype. Mapping to SUPT_0216 is the strongest Sst-positive hit, but per-cell evidence is too sparse to be informative.
+- Ndnf::Nkx2-1-IN signal fragments across multiple WMBv1 targets with F1 < 0.1 each. Mapping at any single level is uninformative. Better source-side evidence (e.g. Chamberland 2024's published per-cell Ndnf::Nkx2-1 scRNA-seq if available) needed to firm this up.
+
+---
+
+## Evidence base
+
+| Edge | Evidence types | Supports |
+|---|---|---|
+| edge_ndnf_nkx2_1_olm_to_CS20230722_SUPT_0216 | Annotation transfer | PARTIAL |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | Chamberland et al. 2024 · PMID:38640347 | [38640347](https://pubmed.ncbi.nlm.nih.gov/38640347/) | soma location |

--- a/reports/hippocampus/sst_nos1_subfamily_chamberland_summary.md
+++ b/reports/hippocampus/sst_nos1_subfamily_chamberland_summary.md
@@ -1,0 +1,49 @@
+# Sst::Nos1-IN (long-range projecting, Chamberland 2024) — WMBv1 Mapping Report
+*2026-05-12 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/hippocampus/hippocampus_chamberland_subfamilies.yaml`*
+
+---
+
+## Classical type
+
+| Property | Value | References |
+|---|---|---|
+| CL term | — | |
+| Soma location | CA1 stratum oriens [UBERON:0005371] | [1] |
+| NT | GABAergic | [1] |
+| Markers | Sst+, Nos1+ | [1] |
+
+---
+
+## Mapping candidates
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
+|---|---|---|---|---|---|
+| — | 0859 Sst Chodl Gaba_4 [CS20230722_CLUS_0859] | 0241 Sst Chodl Gaba_4 | 1,123 |  |  |
+
+All edges: `skos:exactMatch`
+
+---
+
+## 0859 Sst Chodl Gaba_4 · 
+
+*`CS20230722_CLUS_0859` · 1,123 cells (10x) · supertype: 0241 Sst Chodl Gaba_4*
+
+**Supporting evidence:**
+
+- Chamberland Sst::Nos1-IN cells map cleanly to the Sst Chodl Gaba subclass (F1=0.99 at subclass and supertype, F1=0.97 at cluster level → CLUS_0859). The mapping crosses subclass boundaries from the broader Sst Gaba subclass to the Sst Chodl Gaba subclass — biologically consistent because Sst Chodl types are long-range-projecting Sst interneurons (matching the hippocampo-septal projection identity of Sst::Nos1-IN cells). High confidence; near-deterministic mapping. [Annotation transfer]
+
+---
+
+## Evidence base
+
+| Edge | Evidence types | Supports |
+|---|---|---|
+| edge_sst_nos1_to_CS20230722_CLUS_0859 | Annotation transfer | SUPPORT |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | Chamberland et al. 2024 · PMID:38640347 | [38640347](https://pubmed.ncbi.nlm.nih.gov/38640347/) | soma location |


### PR DESCRIPTION
## Summary

Regenerates 10 reports illustrating Phase 2/3 schema features, deliberately selected from regions not touched by the parallel curation branch (`after_merge_20260508`) so this PR avoids any conflict with that work.

## Schema features illustrated

| Feature | Example node(s) |
|---|---|
| `skos:exactMatch` (HIGH-confidence anchor) | classical_lugaro · classical_globular · sst_nos1_subfamily_chamberland · classical_gpi_shell |
| `skos:broadMatch` + `1:n` cardinality | dg_immature_granule_neuron |
| `evidencell:CrossCuttingMatch` (canonical worked example) | classical_basket (cerebellar MLI1 spans classical basket + stellate) |
| `evidencell:PartialOverlapMatch` (deprecated under 2026-05-26 rubric) | pli2_osorno · classical_stellate · chrna2_olm_subfamily_chamberland |
| `evidencell:UncertainRelationship` | ndnf_nkx2_1_olm_subfamily_chamberland |

## Regions covered

cerebellum (CB_PLI + CB_MLI), hippocampus (chamberland subfamilies), BG, dentate_gyrus.

## What this does NOT do

- Does **not** touch the contested `hippocampus_GABAergic_interneurons.yaml` or `hippocampus_glutamatergic.yaml` files.
- Does **not** run LLM gen-report synthesis (this is the deterministic structural regen only — verdict blocks and prose rationale are not added).
- Does **not** apply the 2026-05-26 predicate rubric refresh (PR #72 is on a sibling branch, not yet on phase2_3) — `evidencell:PartialOverlapMatch` edges still display under their current name.

## Test plan

- [x] All 10 reports written by `just gen-report-node`
- [x] No paper-style reports clobbered (deterministic generator refuses by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
