### PR TITLE
CI: pin astral-sh/setup-uv to v8.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
The previous bump targeted the rolling major-version tag `v8`, but astral-sh/setup-uv never created one — only `v8.0.0` and `v8.1.0` exist as full-version tags, and the rolling tags stop at `v7`. CI fails to resolve `v8` as a result.

Pin to the latest v8 release (`v8.1.0`) instead. Subsequent bumps will need explicit version updates rather than tracking a major-tag.