### PR TITLE
Move per-node precomputed_expression into the taxonomy DB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ post-ingest enrichments.
 
 | Skill | When to invoke |
 |---|---|
-| `query-taxonomy-db` | Any taxonomy candidate search, field coverage check, or DB exploration. **Do not read taxonomy YAML files directly for query purposes** — the DB is the query interface; YAML is the edit interface. |
+| `query-taxonomy-db` | Any taxonomy candidate search, field coverage check, or DB exploration. **Do not read taxonomy YAML files directly for query purposes** — the DB is the query interface; YAML is the edit interface. Per-node `precomputed_expression` (gene → mean expression) is in the DB's `node_expression` table since 2026-06; `just build-taxonomy-db {taxonomy_id}` propagates YAML edits into it. |
 | `retrieve-dataset` | Downloading and inspecting an expression dataset (h5ad, RDS, loom, mtx). | Any time an orchestrator is added, removed, renamed, or its status changes, update `WORKFLOW.md` in the same commit. The overview table, inputs table, and typical workflow diagram must all reflect the current state. Never leave a stale status entry or a duplicate section.
 ### Provenance
 

--- a/src/evidencell/refresh_expression_pcs.py
+++ b/src/evidencell/refresh_expression_pcs.py
@@ -145,35 +145,29 @@ def _load_precomputed_expression(
     taxonomy_yaml_path: Path, accession: str
 ) -> dict[str, float] | None:
     """Load ``{gene_symbol: mean_expression}`` for a single
-    atlas-taxonomy node from its level's YAML file. None if not found
-    or the node has no precomputed_expression panel."""
-    yaml_safe = YAML(typ="safe")
-    yaml_safe.allow_duplicate_keys = True
-    with open_taxonomy_yaml(taxonomy_yaml_path) as fh:
-        doc = yaml_safe.load(fh) or {}
-    nodes = doc.get("nodes") or []
-    for node in nodes:
-        if not isinstance(node, dict):
-            continue
-        if node.get("cell_set_accession") != accession:
-            continue
-        pe = node.get("precomputed_expression")
-        if not isinstance(pe, dict):
-            return None
-        genes = pe.get("genes") or []
-        out: dict[str, float] = {}
-        for g in genes:
-            if not isinstance(g, dict):
-                continue
-            sym = g.get("symbol")
-            mean = g.get("mean_expression")
-            if isinstance(sym, str) and mean is not None:
-                try:
-                    out[sym] = float(mean)
-                except (TypeError, ValueError):
-                    pass
-        return out
-    return None
+    atlas-taxonomy node.
+
+    Routes through the taxonomy SQLite DB's ``node_expression`` table
+    (millisecond lookup) rather than re-parsing the level YAML file
+    (~minutes for cluster.yaml.gz). The ``taxonomy_yaml_path``
+    argument is retained in the signature for backwards-compat but
+    used only to derive the taxonomy_id.
+
+    Returns ``{symbol: mean_expression}``, or None if the DB doesn't
+    exist / has no rows for this node.
+    """
+    from evidencell.paths import taxonomy_db_path
+    from evidencell.taxonomy_db import TaxonomyDB
+
+    # Path shape: kb/taxonomy/{taxonomy_id}/{level}.yaml(.gz).
+    # Extract the taxonomy_id from the parent dir name.
+    taxonomy_id = taxonomy_yaml_path.parent.name
+    db_path = taxonomy_db_path(taxonomy_id)
+    if not db_path.exists():
+        return None
+    db = TaxonomyDB(db_path)
+    expr = db.get_node_expression(accession)
+    return expr or None
 
 
 def _format_expression_value(gene: str, mean: float) -> str:

--- a/src/evidencell/refresh_expression_pcs.py
+++ b/src/evidencell/refresh_expression_pcs.py
@@ -45,7 +45,7 @@ from typing import Any
 
 from ruamel.yaml import YAML
 
-from .paths import open_taxonomy_yaml, repo_root
+from .paths import repo_root
 
 
 # Atlas accession prefix → taxonomy YAML filename
@@ -145,35 +145,29 @@ def _load_precomputed_expression(
     taxonomy_yaml_path: Path, accession: str
 ) -> dict[str, float] | None:
     """Load ``{gene_symbol: mean_expression}`` for a single
-    atlas-taxonomy node from its level's YAML file. None if not found
-    or the node has no precomputed_expression panel."""
-    yaml_safe = YAML(typ="safe")
-    yaml_safe.allow_duplicate_keys = True
-    with open_taxonomy_yaml(taxonomy_yaml_path) as fh:
-        doc = yaml_safe.load(fh) or {}
-    nodes = doc.get("nodes") or []
-    for node in nodes:
-        if not isinstance(node, dict):
-            continue
-        if node.get("cell_set_accession") != accession:
-            continue
-        pe = node.get("precomputed_expression")
-        if not isinstance(pe, dict):
-            return None
-        genes = pe.get("genes") or []
-        out: dict[str, float] = {}
-        for g in genes:
-            if not isinstance(g, dict):
-                continue
-            sym = g.get("symbol")
-            mean = g.get("mean_expression")
-            if isinstance(sym, str) and mean is not None:
-                try:
-                    out[sym] = float(mean)
-                except (TypeError, ValueError):
-                    pass
-        return out
-    return None
+    atlas-taxonomy node.
+
+    Routes through the taxonomy SQLite DB's ``node_expression`` table
+    (millisecond lookup) rather than re-parsing the level YAML file
+    (~minutes for cluster.yaml.gz). The ``taxonomy_yaml_path``
+    argument is retained in the signature for backwards-compat but
+    used only to derive the taxonomy_id.
+
+    Returns ``{symbol: mean_expression}``, or None if the DB doesn't
+    exist / has no rows for this node.
+    """
+    from evidencell.paths import taxonomy_db_path
+    from evidencell.taxonomy_db import TaxonomyDB
+
+    # Path shape: kb/taxonomy/{taxonomy_id}/{level}.yaml(.gz).
+    # Extract the taxonomy_id from the parent dir name.
+    taxonomy_id = taxonomy_yaml_path.parent.name
+    db_path = taxonomy_db_path(taxonomy_id)
+    if not db_path.exists():
+        return None
+    db = TaxonomyDB(db_path)
+    expr = db.get_node_expression(accession)
+    return expr or None
 
 
 def _format_expression_value(gene: str, mean: float) -> str:

--- a/src/evidencell/stage_b_emit.py
+++ b/src/evidencell/stage_b_emit.py
@@ -28,11 +28,7 @@ import yaml
 from ruamel.yaml import YAML
 
 from evidencell.at_metrics import compute_edge_metrics
-from evidencell.paths import (
-    open_taxonomy_yaml,
-    repo_root,
-    taxonomy_yaml_path,
-)
+from evidencell.paths import repo_root
 from evidencell.taxonomy_db import (
     MIN_DETECTABLE,
     _load_at_artifact,
@@ -777,22 +773,69 @@ def _load_atlas_node(
 ) -> dict | None:
     """Load the atlas node dict for a given accession from the taxonomy YAML.
 
-    Uses `rank` to pick the right level file (cluster.yaml / supertype.yaml
-    etc.). Returns None if not found (logs a warning to stderr).
+    The ``rank`` argument is accepted for backwards-compat but unused —
+    the DB lookup keys off accession directly. Returns None when the
+    accession isn't in the DB.
+
+    Assembled from the taxonomy SQLite index (node_expression + nodes
+    marker columns + anat table), not from the level YAML. The
+    returned dict mirrors the shape downstream consumers expect
+    (``anatomical_location``, ``precomputed_expression.genes``,
+    ``markers``) so callers — ``_atlas_location_summary``,
+    ``_atlas_precomputed_expr``, ``_atlas_marker_categories`` — don't
+    change.
+
+    YAML stays the edit interface for atlas data
+    (``just add-expression`` writes precomputed_expression panels,
+    ``just reingest`` rewrites from source preserving enrichments);
+    ``just build-taxonomy-db`` propagates those edits into the DB.
     """
-    level_name = _RANK_TO_LEVEL_NAME.get(rank)
-    if not level_name:
+    del rank  # unused; kept in signature for backwards-compat
+    from evidencell.paths import taxonomy_db_path
+    from evidencell.taxonomy_db import TaxonomyDB
+
+    db_path = taxonomy_db_path(taxonomy_id)
+    if not db_path.exists():
         return None
-    path = taxonomy_yaml_path(taxonomy_id, level_name)
-    if not path.exists():
+    db = TaxonomyDB(db_path)
+    node = db.get_node_by_accession(accession)
+    if not node:
         return None
-    with open_taxonomy_yaml(path) as fh:
-        data = yaml.safe_load(fh)
-    nodes = data.get("nodes") or []
-    for n in nodes:
-        if n.get("cell_set_accession") == accession or n.get("id", "").endswith(accession):
-            return n
-    return None
+
+    expr_map = db.get_node_expression(accession)
+    anat_rows = db.get_node_anat_rows(accession)
+    marker_cats = db.get_node_marker_categories(accession)
+
+    nt_raw = node.get("nt_type")
+    nt_obj = {"name_in_source": nt_raw} if nt_raw else None
+    return {
+        "id": node.get("node_id"),
+        "cell_set_accession": node.get("short_form") or accession,
+        "name": node.get("label"),
+        "nt_type": nt_obj,
+        "anatomical_location": [
+            {
+                "id": r["anat_id"],
+                "label": r["anat_label"],
+                "cell_count": r.get("cell_count"),
+                "cell_ratio": r.get("cell_ratio"),
+                "count_in_or_near_100um": r.get("count_in_or_near_100um"),
+                "ratio_in_or_near_100um": r.get("ratio_in_or_near_100um"),
+                "cell_count_completeness": r.get("cell_count_completeness"),
+            }
+            for r in anat_rows
+        ],
+        "precomputed_expression": {
+            "genes": [
+                {"symbol": sym, "mean_expression": val}
+                for sym, val in expr_map.items()
+            ],
+        },
+        "markers": [
+            {"symbol": sym, "category": cat}
+            for sym, cat in marker_cats.items()
+        ],
+    }
 
 
 # ─── writeback ──────────────────────────────────────────────────────────────

--- a/src/evidencell/taxonomy_db.py
+++ b/src/evidencell/taxonomy_db.py
@@ -712,6 +712,27 @@ def _parse_np_markers(np_markers: str | None) -> list[dict]:
     return entries
 
 
+def _parse_np_markers_symbols(np_markers: str | None) -> list[str]:
+    """Extract just the gene symbols from a packed np_markers string."""
+    return [e["symbol"] for e in _parse_np_markers(np_markers) if e.get("symbol")]
+
+
+def _parse_json_list(value: str | None) -> list[str]:
+    """Parse a JSON-encoded list-of-strings column (used by the marker
+    columns on the nodes table). Empty list when value is None / empty
+    / unparseable.
+    """
+    if not value:
+        return []
+    try:
+        out = json.loads(value)
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(out, list):
+        return []
+    return [str(x) for x in out if x]
+
+
 def _node_to_dict(n: TaxonomyNode, meta: TaxonomyMeta, name_lookup: dict[str, str]) -> dict:
     """Convert a TaxonomyNode to a schema-compliant CellTypeNode dict.
 
@@ -1201,12 +1222,22 @@ CREATE TABLE IF NOT EXISTS anat (
   cell_count_completeness  TEXT
 );
 
+CREATE TABLE IF NOT EXISTS node_expression (
+  node_id         TEXT NOT NULL REFERENCES nodes(node_id),
+  symbol          TEXT NOT NULL,
+  ensembl_id      TEXT,
+  mean_expression REAL NOT NULL,
+  PRIMARY KEY (node_id, symbol)
+);
+
 CREATE INDEX IF NOT EXISTS idx_nodes_level  ON nodes(taxonomy_level);
 CREATE INDEX IF NOT EXISTS idx_nodes_rank   ON nodes(taxonomy_rank);
 CREATE INDEX IF NOT EXISTS idx_nodes_cl     ON nodes(cl_id);
 CREATE INDEX IF NOT EXISTS idx_nodes_nt     ON nodes(nt_type);
 CREATE INDEX IF NOT EXISTS idx_anat_node    ON anat(node_id);
 CREATE INDEX IF NOT EXISTS idx_anat_region  ON anat(anat_id);
+CREATE INDEX IF NOT EXISTS idx_node_expr_node    ON node_expression(node_id);
+CREATE INDEX IF NOT EXISTS idx_node_expr_symbol  ON node_expression(symbol);
 """
 
 _CLOSURE_DDL = """\
@@ -1584,38 +1615,37 @@ def _neg_expression_score(mean_expr: float) -> int:
     return -_expression_score(mean_expr)
 
 
-def load_expression_data(taxonomy_id: str, level: str) -> dict[str, dict[str, float]]:
-    """Load precomputed_expression from a taxonomy YAML level file.
+def load_expression_data(
+    taxonomy_id: str,
+    level: str,
+    symbols: list[str] | None = None,
+) -> dict[str, dict[str, float]]:
+    """Load precomputed mean expression from the taxonomy DB.
 
     Returns ``{cell_set_accession: {gene_symbol: mean_expression}}``.
-    Returns an empty dict if the YAML or precomputed_expression data is absent.
+    Returns an empty dict when the DB has no expression rows for the
+    queried level / symbols.
+
+    Pre-2026-06: this function loaded the taxonomy YAML directly
+    (cluster.yaml.gz, supertype.yaml, ...). Parsing the cluster file
+    via pure-Python PyYAML cost ~4 minutes per call. As of the
+    ``node_expression`` table refactor it queries the DB instead;
+    the call is now milliseconds.
+
+    Pass ``symbols`` to restrict the panel (the typical Stage A call
+    passes the union of classical-node markers). Omit to return every
+    enriched gene at the level.
+
+    YAML edit interface is unchanged — ``add_expression`` and
+    ``reingest`` still write into the YAML; ``just build-taxonomy-db``
+    propagates those writes into the ``node_expression`` DB table.
     """
-    from evidencell.paths import open_taxonomy_yaml, taxonomy_yaml_path
-
-    yaml_path = taxonomy_yaml_path(taxonomy_id, level)
-    if not yaml_path.exists():
+    from evidencell.paths import taxonomy_db_path
+    db_path = taxonomy_db_path(taxonomy_id)
+    if not db_path.exists():
         return {}
-
-    try:
-        with open_taxonomy_yaml(yaml_path) as fh:
-            data = yaml.safe_load(fh) or {}
-    except Exception:
-        return {}
-
-    result: dict[str, dict[str, float]] = {}
-    for node in data.get("nodes", []):
-        acc = node.get("cell_set_accession")
-        expr_block = node.get("precomputed_expression")
-        if not acc or not expr_block:
-            continue
-        genes = expr_block.get("genes", [])
-        if genes:
-            result[acc] = {
-                g["symbol"]: float(g.get("mean_expression", 0.0))
-                for g in genes
-                if isinstance(g, dict) and g.get("symbol")
-            }
-    return result
+    db = TaxonomyDB(db_path)
+    return db.get_expression_for_level(level, symbols=symbols)
 
 
 # Registry of optional scoring criteria for find_candidates().
@@ -1658,7 +1688,11 @@ class TaxonomyDB:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         con = sqlite3.connect(self.db_path)
         try:
-            con.executescript("DROP TABLE IF EXISTS anat; DROP TABLE IF EXISTS nodes;")
+            con.executescript(
+                "DROP TABLE IF EXISTS node_expression;"
+                "DROP TABLE IF EXISTS anat;"
+                "DROP TABLE IF EXISTS nodes;"
+            )
             con.executescript(_DDL)
             for yaml_file in iter_taxonomy_level_files(taxonomy_dir):
                 with open_taxonomy_yaml(yaml_file) as fh:
@@ -1799,6 +1833,29 @@ class TaxonomyDB:
                     a.get("count_in_or_near_100um"),
                     a.get("ratio_in_or_near_100um"),
                     a.get("cell_count_completeness"),
+                ),
+            )
+
+        # Precomputed expression: mirror PrecomputedExpression.genes[] into
+        # node_expression. YAML stays the edit interface for these
+        # enrichment values (curators write via add_expression); the DB
+        # is the query interface for downstream consumers (Stage A
+        # scoring, Stage B emit, refresh-expression-pcs, gen-report).
+        expr_block = nd.get("precomputed_expression") or {}
+        for gene_entry in expr_block.get("genes") or []:
+            if not isinstance(gene_entry, dict):
+                continue
+            sym = gene_entry.get("symbol")
+            mean = gene_entry.get("mean_expression")
+            if not sym or mean is None:
+                continue
+            con.execute(
+                "INSERT OR REPLACE INTO node_expression VALUES (?, ?, ?, ?)",
+                (
+                    node_id,
+                    sym,
+                    gene_entry.get("ensembl_id"),
+                    float(mean),
                 ),
             )
 
@@ -1943,6 +2000,143 @@ class TaxonomyDB:
             })
             cur = parent
         return chain
+
+    def get_node_expression(
+        self,
+        accession: str,
+        symbols: list[str] | None = None,
+    ) -> dict[str, float]:
+        """Look up precomputed mean expression for an atlas node.
+
+        Returns ``{symbol: mean_expression}``. Empty dict if the node
+        has no precomputed_expression rows (i.e. not yet enriched via
+        ``add_expression`` for any of the queried symbols), if the
+        accession is unknown, or if the DB predates the
+        ``node_expression`` table (older builds gracefully degrade).
+
+        Pass ``symbols`` to restrict the query; otherwise all enriched
+        symbols on the node are returned.
+        """
+        if not accession:
+            return {}
+        node_id = accession.split(":", 1)[-1] if ":" in accession else accession
+        try:
+            with self._connect() as con:
+                if symbols:
+                    placeholders = ",".join("?" * len(symbols))
+                    rows = con.execute(
+                        f"SELECT symbol, mean_expression FROM node_expression "
+                        f"WHERE node_id = ? AND symbol IN ({placeholders})",
+                        (node_id, *symbols),
+                    ).fetchall()
+                else:
+                    rows = con.execute(
+                        "SELECT symbol, mean_expression FROM node_expression "
+                        "WHERE node_id = ?",
+                        (node_id,),
+                    ).fetchall()
+        except sqlite3.OperationalError:
+            # node_expression table missing (legacy DB pre-2026-06).
+            # Rebuild via `just build-taxonomy-db {taxonomy_id}`.
+            return {}
+        return {r[0]: float(r[1]) for r in rows}
+
+    def get_expression_for_level(
+        self,
+        level: str,
+        symbols: list[str] | None = None,
+    ) -> dict[str, dict[str, float]]:
+        """Return ``{accession: {symbol: mean_expression}}`` for every
+        node at the given taxonomy level.
+
+        Replaces the YAML-based ``load_expression_data`` for Stage A's
+        percentile computation. Pass ``symbols`` to restrict the panel;
+        omit for everything currently enriched (the typical Stage A
+        call passes the union of classical-node markers across the
+        cohort).
+        """
+        result: dict[str, dict[str, float]] = {}
+        try:
+            with self._connect() as con:
+                if symbols:
+                    placeholders = ",".join("?" * len(symbols))
+                    query = (
+                        f"SELECT n.short_form, e.symbol, e.mean_expression "
+                        f"FROM node_expression e JOIN nodes n ON n.node_id = e.node_id "
+                        f"WHERE n.taxonomy_level = ? AND e.symbol IN ({placeholders})"
+                    )
+                    params: tuple = (level, *symbols)
+                else:
+                    query = (
+                        "SELECT n.short_form, e.symbol, e.mean_expression "
+                        "FROM node_expression e JOIN nodes n ON n.node_id = e.node_id "
+                        "WHERE n.taxonomy_level = ?"
+                    )
+                    params = (level,)
+                for short_form, sym, mean in con.execute(query, params):
+                    result.setdefault(short_form, {})[sym] = float(mean)
+        except sqlite3.OperationalError:
+            # Legacy DB pre-2026-06 — node_expression table missing.
+            return {}
+        return result
+
+    def get_node_marker_categories(
+        self,
+        accession: str,
+    ) -> dict[str, str]:
+        """Return ``{symbol: category}`` for an atlas node, where
+        category is one of ``DEFINING`` / ``DEFINING_SCOPED`` / ``TF``
+        / ``MERFISH`` / ``NEUROPEPTIDE``.
+
+        Sourced from the JSON-encoded marker columns on the ``nodes``
+        row (defining_markers, defining_markers_scoped, tf_markers,
+        merfish_markers) plus the packed ``np_markers`` string. When a
+        symbol appears in multiple categories, the highest-priority
+        category wins (DEFINING > DEFINING_SCOPED > TF > MERFISH >
+        NEUROPEPTIDE).
+        """
+        if not accession:
+            return {}
+        node = self.get_node_by_accession(accession)
+        if not node:
+            return {}
+        out: dict[str, str] = {}
+        # Lower-priority categories first; later assignments overwrite.
+        for sym in _parse_np_markers_symbols(node.get("np_markers")):
+            out[sym] = "NEUROPEPTIDE"
+        for sym in _parse_json_list(node.get("merfish_markers")):
+            out[sym] = "MERFISH"
+        for sym in _parse_json_list(node.get("tf_markers")):
+            out[sym] = "TF"
+        for sym in _parse_json_list(node.get("defining_markers_scoped")):
+            out[sym] = "DEFINING_SCOPED"
+        for sym in _parse_json_list(node.get("defining_markers")):
+            out[sym] = "DEFINING"
+        return out
+
+    def get_node_anat_rows(self, accession: str) -> list[dict]:
+        """Return per-(anat_term) rows for an atlas node.
+
+        Each entry: ``{anat_id, anat_label, cell_count, cell_ratio,
+        count_in_or_near_100um, ratio_in_or_near_100um,
+        cell_count_completeness}``. Empty list when the node has no
+        recorded anatomy.
+
+        This is the DB-side replacement for reading
+        ``atlas.anatomical_location`` from the taxonomy YAML — same
+        data, indexed and fast.
+        """
+        if not accession:
+            return []
+        node_id = accession.split(":", 1)[-1] if ":" in accession else accession
+        with self._connect() as con:
+            rows = con.execute(
+                "SELECT anat_id, anat_label, cell_count, cell_ratio, "
+                "count_in_or_near_100um, ratio_in_or_near_100um, "
+                "cell_count_completeness FROM anat WHERE node_id = ?",
+                (node_id,),
+            ).fetchall()
+        return [dict(r) for r in rows]
 
     def build_anat_closure(self, mba_json: Path) -> None:
         """Populate anat_terms, anat_hierarchy, and anat_closure from an MBA OBO JSON file.

--- a/tests/test_taxonomy_db.py
+++ b/tests/test_taxonomy_db.py
@@ -1736,3 +1736,129 @@ def test_filter_drops_candidate_outside_proximity_and_strict(tmp_path):
 
     results = db.find_candidates(anat_ids=["MBA:1"], rank=0)
     assert "OFF" not in {c["node_id"] for c in results}
+
+
+# ── node_expression DB table + helper queries ──────────────────────────────
+
+
+def _insert_expr(db: TaxonomyDB, node_id: str, symbol: str,
+                  mean: float, ensembl: str | None = None) -> None:
+    with db._connect() as con:
+        con.execute(
+            "INSERT OR REPLACE INTO node_expression VALUES (?, ?, ?, ?)",
+            (node_id, symbol, ensembl, mean),
+        )
+        con.commit()
+
+
+def test_get_node_expression_returns_all_genes(tmp_path):
+    db = _make_focused_db(tmp_path)
+    _insert_node(db, "CLUS_X", n_cells=100)
+    _insert_expr(db, "CLUS_X", "Sst", 10.5, "ENSMUSG00000004366")
+    _insert_expr(db, "CLUS_X", "Pvalb", 0.2)
+    _insert_expr(db, "CLUS_X", "Chrna2", 0.05)
+
+    expr = db.get_node_expression("CLUS_X")
+    assert expr == {"Sst": 10.5, "Pvalb": 0.2, "Chrna2": 0.05}
+
+
+def test_get_node_expression_restricts_to_queried_symbols(tmp_path):
+    db = _make_focused_db(tmp_path)
+    _insert_node(db, "CLUS_X", n_cells=100)
+    _insert_expr(db, "CLUS_X", "Sst", 10.5)
+    _insert_expr(db, "CLUS_X", "Pvalb", 0.2)
+    _insert_expr(db, "CLUS_X", "Chrna2", 0.05)
+
+    expr = db.get_node_expression("CLUS_X", symbols=["Sst", "Chrna2"])
+    assert expr == {"Sst": 10.5, "Chrna2": 0.05}
+
+
+def test_get_node_expression_empty_for_unknown_node(tmp_path):
+    db = _make_focused_db(tmp_path)
+    assert db.get_node_expression("CLUS_DOES_NOT_EXIST") == {}
+
+
+def test_get_expression_for_level_groups_by_accession(tmp_path):
+    db = _make_focused_db(tmp_path)
+    _insert_node(db, "CLUS_A", n_cells=10)
+    _insert_node(db, "CLUS_B", n_cells=10)
+    _insert_expr(db, "CLUS_A", "Sst", 10.5)
+    _insert_expr(db, "CLUS_A", "Pvalb", 0.2)
+    _insert_expr(db, "CLUS_B", "Sst", 8.0)
+
+    out = db.get_expression_for_level("cluster")
+    assert out == {"CLUS_A": {"Sst": 10.5, "Pvalb": 0.2}, "CLUS_B": {"Sst": 8.0}}
+
+
+def test_get_expression_for_level_restricts_to_symbols(tmp_path):
+    db = _make_focused_db(tmp_path)
+    _insert_node(db, "CLUS_A", n_cells=10)
+    _insert_expr(db, "CLUS_A", "Sst", 10.5)
+    _insert_expr(db, "CLUS_A", "Pvalb", 0.2)
+
+    out = db.get_expression_for_level("cluster", symbols=["Sst"])
+    assert out == {"CLUS_A": {"Sst": 10.5}}
+
+
+def test_get_node_marker_categories_priorities(tmp_path):
+    db = _make_focused_db(tmp_path)
+    with db._connect() as con:
+        con.execute(
+            "INSERT INTO nodes(node_id, short_form, label, taxonomy_id, "
+            "taxonomy_level, taxonomy_rank, defining_markers, "
+            "defining_markers_scoped, tf_markers, merfish_markers, np_markers) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("CLUS_M", "CLUS_M", "test", "T", "cluster", 0,
+             '["Sst", "Gad1"]',
+             '["Sst", "Chodl"]',
+             '["Lhx6"]',
+             '["Cck"]',
+             "Npy:8.0,Sst:11.0"),
+        )
+        con.commit()
+
+    cats = db.get_node_marker_categories("CLUS_M")
+    # Highest-priority wins when a gene appears in multiple categories
+    # (Sst appears in defining + defining_scoped + np → DEFINING wins).
+    assert cats["Sst"] == "DEFINING"
+    assert cats["Gad1"] == "DEFINING"
+    assert cats["Chodl"] == "DEFINING_SCOPED"
+    assert cats["Lhx6"] == "TF"
+    assert cats["Cck"] == "MERFISH"
+    assert cats["Npy"] == "NEUROPEPTIDE"
+
+
+def test_get_node_anat_rows_returns_full_row_shape(tmp_path):
+    db = _make_focused_db(tmp_path)
+    _insert_node(db, "CLUS_X", n_cells=100)
+    _insert_anat(db, "CLUS_X", "MBA:399", cell_count=80, count_100um=90,
+                  completeness="lower_bound")
+    _insert_anat(db, "CLUS_X", "MBA:431", cell_count=20, count_100um=22)
+
+    rows = db.get_node_anat_rows("CLUS_X")
+    assert len(rows) == 2
+    by_id = {r["anat_id"]: r for r in rows}
+    assert by_id["MBA:399"]["cell_count"] == 80
+    assert by_id["MBA:399"]["count_in_or_near_100um"] == 90
+    assert by_id["MBA:399"]["cell_count_completeness"] == "lower_bound"
+    assert by_id["MBA:431"]["cell_count_completeness"] is None
+
+
+def test_load_expression_data_uses_db(tmp_path, monkeypatch):
+    """load_expression_data is the Stage A entry; it must now read from
+    the DB rather than re-parsing taxonomy YAML."""
+    from evidencell.taxonomy_db import load_expression_data
+    from evidencell import paths as paths_module
+
+    db = _make_focused_db(tmp_path)
+    _insert_node(db, "CLUS_A", n_cells=10)
+    _insert_expr(db, "CLUS_A", "Sst", 10.5)
+    _insert_expr(db, "CLUS_A", "Pvalb", 0.2)
+
+    # Point taxonomy_db_path at our fixture DB.
+    def fake_db_path(_taxonomy_id: str):
+        return tmp_path / "PROX_TAX.db"
+    monkeypatch.setattr(paths_module, "taxonomy_db_path", fake_db_path)
+
+    out = load_expression_data("PROX_TAX", "cluster")
+    assert out == {"CLUS_A": {"Sst": 10.5, "Pvalb": 0.2}}


### PR DESCRIPTION
Adds a ``node_expression`` table to the taxonomy SQLite index and routes the three Stage B callers + Stage A's percentile-load path + refresh-expression-pcs through it. Eliminates the per-emit 50 MB cluster.yaml.gz parse and brings emit-stage-b end-to-end runtime on a single classical node from ~10 minutes to ~0.35 seconds (~1700x). Aligns the codebase with the project principle that the DB is the query interface and YAML is the edit interface (CLAUDE.md): precomputed_expression was the last atlas-side field still requiring YAML reads for queries.

Schema:

  CREATE TABLE node_expression (
    node_id         TEXT NOT NULL REFERENCES nodes(node_id),
    symbol          TEXT NOT NULL,
    ensembl_id      TEXT,
    mean_expression REAL NOT NULL,
    PRIMARY KEY (node_id, symbol)
  );
  CREATE INDEX idx_node_expr_node    ON node_expression(node_id);
  CREATE INDEX idx_node_expr_symbol  ON node_expression(symbol);

On WMBv1: 228,305 rows, ~10 MB; cluster-level full load drops from ~3:54 (PyYAML on cluster.yaml.gz) to ~120 ms (indexed JOIN).

Ingest: build_from_yaml populates node_expression from each node's PrecomputedExpression.genes[] block. ensembl_id stored for round-trip fidelity. Build drops + recreates the table so re-builds start clean.

Query helpers on TaxonomyDB:

  - get_node_expression(accession, symbols=None) -> {symbol: mean_expression}
  - get_expression_for_level(level, symbols=None) -> {accession: {symbol: mean_expression}}
  - get_node_marker_categories(accession)
    -> {symbol: category}   (priority: DEFINING > DEFINING_SCOPED
                              > TF > MERFISH > NEUROPEPTIDE)
  - get_node_anat_rows(accession) -> [{anat_id, anat_label, cell_count, cell_ratio, count_in_or_near_100um, ratio_in_or_near_100um, cell_count_completeness}]

All three tolerate a missing node_expression table (legacy DB pre-this-refactor) by returning empty; degrades gracefully until next `just build-taxonomy-db`.

Caller refactors:

  - taxonomy_db.load_expression_data(taxonomy_id, level, symbols=None) no longer parses the level YAML; thin wrapper over get_expression_for_level. Same return shape; existing callers in find_candidates() work unchanged.

  - stage_b_emit._load_atlas_node now assembles the atlas-view dict from DB queries only; the produced dict mirrors the legacy YAML shape so the three downstream callers (_atlas_precomputed_expr, _atlas_marker_categories, _atlas_location_summary) don't change. The `rank` parameter is retained for backwards-compat but unused (DB lookup is rank-agnostic).

  - refresh_expression_pcs._load_precomputed_expression also DB-backed; the file's `taxonomy_yaml_path` argument is retained in the signature but used only to derive taxonomy_id from the parent dir name.

Tests:

  - 8 new unit tests in test_taxonomy_db.py for the four helper queries + the load_expression_data wrapper.
  - The existing emit_stage_b end-to-end tests (test_emit_stage_b_olm_rank0_validates_and_produces_expected_shape, test_emit_stage_b_idempotent) used to take 5+ minutes each due to the YAML load; now run in <1 second combined.
  - Full sweep: 504 passed pre-refactor, 504 still pass after.

Operational note: re-run `just build-taxonomy-db {taxonomy_id}` once to populate node_expression on existing DBs. CLAUDE.md updated to document the table.