### PR TITLE
refresh_reports 20260608: sexually_dimorphic refresh + reports

### DIFF
--- a/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml
+++ b/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml
@@ -1088,6 +1088,346 @@ nodes:
     definition_basis: ATLAS_TRANSCRIPTOMIC
     taxonomy_id: CCN20230722
     cell_set_accession: CS20230722_SUPT_0249
+  - id: CS20230722_CLUS_1469
+    name: 1469 MPO-ADP Lhx8 Gaba_3
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1469
+  - id: CS20230722_CLUS_5246
+    name: 5246 Tanycyte NN_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_5246
+  - id: CS20230722_CLUS_1910
+    name: 1910 PVpo-VMPO-MPN Hmx2 Gaba_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1910
+  - id: CS20230722_CLUS_5211
+    name: 5211 Astro-NT NN_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_5211
+  - id: CS20230722_SUPT_1172
+    name: 1172 Tanycyte NN_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_1172
+  - id: CS20230722_SUPT_0419
+    name: 0419 PVR Six3 Sox3 Gaba_9
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0419
+  - id: CS20230722_SUPT_0485
+    name: 0485 PVpo-VMPO-MPN Hmx2 Gaba_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0485
+  - id: CS20230722_SUPT_0400
+    name: 0400 SI-MPO-LPO Lhx8 Gaba_5
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0400
+  - id: CS20230722_CLUS_1304
+    name: 1304 MEA-BST Lhx6 Nfib Gaba_5
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1304
+  - id: CS20230722_CLUS_1305
+    name: 1305 MEA-BST Lhx6 Nfib Gaba_5
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1305
+  - id: CS20230722_CLUS_1303
+    name: 1303 MEA-BST Lhx6 Nfib Gaba_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1303
+  - id: CS20230722_CLUS_1310
+    name: 1310 MEA-BST Lhx6 Nfib Gaba_5
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1310
+  - id: CS20230722_CLUS_1542
+    name: 1542 BST-MPN Six3 Nrgn Gaba_3
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1542
+  - id: CS20230722_SUPT_0360
+    name: 0360 MEA-BST Lhx6 Nfib Gaba_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0360
+  - id: CS20230722_SUPT_0420
+    name: 0420 BST-MPN Six3 Nrgn Gaba_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0420
+  - id: CS20230722_SUPT_0422
+    name: 0422 BST-MPN Six3 Nrgn Gaba_3
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0422
+  - id: CS20230722_SUPT_0421
+    name: 0421 BST-MPN Six3 Nrgn Gaba_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0421
+  - id: CS20230722_CLUS_1466
+    name: 1466 MPO-ADP Lhx8 Gaba_3
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1466
+  - id: CS20230722_CLUS_1536
+    name: 1536 PVR Six3 Sox3 Gaba_9
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1536
+  - id: CS20230722_CLUS_1885
+    name: 1885 PVpo-VMPO-MPN Hmx2 Gaba_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1885
+  - id: CS20230722_CLUS_1887
+    name: 1887 PVpo-VMPO-MPN Hmx2 Gaba_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1887
+  - id: CS20230722_CLUS_2118
+    name: 2118 ADP-MPO Trp73 Glut_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_2118
+  - id: CS20230722_SUPT_0403
+    name: 0403 MPO-ADP Lhx8 Gaba_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0403
+  - id: CS20230722_SUPT_0401
+    name: 0401 SI-MPO-LPO Lhx8 Gaba_6
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0401
+  - id: CS20230722_SUPT_0348
+    name: 0348 MEA-BST Lhx6 Sp9 Gaba_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0348
+  - id: CS20230722_SUPT_0398
+    name: 0398 SI-MPO-LPO Lhx8 Gaba_3
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0398
+  - id: CS20230722_CLUS_2290
+    name: 2290 VMH Fezf1 Glut_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_2290
+  - id: CS20230722_CLUS_2292
+    name: 2292 VMH Fezf1 Glut_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_2292
+  - id: CS20230722_CLUS_1959
+    name: 1959 DMH Hmx2 Gaba_6
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1959
+  - id: CS20230722_CLUS_2295
+    name: 2295 VMH Fezf1 Glut_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_2295
+  - id: CS20230722_CLUS_2297
+    name: 2297 VMH Fezf1 Glut_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_2297
+  - id: CS20230722_SUPT_0557
+    name: 0557 ARH-PVp Tbx3 Glut_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0557
+  - id: CS20230722_SUPT_0439
+    name: 0439 DMH Prdm13 Gaba_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0439
+  - id: CS20230722_SUPT_0569
+    name: 0569 VMH Nr5a1 Glut_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0569
+  - id: CS20230722_SUPT_0568
+    name: 0568 VMH Nr5a1 Glut_3
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0568
+  - id: CS20230722_CLUS_2366
+    name: 2366 PVH-SO-PVa Otp Glut_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_2366
+  - id: CS20230722_CLUS_1549
+    name: 1549 BST-MPN Six3 Nrgn Gaba_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1549
+  - id: CS20230722_CLUS_1561
+    name: 1561 BST-MPN Six3 Nrgn Gaba_6
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1561
+  - id: CS20230722_CLUS_1563
+    name: 1563 BST-MPN Six3 Nrgn Gaba_6
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1563
+  - id: CS20230722_SUPT_0587
+    name: 0587 PVH-SO-PVa Otp Glut_3
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0587
+  - id: CS20230722_SUPT_0586
+    name: 0586 PVH-SO-PVa Otp Glut_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0586
+  - id: CS20230722_SUPT_0414
+    name: 0414 PVR Six3 Sox3 Gaba_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0414
+  - id: CS20230722_CLUS_1409
+    name: 1409 CEA-BST Rai14 Pdyn Crh Gaba_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1409
+  - id: CS20230722_CLUS_1410
+    name: 1410 CEA-BST Rai14 Pdyn Crh Gaba_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1410
+  - id: CS20230722_CLUS_1475
+    name: 1475 MPO-ADP Lhx8 Gaba_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1475
+  - id: CS20230722_CLUS_1476
+    name: 1476 MPO-ADP Lhx8 Gaba_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1476
+  - id: CS20230722_CLUS_1499
+    name: 1499 BST Tac2 Gaba_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1499
+  - id: CS20230722_SUPT_0410
+    name: 0410 BST Tac2 Gaba_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0410
+  - id: CS20230722_SUPT_0343
+    name: 0343 MEA-BST Sox6 Gaba_7
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0343
+  - id: CS20230722_SUPT_0379
+    name: 0379 CEA-AAA-BST Six3 Sp9 Gaba_7
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0379
+  - id: CS20230722_SUPT_0383
+    name: 0383 ACB-BST-FS D1 Gaba_3
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0383
+  - id: CS20230722_CLUS_5303
+    name: 5303 VLMC NN_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_5303
+  - id: CS20230722_CLUS_1569
+    name: 1569 ARH-PVi Six6 Dopa-Gaba_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1569
+  - id: CS20230722_CLUS_1570
+    name: 1570 ARH-PVi Six6 Dopa-Gaba_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1570
+  - id: CS20230722_CLUS_1571
+    name: 1571 ARH-PVi Six6 Dopa-Gaba_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1571
+  - id: CS20230722_CLUS_1683
+    name: 1683 SBPV-PVa Six6 Satb2 Gaba_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_1683
+  - id: CS20230722_SUPT_1190
+    name: 1190 VLMC NN_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_1190
+  - id: CS20230722_SUPT_1173
+    name: 1173 Tanycyte NN_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_1173
+  - id: CS20230722_SUPT_1174
+    name: 1174 Tanycyte NN_3
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_1174
+  - id: CS20230722_SUPT_0427
+    name: 0427 ARH-PVi Six6 Dopa-Gaba_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0427
+  - id: CS20230722_SUPT_0495
+    name: 0495 ARH-PVp Tbx3 Gaba_3
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0495
+  - id: CS20230722_CLUS_2471
+    name: 2471 PMv-TMv Pitx2 Glut_3
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_2471
+  - id: CS20230722_CLUS_2314
+    name: 2314 VMH Nr5a1 Glut_4
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_2314
+  - id: CS20230722_CLUS_2575
+    name: 2575 MM Foxb1 Glut_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_2575
+  - id: CS20230722_CLUS_2395
+    name: 2395 PH-ant-LHA Otp Bsx Glut_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_CLUS_2395
+  - id: CS20230722_SUPT_0605
+    name: 0605 PMv-TMv Pitx2 Glut_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0605
+  - id: CS20230722_SUPT_0429
+    name: 0429 TMv-PMv Tbx3 Hist-Gaba_1
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0429
+  - id: CS20230722_SUPT_0430
+    name: 0430 TMv-PMv Tbx3 Hist-Gaba_2
+    definition_basis: ATLAS_TRANSCRIPTOMIC
+    taxonomy_id: CCN20230722
+    cell_set_accession: CS20230722_SUPT_0430
 edges:
 
   - id: edge_avpv_kiss1_neuron_to_cs20230722_supt_0486
@@ -1105,7 +1445,7 @@ edges:
           (dopaminergic designation, male_female_ratio=0.02) is the strongest sub-resolution
           candidate for the female-biased AVPV Kiss1/TH population. PARTIAL_OVERLAP because
           SUPT_0486 spans a broader preoptic zone than the AVPV/PeN.
-    property_comparisons:
+    property_comparisons: &id001
       - property: nt_type
         node_a_value: "GABAergic / dopaminergic (TH co-expression)"
         node_b_value: not asserted
@@ -1165,7 +1505,7 @@ edges:
 
     mapping_justification: semapv:UnreviewedManualMapping
     mapping_cardinality: "1:1"
-    discovery_score:
+    discovery_score: &id002
       score: 2
       rank_in_cohort: 5
       cohort_size: 50
@@ -1194,7 +1534,7 @@ edges:
   - id: edge_avpv_th_neuron_to_cs20230722_supt_0486
     lit_type: avpv_th_neuron
     taxonomy_type: CS20230722_SUPT_0486
-    relationship: skos:closeMatch
+    relationship: skos:broadMatch
     evidence:
       - evidence_type: ATLAS_METADATA
         supports: SUPPORT
@@ -1207,59 +1547,69 @@ edges:
           female sex ratio in child cluster) converge on SUPT_0486/CLUS_1915.
     property_comparisons:
       - property: nt_type
-        node_a_value: "dopaminergic (A14 group)"
-        node_b_value: "GABAergic (Gaba_5 label); child CLUS_1915 nt_type=Dopa"
-        alignment: APPROXIMATE
-        notes: Dopaminergic identity resolved at cluster level; supertype label reflects majority.
-      - property: location_MBA272
-        node_a_value: "MBA:272 (AVPV)"
-        node_b_value: "MBA:272 (AVPV) n=16; MBA:133 PVpo n=64; MBA:515 MPN n=37"
-        alignment: APPROXIMATE
-        notes: Direct AVPV cells present (n=16); supertype also spans broader preoptic zone.
-      - property: marker_Th
-        node_a_value: "POSITIVE (protein, primary defining marker)"
-        node_b_value: "precomputed mean_expression=2.72"
-        alignment: APPROXIMATE
-      - property: marker_Kiss1
-        node_a_value: "POSITIVE (transcript, co-expressed with Th in AVPV)"
-        node_b_value: "precomputed mean_expression=0.62"
-        alignment: APPROXIMATE
-      - property: sex_ratio
-        node_a_value: "female-biased (2-4x more TH+ neurons in females)"
-        node_b_value: "child CLUS_1915 male_female_ratio=0.02 (extreme female bias)"
-        alignment: CONSISTENT
-        notes: >
-          Strong female-bias confirmation at child cluster level; supertype-level sex
-          ratio not separately available.
-      - property: annotation_transfer_f1
-        node_a_value: "not applicable"
-        node_b_value: "NOT_ASSESSED"
+        node_a_value: "dopaminergic"
+        node_b_value: not asserted
         alignment: NOT_ASSESSED
-        notes: Annotation transfer not yet run for avpv_th_neuron. Priority experiment.
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Anteroventral periventricular nucleus [MBA:272]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=381 [painted]; Periventricular hypothalamic nucleus, preoptic part [MBA:133] count_100um=354 [painted]; Medial preoptic nucleus [MBA:515] count_100um=276 [painted]
+        alignment: DISCORDANT
+        notes: 'region_fraction_100um: 0.061; strict region_fraction: 0.043; region_evidence: SELF'
+      - property: marker_Th
+        node_a_value: Th — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Kiss1
+        node_a_value: Kiss1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
     caveats:
       - caveat_type: NT_PREDICTION_UNCERTAIN
-        description: >
-          SUPT_0486 carries a Gaba_5 label at supertype level while the classical AVPV
-          TH neuron is dopaminergic. Dopaminergic identity is resolved only at cluster
-          level (CLUS_1915, Dopa designation).
+        description: "SUPT_0486 carries a Gaba_5 label at supertype level while the classical AVPV TH neuron is dopaminergic. Dopaminergic identity is resolved only at cluster level (CS20230722_CLUS_1915, Dopa designation).\n"
       - caveat_type: AMBIGUOUS_MAPPING
-        description: >
-          avpv_th_neuron and avpv_kiss1_neuron both map to SUPT_0486 — these two classical
-          types substantially overlap (most AVPV/PeN Kiss1 cells co-express Th). Cluster-level
-          resolution needed to determine whether they are separable within SUPT_0486.
-      - caveat_type: OTHER
-        description: '[AUTO_REPREDICATED_2026_05_26] Predicate auto-migrated from deprecated evidencell:PartialOverlapMatch to skos:closeMatch by `refresh_predicates.py`. Rule: rule-3b: no AT F1, existing caveats → closeMatch. Curator review recommended.'
+        description: "avpv_th_neuron and avpv_kiss1_neuron both map to SUPT_0486; the two classical types substantially overlap (most AVPV/PeN Kiss1 cells co-express Th). Cluster-level resolution needed to determine whether they are separable within SUPT_0486.\n"
+      - caveat_type: DISCORDANT_ANATOMY
+        description: "region_fraction_100um=0.061 at MBA:272; bulk of supertype soma sit in adjacent MBA:133 (preoptic periventricular) and MBA:515 (medial preoptic nucleus) — interpretable as boundary scatter rather than off-target placement.\n"
     unresolved_questions:
       - >
         Does CLUS_1915 specifically correspond to AVPV A14 TH neurons? Confirm by
         cluster-level Kiss1/Th/Esr1 co-expression profiling.
+      - "Does CS20230722_CLUS_1915 specifically correspond to AVPV A14 TH neurons? Confirm by cluster-level Kiss1/Th/Esr1 co-expression profiling.\n"
+      - "Curator removal of duplicate edge edge_avpv_th_neuron_to_CS20230722_CLUS_1915 — legacy/fresh-emit ID collision on taxonomy_type CS20230722_CLUS_1915.\n"
     proposed_experiments:
-      - >
-        MapMyCells annotation transfer of AVPV TH-lineage (Th-Cre or Kiss1-Cre)
-        scRNA-seq data to WMBv1 for F1-based confirmation.
-
-    mapping_justification: semapv:UnreviewedManualMapping
-    mapping_cardinality: "1:1"
+      - "Cluster annotation transfer of Th-Cre or Kiss1-Cre AVPV transgene-marked transcriptomes onto WMBv1, targeting F1 >= 0.80 at supertype CS20230722_SUPT_0486 and cluster CS20230722_CLUS_1915.\n"
+      - "Atlas-side cluster-resolved Th/Kiss1/Esr1 co-expression profiling across SUPT_0486 children to localise the female-biased dopaminergic signal beyond CS20230722_CLUS_1915.\n"
+    mapping_justification: semapv:ManualMappingCuration
+    mapping_cardinality: "1:n"
+    discovery_score:
+      score: 1
+      rank_in_cohort: 6
+      cohort_size: 12
+      next_best_score: 2
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 12
+          filters:
+            - region=MBA:272
+            - nt_type=dopaminergic
+            - sex_bias=female
+      expression_detail: []
+      region_fraction: 0.043
+      region_fraction_100um: 0.061
+      region_evidence: SELF
+    confidence: MODERATE
+    confidence_score: 0.55
+    rationale: "[tier:STRONGEST] CS20230722_SUPT_0486 (rank 1, cohort rank 6 of 12 by composite score; the supertype's broader female-biased Dopa signal is concentrated in child CS20230722_CLUS_1915, MFR=0.02, Th=6.6, Kiss1=2.51) is the broadest defensible anchor for the classical AVPV Th/Kiss1 dopaminergic population; supertype-level NT label is Gaba_5 with Dopa identity rescued only at the cluster level, and region_fraction_100um=0.061 reflects boundary scatter across MBA:133 / MBA:515 adjacent to MBA:272. Marker concordance is supported indirectly via child CS20230722_CLUS_1915 (Th, Kiss1, Slc18a2 DEFINING).\n"
+    reconciliation_note: "Paired with the cluster-level call on CS20230722_CLUS_1915 (skos:closeMatch + 1:1); the supertype carries the broader mapping while CS20230722_CLUS_1915 is the best-resolved child carrying the female-biased Th/Kiss1 profile. Also overlaps with avpv_kiss1_neuron, which targets the same supertype.\n"
+    rationale_generated_at: '2026-06-08T18:35:20+00:00'
+    report_path: reports/sexually_dimorphic/avpv_th_neuron_summary.md
+    rationale_source_hash: 4a372866
   - id: edge_sdn_poa_calbindin_neuron_to_cs20230722_supt_0423
     lit_type: sdn_poa_calbindin_neuron
     taxonomy_type: CS20230722_SUPT_0423
@@ -1275,67 +1625,79 @@ edges:
           marker assertion, and the SDN-POA cannot be resolved from the broader MPN in
           WMBv1 MERFISH data.
     property_comparisons:
-      - property: location_MBA515_MPN
-        node_a_value: "MBA:515 (Medial preoptic nucleus; SDN-POA is a histological subnucleus within MPN)"
-        node_b_value: "MBA:515 (MPN) n=47; also BNST n=18, AHN n=46, PVN n=31"
-        alignment: APPROXIMATE
-        notes: >
-          Classical node corrected from MBA:464 (PVN descending division) to MBA:515 (MPN).
-          SDN-POA is a histologically defined subnucleus within MPN, not separately resolved
-          in WMBv1 MERFISH data.
-      - property: marker_Calb1
-        node_a_value: "POSITIVE (protein, primary defining marker)"
-        node_b_value: "precomputed mean_expression=6.42 (DEFINING_SCOPED atlas marker)"
-        alignment: CONSISTENT
-      - property: negative_marker_Th
-        node_a_value: "ABSENT (negative marker; no TH cell bodies in SDN-POA)"
-        node_b_value: "precomputed mean_expression=0.99"
-        alignment: DISCORDANT
-        notes: >
-          Low but non-zero Th expression in SUPT_0423. May reflect Th-expressing cells
-          in the BST/AHN/PVN components rather than MPN-proper cells. Child cluster
-          CLUS_1550 (MPN primary soma) shows Th=2.75 — concern persists at cluster level.
-      - property: sex_ratio
-        node_a_value: "male-biased (SDN-POA has more cells in males; classical IHC)"
-        node_b_value: "child CLUS_1550 male_female_ratio=3.35 (male-biased)"
-        alignment: CONSISTENT
-        notes: >
-          CLUS_1550 (MPN primary soma, n=22) MFR=3.35 is male-biased, consistent with the
-          MALE_BIASED sex_bias of sdn_poa_calbindin_neuron. This is the only cluster in
-          SUPT_0423 with MPN as primary soma and an unambiguous male bias.
-      - property: annotation_transfer_f1
-        node_a_value: "not applicable"
-        node_b_value: "NOT_ASSESSED"
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
         alignment: NOT_ASSESSED
-        notes: >
-          Annotation transfer pipeline has not been run for this classical node.
-          Recommended next step: MapMyCells annotation of MPN Calb1+ or SDN-POA scRNA-seq data.
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic nucleus [MBA:515]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=295 [painted]; Medial preoptic nucleus [MBA:515] count_100um=113 [painted]; Anterior hypothalamic nucleus [MBA:88] count_100um=86 [painted]
+        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.336; strict region_fraction: 0.140; region_evidence: SELF'
+      - property: marker_Calb1
+        node_a_value: Calb1 — defining marker
+        node_b_value: 'Calb1: 6.42; cohort_pct 0.771; child-coverage 1.000; atlas category: DEFINING_SCOPED'
+        alignment: CONSISTENT
+        notes: val=6.42; cohort percentile 0.771; child-cluster coverage 1.000
+      - property: negative_marker_Th
+        node_a_value: Th — ABSENT (classical negative marker)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
     caveats:
       - caveat_type: MERFISH_REGISTRATION_UNCERTAINTY
-        description: >
-          The SDN-POA is a histologically defined subnucleus within MPN, not resolvable
-          as a distinct spatial domain in WMBv1 MERFISH data. Matching is possible only at
-          MPN level (SUPT_0423 MBA:515, n=47); SDN-POA cells cannot be distinguished from
-          other MPN Calb1 neurons.
+        description: "The SDN-POA is a histologically defined subnucleus within MPN, not resolvable as a distinct spatial domain in WMBv1 MERFISH data. Matching is possible only at MPN level (SUPT_0423 MBA:515, n=113); SDN-POA cells cannot be distinguished from other MPN Calb1 neurons.\n"
       - caveat_type: MARKER_NOT_SPECIFIC
-        description: >
-          Calb1 is expressed across many brain regions and is DEFINING_SCOPED (not DEFINING)
-          in SUPT_0423. Calb1 alone is insufficient to identify SDN-POA neurons specifically;
-          the supertype spans BST, MPN, AHN, and PVN.
+        description: "Calb1 is expressed across many brain regions and is DEFINING_SCOPED (not DEFINING) on CS20230722_SUPT_0423. Calb1 alone is insufficient to identify SDN-POA neurons specifically; the supertype spans BST, MPN, AHN, and PVN.\n"
     unresolved_questions:
       - >
         Do any clusters within SUPT_0423 show peak Calb1 co-located with MBA:515 (MPN)
         and male-biased sex ratio consistent with SDN-POA identity?
+      - "Do any clusters within CS20230722_SUPT_0423 show peak Calb1 co-located with MBA:515 and male-biased sex ratio consistent with SDN-POA identity?\n"
     proposed_experiments:
-      - >
-        Spatial inspection of SUPT_0423 MERFISH cells in MBA:515 for sub-regional
-        clustering consistent with SDN-POA dorsomedial position.
-
+      - "Spatial inspection of CS20230722_SUPT_0423 MERFISH cells inside MBA:515 for sub-regional clustering consistent with the dorsomedial SDN-POA position.\n"
+      - "Cluster annotation transfer of an MPN/SDN-POA Calb1+ transcriptomic dataset to the WMBv1 taxonomy, targeting F1 >= 0.70 against CS20230722_SUPT_0423.\n"
     mapping_justification: semapv:UnspecifiedMatching
+    discovery_score:
+      score: 3
+      rank_in_cohort: 34
+      cohort_size: 50
+      next_best_score: 4
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:515
+            - sex_bias=male
+      expression_detail:
+        - gene: Calb1
+          val: 6.42
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.771
+          coverage: 1.0
+      region_fraction: 0.14
+      region_fraction_100um: 0.336
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.25
+    rationale: "[tier:STRONGEST] CS20230722_SUPT_0423 is the only rank-1 candidate where the medial preoptic nucleus [MBA:515] contributes a non-trivial fraction of soma (region_fraction_100um: 0.336; strict region_fraction: 0.140) and Calb1=6.42 (DEFINING_SCOPED; cohort percentile 0.771; child-coverage 1.000) matches the primary classical defining marker. The SDN-POA is a histologically defined subnucleus within MPN and cannot be resolved as a distinct spatial domain in WMBv1 MERFISH data; Calb1 alone is not specific for SDN-POA identity.\n"
+    reconciliation_note: "Paired with best-child edge to CS20230722_CLUS_1550 (the only MPN-primary child of this supertype with male-biased MFR); see report.\n"
+    rationale_generated_at: '2026-06-08T18:35:21+00:00'
+    report_path: reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+    rationale_source_hash: e3070b51
   - id: edge_mpoa_esr1_neuron_to_cs20230722_supt_0486
     lit_type: mpoa_esr1_neuron
     taxonomy_type: CS20230722_SUPT_0486
-    relationship: evidencell:CrossCuttingMatch
+    relationship: skos:broadMatch
     evidence:
       - evidence_type: ATLAS_METADATA
         supports: SUPPORT
@@ -1370,15 +1732,11 @@ edges:
         notes: GABAergic component matches; glutamatergic MPOA Esr1 neurons map elsewhere.
     caveats:
       - caveat_type: AMBIGUOUS_MAPPING
-        description: >
-          MPOA Esr1 neurons are functionally heterogeneous (parental behavior, male mating,
-          female socio-sexual behavior via Nts+ subtype). The classical node spans multiple
-          transcriptomic supertypes. SUPT_0486 captures the GABAergic fraction only. The
-          glutamatergic fraction requires identification of a preoptic glutamatergic supertype.
+        description: "MPOA Esr1+ neurons are functionally heterogeneous (parental behavior, male mating, female socio-sexual via Nts+). The classical node spans multiple transcriptomic supertypes; CS20230722_SUPT_0486 captures only the GABAergic fraction.\n"
       - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
-        description: >
-          The functional subtypes within MPOA Esr1 neurons (parental, mating, female
-          socio-sexual) likely distribute across multiple clusters within SUPT_0486.
+        description: "Functional subpopulations (parental, mating, female socio-sexual) likely distribute across multiple child clusters within CS20230722_SUPT_0486.\n"
+      - caveat_type: OTHER
+        description: "Property comparisons on this edge were not refreshed in the 2026-06-08 Stage A sweep; the edge sits outside the current top-50 at rank 1 and warrants curator review (cf. evidencell#111).\n"
     unresolved_questions:
       - >
         Which clusters within SUPT_0486 have highest Esr1/Ar/Pgr and strongest MPN
@@ -1387,11 +1745,26 @@ edges:
         Does the Nts+ female socio-sexual subpopulation map to SUPT_0486 or to a
         separate preoptic supertype?
 
-    mapping_justification: semapv:UnreviewedManualMapping
+      - "Which clusters within CS20230722_SUPT_0486 have highest Esr1/Ar/Pgr and strongest MPN anatomical signal?\n"
+      - "Does the Nts+ female socio-sexual subpopulation map to CS20230722_SUPT_0486 or to a separate preoptic supertype?\n"
+      - "Curator review of edge_mpoa_esr1_neuron_to_cs20230722_supt_0486: property_comparisons not refreshed in 2026-06-08 sweep; edge outside current Stage A top-50 (cf. evidencell#111).\n"
+    mapping_justification: semapv:ManualMappingCuration
+    confidence: MODERATE
+    confidence_score: 0.55
+    rationale: "[tier:STRONGEST] Atlas precomputed expression on CS20230722_SUPT_0486 confirms all three classical defining markers (Esr1=7.72 DEFINING, Ar=8.15, Pgr=6.80) and the supertype carries MBA:515 (MPN) cells concordant with the classical MBA:523 soma label; this captures the GABAergic component of the Esr1+ MPOA population. Co-primary with CS20230722_SUPT_0521 (glutamatergic component). Property comparisons on this edge were not refreshed in the 2026-06-08 sweep; the edge sits outside the current Stage A top-50 at rank 1 and warrants curator review (cf. evidencell#111).\n"
+    reconciliation_note: "Paired with CS20230722_SUPT_0521 as co-primary: SUPT_0486 captures the GABAergic fraction, SUPT_0521 the glutamatergic fraction of the classical Esr1+ MPOA population. Together they argue for splitting the classical node or narrowing it to MPN-proper.\n"
+    mapping_cardinality: "1:n"
+    proposed_experiments:
+      - "Cluster-level resolution within CS20230722_SUPT_0486 quantifying which child cluster has the strongest joint Esr1/Ar/Pgr profile and densest MPN anatomical signal. Expected output: ATLAS_METADATA and MarkerAnalysisEvidence.\n"
+      - "ISH or MERFISH co-staining for Esr1, Slc32a1 (vGAT) and Slc17a6 (vGlut2) in MPOA to quantify the GABA vs Glut split of Esr1+ cells. Expected output: MarkerAnalysisEvidence.\n"
+      - "Cluster annotation transfer of published MPOA Esr1+ transcriptomic data (e.g. Moffitt 2018) onto CS20230722_SUPT_0486 vs CS20230722_SUPT_0521; target F1 >= 0.5 at supertype level with a clear best-child.\n"
+    rationale_generated_at: '2026-06-08T18:35:22+00:00'
+    report_path: reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+    rationale_source_hash: 89ee1357
   - id: edge_mpoa_esr1_neuron_to_cs20230722_supt_0521
     lit_type: mpoa_esr1_neuron
     taxonomy_type: CS20230722_SUPT_0521
-    relationship: evidencell:CrossCuttingMatch
+    relationship: skos:broadMatch
     evidence:
       - evidence_type: BULK_CORRELATION
         supports: SUPPORT
@@ -1414,36 +1787,37 @@ edges:
           n_child_clusters_in_top_10=4.
     property_comparisons:
       - property: nt_type
-        node_a_value: "GABAergic and/or glutamatergic (classical population is heterogeneous)"
-        node_b_value: "Glutamatergic (Tbr1 Glut_3 label)"
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic area [MBA:523]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=311 [painted]; third ventricle [MBA:129] count_100um=254 [painted]; Median preoptic nucleus [MBA:452] count_100um=183 [painted]
         alignment: APPROXIMATE
-        notes: >
-          Existing edge to SUPT_0486 (GABAergic) covers the GABAergic fraction;
-          SUPT_0521 covers a glutamatergic fraction not previously mapped.
-      - property: location_MBA_preoptic
-        node_a_value: "MBA:515 (MPN) and broader medial preoptic"
-        node_b_value: "Anteroventral periventricular nucleus, Median preoptic nucleus"
-        alignment: APPROXIMATE
-        notes: >
-          AVPV/MePO is part of the broader medial preoptic area but not the MPN proper.
-          The classical mpoa_esr1_neuron may include AVPV/MePO Esr1+ populations or
-          may need to be narrowed to MPN-specific Esr1+ neurons.
+        notes: 'region_fraction_100um: 0.138; strict region_fraction: 0.032; region_evidence: SELF'
       - property: marker_Esr1
-        node_a_value: "POSITIVE (transcript, primary defining marker)"
-        node_b_value: "Esr1+ by experimental design (TRAP-Cre line)"
-        alignment: CONSISTENT
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
     caveats:
       - caveat_type: AMBIGUOUS_MAPPING
-        description: >
-          Co-primary candidate alongside edge_mpoa_esr1_neuron_to_cs20230722_supt_0486.
-          The two supertypes capture different NT-typed Esr1+ preoptic populations; the
-          classical node may need to be split (mpoa_esr1_neuron_GABAergic vs
-          mpoa_esr1_neuron_glutamatergic) or narrowed to MPN proper.
+        description: "Co-primary candidate alongside edge_mpoa_esr1_neuron_to_cs20230722_supt_0486. The two supertypes capture different NT-typed Esr1+ preoptic populations; the classical node may need to be split (mpoa_esr1_neuron_GABAergic vs mpoa_esr1_neuron_glutamatergic) or narrowed to MPN proper.\n"
       - caveat_type: OTHER
-        description: >
-          ATLAS_DISSECTION_OVERLAP — Knoedler's "POA" dissection captures a broader preoptic
-          zone than MPN proper; AVPV and MePO Esr1+ neurons (anatomically anterior to MPN)
-          are likely included in the bulk pool and contribute to the SUPT_0521 signal.
+        description: "ATLAS_DISSECTION_OVERLAP - Knoedler's \"POA\" dissection captures a broader preoptic zone than MPN proper; AVPV and MePO Esr1+ neurons (anatomically anterior to MPN) are likely included in the bulk pool and contribute to the CS20230722_SUPT_0521 signal. Reflected in region_fraction_100um: 0.138 (boundary scatter).\n"
+      - caveat_type: OTHER
+        description: "Atlas-side Esr1, Ar, Pgr expression are NOT_ASSESSED at CS20230722_SUPT_0521 (genes absent from Stage A expression_detail and precomputed expression). Direct atlas-side marker confirmation is the highest-priority follow-up.\n"
     unresolved_questions:
       - >
         Should mpoa_esr1_neuron be split into GABAergic (SUPT_0486) and glutamatergic
@@ -1451,15 +1825,38 @@ edges:
       - >
         Is the AVPV/MePO Esr1+ population (SUPT_0521) functionally distinct from MPN
         Esr1+ (SUPT_0486) in the parental/mating circuit literature?
+      - "Should mpoa_esr1_neuron be split into GABAergic (CS20230722_SUPT_0486) and glutamatergic (CS20230722_SUPT_0521) subnodes, or narrowed to MPN-proper Esr1+ neurons?\n"
+      - "Is the AVPV/MePO Esr1+ population (CS20230722_SUPT_0521) functionally distinct from MPN Esr1+ (CS20230722_SUPT_0486) in the parental/mating circuit literature?\n"
     proposed_experiments:
-      - >
-        ISH or MERFISH co-staining for Esr1, Slc17a6 (vGlut2), Slc32a1 (vGAT) in MPOA
-        to quantify the GABAergic vs glutamatergic fractions of Esr1+ cells.
-      - >
-        MapMyCells annotation transfer of published MPOA Esr1+ scRNA-seq data
-        (e.g. Moffitt 2018) to SUPT_0521 vs SUPT_0486; expect F1 split.
-
-    mapping_justification: semapv:UnreviewedManualMapping
+      - "Targeted query of the WMBv1 precomputed-stats HDF5 for Esr1, Ar, Pgr at CS20230722_SUPT_0521 and its top child clusters (the Knoedler 2022 POA_FR vs VMH_FR bulk-correlation top hits). Target detect Esr1 >= MIN_DETECTABLE on at least one Tbr1 Glut_3 child cluster.\n"
+      - "ISH or MERFISH co-staining for Esr1, Slc17a6 (vGlut2), Slc32a1 (vGAT) in MPOA to quantify the GABA vs Glut fractions of Esr1+ cells in MPN proper vs AVPV/MePO.\n"
+      - "Cluster annotation transfer of published MPOA Esr1+ transcriptomic data (e.g. Moffitt 2018) onto CS20230722_SUPT_0521 vs CS20230722_SUPT_0486; expected F1 split between the two supertypes.\n"
+    mapping_justification: semapv:ManualMappingCuration
+    discovery_score:
+      score: 2
+      rank_in_cohort: 45
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:523
+      expression_detail: []
+      region_fraction: 0.032
+      region_fraction_100um: 0.138
+      region_evidence: SELF
+    confidence: MODERATE
+    confidence_score: 0.55
+    rationale: "[tier:NEXT] Knoedler 2022 (GSE183092) Esr1+ TRAP-seq POA_FR vs VMH_FR bulk-correlation ranks a CS20230722_SUPT_0521 child cluster first of 5322 atlas clusters (delta=0.0151), with three further CS20230722_SUPT_0521 child clusters in the top 10, concentrating the bulk Esr1+ preoptic signal on a single glutamatergic supertype. Co-primary with CS20230722_SUPT_0486 (GABAergic component). Location is APPROXIMATE (region_fraction_100um: 0.138) because Knoedler's POA dissection captures a broader preoptic zone (AVPV/MePO) than MPN proper. Atlas-side Esr1/Ar/Pgr expression is NOT_ASSESSED on this supertype - direct atlas-side marker confirmation is the next-step gap.\n"
+    reconciliation_note: "Paired with CS20230722_SUPT_0486 as co-primary: SUPT_0521 captures the glutamatergic fraction, SUPT_0486 the GABAergic fraction of the classical Esr1+ MPOA population.\n"
+    mapping_cardinality: "1:n"
+    rationale_generated_at: '2026-06-08T18:35:22+00:00'
+    report_path: reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+    rationale_source_hash: f2f224d7
   - id: edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564
     lit_type: vmhvl_esr1_pr_neuron
     taxonomy_type: CS20230722_SUPT_0564
@@ -1493,51 +1890,103 @@ edges:
           Companion target SUPT_0563 takes ranks 1, 2, 4 in the same contrast.
           See edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563 for the supporting numbers.
     property_comparisons:
-      - property: location_MBA693_VMHvl
-        node_a_value: "MBA:693 (VMHvl)"
-        node_b_value: "MBA:693 (VMH) n=360 (dominant location)"
-        alignment: CONSISTENT
       - property: nt_type
-        node_a_value: "not stated; VMHvl neurons predominantly glutamatergic"
-        node_b_value: "Glutamatergic (VMH Fezf1 Glut label)"
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventromedial hypothalamic nucleus [MBA:693]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=620 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=494 [painted]; Tuberal nucleus [MBA:614] count_100um=218 [painted]
         alignment: CONSISTENT
-      - property: marker_Nkx2-1
-        node_a_value: "POSITIVE (transcript, defining marker)"
-        node_b_value: "precomputed mean_expression=5.34"
-        alignment: CONSISTENT
-      - property: marker_Pgr
-        node_a_value: "POSITIVE (transcript, defining marker)"
-        node_b_value: "precomputed mean_expression=4.54"
-        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.795; strict region_fraction: 0.581; region_evidence: SELF'
       - property: marker_Esr1
-        node_a_value: "POSITIVE (transcript, defining marker)"
-        node_b_value: "precomputed mean_expression=2.35"
-        alignment: APPROXIMATE
-        notes: Moderate expression; Esr1 marks a subset, not the full supertype.
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Nkx2-1
+        node_a_value: Nkx2-1 — defining marker
+        node_b_value: 'Nkx2-1: 5.34; cohort_pct 0.887; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=5.34; cohort percentile 0.887; child-cluster coverage 1.000
       - property: marker_Tac1
-        node_a_value: "POSITIVE (transcript, defining marker and neuropeptide)"
-        node_b_value: "precomputed mean_expression=1.39"
-        alignment: APPROXIMATE
-        notes: Low expression; consistent with subset Esr1/Nkx2-1/Tac1 functional subpopulation.
+        node_a_value: Tac1 — defining marker
+        node_b_value: 'Tac1: 1.39; cohort_pct 0.670; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=1.39; cohort percentile 0.670; child-cluster coverage 1.000
+      - property: neuropeptide_Tac1
+        node_a_value: Tac1 — neuropeptide (classical)
+        node_b_value: 'Tac1: 1.39; cohort_pct 0.670; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=1.39; cohort percentile 0.670; child-cluster coverage 1.000
     caveats:
       - caveat_type: AMBIGUOUS_MAPPING
-        description: >
-          VMHvl contains 17 transcriptomic types (Kim 2019). The classical vmhvl_esr1_pr_neuron
-          spans multiple functional subtypes. CS20230722_SUPT_0563 (VMH Fezf1 Glut_1) — parent
-          of the two most female-biased clusters (CLUS_2290 MFR=0.08, CLUS_2292 MFR=0.12) —
-          was not retrieved in the rank-1 DB query and should be assessed as a co-primary
-          mapping target for the female-biased lordosis subpopulation.
+        description: "VMHvl contains up to 17 transcriptomic types and the classical vmhvl_esr1_pr_neuron spans multiple functional subtypes. CS20230722_SUPT_0564 is one of two co-primary cross-cutting targets; CS20230722_SUPT_0563 captures the female-biased lordosis subpopulation by the Knoedler 2022 VMH-FR vs BNST-FR contrast (CLUS_2290 MFR=0.08, CLUS_2292 MFR=0.12 at delta ranks 2 and 4 of 5322).\n"
       - caveat_type: MARKER_NOT_SPECIFIC
-        description: >
-          Calb1 has the highest mean expression in SUPT_0564 (mean=8.0) but is not a defining
-          marker of vmhvl_esr1_pr_neuron. Calb1 is a canonical marker of the distinct SDN-POA
-          calbindin neuron. High Calb1 in SUPT_0564 warrants primary literature verification.
+        description: "Calb1 has the highest mean expression on CS20230722_SUPT_0564 (mean=8.0) but is not a defining marker of vmhvl_esr1_pr_neuron; Calb1 is the canonical marker of the distinct SDN-POA calbindin neuron. Calb1 co-localisation with Esr1/Pgr in VMHvl warrants primary literature verification.\n"
+      - caveat_type: TAXONOMY_LEVEL_MISMATCH
+        description: "Esr1 and Pgr — two of the four defining markers — are absent from the WMBv1 precomputed-expression panel for CS20230722_SUPT_0564 and its children, so the steroid-receptor identity that names the classical type cannot be confirmed atlas-side. Cluster-level co-expression check on the source transcriptomes is required.\n"
     unresolved_questions:
       - >
         Does Calb1 co-localise with Esr1/Pgr in VMHvl neurons, or does it mark a
         distinct subpopulation within SUPT_0564?
 
-    mapping_justification: semapv:UnreviewedManualMapping
+      - "Does Calb1 co-localise with Esr1/Pgr in VMHvl neurons, or does it mark a distinct subpopulation within CS20230722_SUPT_0564?\n"
+    mapping_justification: semapv:ManualMappingCuration
+    discovery_score:
+      score: 5
+      rank_in_cohort: 7
+      cohort_size: 50
+      next_best_score: 7
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:693
+      expression_detail:
+        - gene: Nkx2-1
+          val: 5.34
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.887
+          coverage: 1.0
+        - gene: Tac1
+          val: 1.39
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.67
+          coverage: 1.0
+      region_fraction: 0.581
+      region_fraction_100um: 0.795
+      region_evidence: SELF
+    confidence: MODERATE
+    confidence_score: 0.55
+    rationale: "[tier:STRONGEST] CS20230722_SUPT_0564 (VMH Fezf1 Glut_2) shows Nkx2-1=5.34 (cohort pct 0.887) and Tac1=1.39 (cohort pct 0.670) with child-cluster coverage 1.00, and VMH [MBA:693] as primary soma location (region_fraction_100um: 0.795). 2 of 4 defining markers CONSISTENT at transcript level; Esr1 and Pgr are absent from the atlas precomputed-expression panel for this supertype and require source-dataset re-analysis. SUPT_0564 carries the broader Pgr+/Nkx2-1+/Tac1+ subpopulation of the heterogeneous classical type.\n"
+    reconciliation_note: "Co-primary cross-cutting target with edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563. The VMHvl Esr1/Pgr classical population is heterogeneous (up to 17 transcriptomic types described); SUPT_0564 captures the broader Pgr+/Nkx2-1+/Tac1+ subpopulation and SUPT_0563 captures the female-biased lordosis subpopulation by independent bulk-correlation evidence from Knoedler 2022 (PMID:35143761). Both edges should be retained until the classical node is split or cluster annotation transfer resolves the structure.\n"
+    mapping_cardinality: "1:n"
+    proposed_experiments:
+      - "Cluster annotation transfer of published VMHvl ERα-Cre or PR-Cre transcriptomes onto WMBv1; target supertype-level F1 split between CS20230722_SUPT_0564 (broader Pgr+ population) and CS20230722_SUPT_0563 (female-biased subpopulation), with cluster-level resolution distinguishing CLUS_2295/CLUS_2297 from CLUS_2290/CLUS_2292. F1 >= 0.5 at supertype level. Adds AnnotationTransferEvidence.\n"
+      - "Cluster-level Esr1, Pgr, Nkx2-1, Tac1 co-expression analysis across CS20230722_SUPT_0564 children (CLUS_2295, CLUS_2297) and CS20230722_SUPT_0563 children (CLUS_2290, CLUS_2292, CLUS_2293) on the WMBv1 source dataset; confirms Esr1+Pgr co-expression currently unassessable from atlas precomputed expression.\n"
+    rationale_generated_at: '2026-06-08T18:35:23+00:00'
+    report_path: reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+    rationale_source_hash: cfa89071
   - id: edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563
     lit_type: vmhvl_esr1_pr_neuron
     taxonomy_type: CS20230722_SUPT_0563
@@ -1562,30 +2011,47 @@ edges:
           best_child_cluster=CLUS_2293 (rank 1 of 5322, δ=0.0180);
           additional_top_hits: CLUS_2290 (rank 2, δ=0.0159, MFR=0.08), CLUS_2292 (rank 4, δ=0.0145, MFR=0.12);
           n_child_clusters_in_top_20=3.
-    property_comparisons:
-      - property: location_MBA693_VMHvl
-        node_a_value: "MBA:693 (VMHvl)"
-        node_b_value: "MBA:693 (VMH) primary location across child clusters"
-        alignment: CONSISTENT
+    property_comparisons: &id005
       - property: nt_type
-        node_a_value: "not stated; VMHvl predominantly glutamatergic"
-        node_b_value: "Glutamatergic (VMH Fezf1 Glut label)"
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventromedial hypothalamic nucleus [MBA:693]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=212 [painted]; Tuberal nucleus [MBA:614] count_100um=174 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=151 [painted]
         alignment: CONSISTENT
-      - property: sex_ratio
-        node_a_value: "female-biased lordosis subpopulation expected"
-        node_b_value: "child clusters CLUS_2290 (MFR=0.08), CLUS_2292 (MFR=0.12) — both strongly female-biased"
+        notes: 'region_fraction_100um: 0.712; strict region_fraction: 0.424; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Nkx2-1
+        node_a_value: Nkx2-1 — defining marker
+        node_b_value: 'Nkx2-1: 6.63; cohort_pct 0.990; child-coverage 1.000'
         alignment: CONSISTENT
-        notes: >
-          Sex ratio at supertype level is NULL; signal is concentrated in the two
-          female-biased child clusters that the bulk correlation also surfaces as top hits.
+        notes: val=6.63; cohort percentile 0.990; child-cluster coverage 1.000
+      - property: marker_Tac1
+        node_a_value: Tac1 — defining marker
+        node_b_value: 'Tac1: 6.48; cohort_pct 0.969; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=6.48; cohort percentile 0.969; child-cluster coverage 1.000
+      - property: neuropeptide_Tac1
+        node_a_value: Tac1 — neuropeptide (classical)
+        node_b_value: 'Tac1: 6.48; cohort_pct 0.969; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=6.48; cohort percentile 0.969; child-cluster coverage 1.000
     caveats:
       - caveat_type: AMBIGUOUS_MAPPING
-        description: >
-          Co-primary with edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564. The classical
-          vmhvl_esr1_pr_neuron is a heterogeneous population; SUPT_0563 captures the
-          female-biased lordosis subpopulation, SUPT_0564 captures the broader
-          Pgr+/Nkx2-1+/Tac1+ subpopulation. Both edges should be retained until the
-          classical node is split or a finer-grained analysis is performed.
+        description: "Co-primary with edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564. The classical vmhvl_esr1_pr_neuron is a heterogeneous population; CS20230722_SUPT_0563 captures the female-biased lordosis subpopulation (CLUS_2290 MFR=0.08, CLUS_2292 MFR=0.12), CS20230722_SUPT_0564 captures the broader Pgr+/Nkx2-1+/Tac1+ subpopulation. Both edges should be retained until the classical node is split or cluster-level annotation transfer resolves the structure.\n"
+      - caveat_type: TAXONOMY_LEVEL_MISMATCH
+        description: "Esr1 and Pgr are absent from the WMBv1 precomputed-expression panel for CS20230722_SUPT_0563 and its children; steroid-receptor identity requires source-dataset re-analysis or transgene-driven cluster annotation transfer.\n"
     unresolved_questions:
       - >
         Is SUPT_0563 vs SUPT_0564 a clean female-vs-broader split, or do both supertypes
@@ -1593,20 +2059,61 @@ edges:
       - >
         Are CLUS_2290 and CLUS_2292 distinct functional subtypes within SUPT_0563, or
         replicates of the same lordosis subpopulation?
+      - "Is CS20230722_SUPT_0563 vs CS20230722_SUPT_0564 a clean female-vs-broader split, or do both supertypes contain heterogeneous sub-populations that cross-cut the classical definition?\n"
+      - "Are CS20230722_CLUS_2290 and CS20230722_CLUS_2292 distinct functional subtypes within CS20230722_SUPT_0563, or replicates of the same lordosis subpopulation?\n"
     proposed_experiments:
-      - >
-        Cluster-level Esr1, Pgr, Nkx2-1, Tac1 co-expression in CLUS_2290, 2292, 2293 vs
-        the female-biased clusters of SUPT_0564 — distinguish the two SUPT mappings.
-      - >
-        MapMyCells annotation transfer of published VMHvl ERα-Cre or PR-Cre scRNA-seq
-        data to WMBv1; expect F1 split between SUPT_0563 (female-biased) and SUPT_0564
-        (broader).
-
-    mapping_justification: semapv:UnreviewedManualMapping
+      - "Cluster-level Esr1, Pgr, Nkx2-1, Tac1 co-expression in CS20230722_CLUS_2290, CS20230722_CLUS_2292, and the rank-1 bulk-correlation hit child cluster versus the female-biased clusters of CS20230722_SUPT_0564 — distinguishes the two co-primary cross-cutting targets.\n"
+      - "Cluster annotation transfer of published VMHvl ERα-Cre or PR-Cre transcriptomes to WMBv1; expected F1 split between CS20230722_SUPT_0563 (female-biased) and CS20230722_SUPT_0564 (broader Pgr+ population). Adds AnnotationTransferEvidence.\n"
+    mapping_justification: semapv:ManualMappingCuration
+    discovery_score: &id006
+      score: 7
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 7
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:693
+      expression_detail:
+        - gene: Nkx2-1
+          val: 6.63
+          reliable: true
+          raw_tier: 2
+          applied_score: 2.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.99
+          coverage: 1.0
+        - gene: Tac1
+          val: 6.48
+          reliable: true
+          raw_tier: 2
+          applied_score: 2.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.969
+          coverage: 1.0
+      region_fraction: 0.424
+      region_fraction_100um: 0.712
+      region_evidence: SELF
+    confidence: MODERATE
+    confidence_score: 0.6
+    rationale: "[tier:STRONGEST] CS20230722_SUPT_0563 (VMH Fezf1 Glut_1) shows Nkx2-1=6.63 (cohort pct 0.990) and Tac1=6.48 (cohort pct 0.969) with child-cluster coverage 1.00 — substantially higher than CS20230722_SUPT_0564 — and VMH-FR vs BNST-FR bulk correlation (corr_VMH_FR_vs_BNST_FR, Knoedler 2022 PMID:35143761) places SUPT_0563 children at three of the top four delta slots: the rank-1 hit in Knoedler 2022 VMH-FR vs BNST-FR bulk-correlation (delta=0.018), CS20230722_CLUS_2290 rank 2 (delta=0.016, MFR=0.08), CS20230722_CLUS_2292 rank 4 (delta=0.014, MFR=0.12). 2 of 4 defining markers CONSISTENT at transcript level (Esr1/Pgr absent from atlas panel). SUPT_0563 carries the female-biased lordosis subpopulation.\n"
+    reconciliation_note: "Co-primary cross-cutting target with edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564. SUPT_0563 was not retrieved in the rank-1 DB query (no DEFINING_SCOPED markers in atlas metadata for this supertype) and is added on the strength of the Knoedler 2022 bulk-correlation evidence plus the supertype-level Nkx2-1/Tac1 transcript-level concordance.\n"
+    mapping_cardinality: "1:n"
+    rationale_generated_at: '2026-06-08T18:35:23+00:00'
+    report_path: reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+    rationale_source_hash: 34eb86e4
   - id: edge_pvn_crfr1_neuron_to_cs20230722_supt_0585
     lit_type: pvn_crfr1_neuron
     taxonomy_type: CS20230722_SUPT_0585
-    relationship: skos:closeMatch
+    relationship: skos:broadMatch
     evidence:
       - evidence_type: ATLAS_METADATA
         supports: PARTIAL
@@ -1617,40 +2124,39 @@ edges:
           PVN neuroendocrine identity. Primary caveat: Crhr1=0.84 is low, indicating CRFR1+
           neurons are a subset of SUPT_0585. Rank-0 candidate CLUS_2382 (parent SUPT_0589)
           has male_female_ratio=2.7, consistent with male-biased dimorphism.
-    property_comparisons:
-      - property: location_MBA38_PVN
-        node_a_value: "MBA:38 (Paraventricular hypothalamic nucleus)"
-        node_b_value: "MBA:38 (PVN) n=98 (primary location)"
-        alignment: CONSISTENT
+    property_comparisons: &id007
       - property: nt_type
-        node_a_value: "not stated; PVN principal neurons predominantly glutamatergic"
-        node_b_value: "Glutamatergic (PVH-SO-PVa Otp Glut)"
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Paraventricular hypothalamic nucleus [MBA:38]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=260 [painted]; Paraventricular hypothalamic nucleus [MBA:38] count_100um=175 [painted]; Anterior hypothalamic nucleus [MBA:88] count_100um=74 [painted]
         alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.665; strict region_fraction: 0.383; region_evidence: SELF'
       - property: marker_Crhr1
-        node_a_value: "POSITIVE (transcript, primary defining marker)"
-        node_b_value: "precomputed mean_expression=0.84"
-        alignment: APPROXIMATE
-        notes: Low Crhr1 expression (0.84) — CRFR1+ neurons represent a subset of SUPT_0585.
+        node_a_value: Crhr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
       - property: marker_Esr1
-        node_a_value: "POSITIVE (transcript, defining marker)"
-        node_b_value: "precomputed mean_expression=3.65 (DEFINING_SCOPED atlas marker)"
-        alignment: APPROXIMATE
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
       - property: marker_Ar
-        node_a_value: "POSITIVE (transcript, defining marker)"
-        node_b_value: "precomputed mean_expression=4.95"
-        alignment: APPROXIMATE
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
     caveats:
       - caveat_type: SINGLE_DATASET
-        description: >
-          pvn_crfr1_neuron characterisation rests on a single primary source (Rosinger 2019,
-          PMID:31055007). Confidence capped at MODERATE pending secondary literature validation.
+        description: "Classical type rests on a single primary source (Rosinger 2019, PMID:31055007). Confidence capped at MODERATE pending secondary literature validation; currently LOW because no transcriptomic confirmation of Crhr1 on the candidate supertype is available.\n"
       - caveat_type: AMBIGUOUS_MAPPING
-        description: >
-          Crhr1=0.84 across SUPT_0585 indicates CRFR1+ neurons are a minority subset.
-          SUPT_0589 (parent of male-biased CLUS_2382, ratio 2.7) is an alternative or
-          co-equal mapping target worth curator assessment.
-      - caveat_type: OTHER
-        description: '[AUTO_REPREDICATED_2026_05_26] Predicate auto-migrated from deprecated evidencell:PartialOverlapMatch to skos:closeMatch by `refresh_predicates.py`. Rule: rule-3b: no AT F1, existing caveats → closeMatch. Curator review recommended.'
+        description: "Atlas-internal Crhr1 mean of 0.84 across SUPT_0585 indicates CRFR1+ cells are a minority subset. SUPT_0589 (parent of male-biased CLUS_2382, ratio 2.7) is an alternative or co-equal mapping target requiring assessment.\n"
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "Per-child-cluster Crhr1, Esr1, Ar expression and per-cluster sex ratio are not in property_comparisons, so the best child cluster within SUPT_0585 cannot be resolved from current facts.\n"
     unresolved_questions:
       - >
         Which cluster within the PVH-SO-PVa Otp Glut subclass shows highest Crhr1
@@ -1658,8 +2164,46 @@ edges:
       - >
         Is SUPT_0589 a better or co-equal mapping target compared to SUPT_0585?
 
-    mapping_justification: semapv:UnreviewedManualMapping
-    mapping_cardinality: "1:1"
+      - "Does the CRFR1+ population concentrate in one supertype or distribute across the PVH-SO-PVa Otp Glut subclass (supporting broadMatch onto the subclass rather than to a single supertype)?\n"
+      - "Curator removal of duplicate edge edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0585 — legacy/fresh-emit ID collision on taxonomy_type CS20230722_SUPT_0585.\n"
+    mapping_justification: semapv:ManualMappingCuration
+    mapping_cardinality: "1:n"
+    discovery_score: &id008
+      score: 4
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:38
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.383
+      region_fraction_100um: 0.665
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.35
+    rationale: "[tier:STRONGEST] PVN soma location (175/645 cells in MBA:38) and atlas-internal Esr1=3.65 (DEFINING_SCOPED) plus Ar=4.95 align with the moderate-Esr1 / high-Ar steroid-receptor profile reported by Rosinger 2019; however, atlas-internal Crhr1 mean of 0.84 indicates the defining-marker-positive population is a minority subset of this supertype, capping confidence at LOW pending direct transcriptomic confirmation.\n"
+    reconciliation_note: "Paired with secondary candidate CLUS_2366 (best child cluster within this supertype by PVN proximity). Sister supertype SUPT_0589 is flagged as a co-equal candidate via its male-biased child CLUS_2382 (ratio 2.7) but is not currently edged on this node; emit and re-assess.\n"
+    proposed_experiments:
+      - "Crhr1-targeted transcriptomic profiling of PVN cells (Crhr1 reporter line FACS or post-hoc immunostained sequencing) with cluster annotation transfer to WMBv1; target F1 >= 0.7 at supertype, F1 >= 0.5 at cluster.\n"
+      - "Extract per-child-cluster precomputed Crhr1 / Esr1 / Ar means and male/female ratio for SUPT_0585, SUPT_0586, SUPT_0587, and SUPT_0589 from the WMBv1 reference store; identify the cluster with combined receptor signature and male bias.\n"
+      - "Emit candidate edges for SUPT_0589 (rank 1) and CLUS_2382 (rank 0) and re-run mapping assessment; CLUS_2382 male/female ratio of 2.7 suggests co-equal candidacy with SUPT_0585.\n"
+      - "Secondary literature search for independent confirmation of the PVN CRFR1 male-biased dimorphism, ideally via transcriptomic or in-situ hybridization data.\n"
+    rationale_generated_at: '2026-06-08T18:35:24+00:00'
+    report_path: reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
+    rationale_source_hash: b1f8877b
   - id: edge_bnst_crf_neuron_to_cs20230722_supt_0393
     lit_type: bnst_crf_neuron
     taxonomy_type: CS20230722_SUPT_0393
@@ -1675,48 +2219,42 @@ edges:
           marker for the classical type (distinguishes dlBNST CRF neurons from the Calb1+
           principal nucleus of BNST). This discordance is the primary driver of UNCERTAIN
           confidence.
-    property_comparisons:
-      - property: location_MBA174_BNST
-        node_a_value: "MBA:351 (BNST — dlBNST, ovBNST, alBNST subnuclei)"
-        node_b_value: "MBA:351 (BNST) n=140 (primary location)"
-        alignment: CONSISTENT
-        notes: MBA:351 and MBA:351 are both BNST-level annotations for the same structure.
+    property_comparisons: &id009
       - property: nt_type
-        node_a_value: "GABAergic (inferred from literature context)"
-        node_b_value: "GABAergic (Gad2 DEFINING marker, Gaba label)"
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]
+        node_b_value: Pallidum [MBA:803] count_100um=222 [painted]; Bed nuclei of the stria terminalis [MBA:351] count_100um=215 [painted]; Striatum [MBA:477] count_100um=107 [painted]
         alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.846; strict region_fraction: 0.628; region_evidence: SELF'
       - property: marker_Crh
-        node_a_value: "POSITIVE (transcript, defining marker and neuropeptide)"
-        node_b_value: "precomputed mean_expression=7.96 (DEFINING_SCOPED atlas marker)"
-        alignment: CONSISTENT
+        node_a_value: Crh — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
       - property: negative_marker_Calb1
-        node_a_value: "ABSENT (negative marker; dlBNST CRF neurons lack Calb1)"
-        node_b_value: "precomputed mean_expression=5.57"
+        node_a_value: Calb1 — ABSENT (classical negative marker)
+        node_b_value: 'Calb1: 5.57; cohort_pct 0.737'
         alignment: DISCORDANT
-        notes: >
-          Critical discordance. Calb1 is explicitly absent in dlBNST CRF neurons but shows
-          substantial supertype-level expression (5.57). SUPT_0393 likely aggregates both
-          Calb1- CRF neurons and Calb1+ BNST neurons. Primary driver of UNCERTAIN confidence.
+        notes: val=5.57; cohort percentile 0.737
+      - property: neuropeptide_Crh
+        node_a_value: Crh — neuropeptide (classical)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
     caveats:
-      - caveat_type: MARKER_NOT_SPECIFIC
-        description: >
-          SUPT_0393 shows Calb1=5.57 despite bnst_crf_neuron having Calb1 as a NEGATIVE
-          marker. This supertype likely aggregates multiple BNST GABAergic subtypes. A child
-          cluster with low Calb1 and high Crh would be a more specific mapping candidate and
-          may support confidence upgrade to LOW or MODERATE.
-      - caveat_type: MERFISH_REGISTRATION_UNCERTAINTY
-        description: >
-          The classical type is defined at sub-nucleus resolution (dlBNST, ovBNST, alBNST).
-          WMBv1 MERFISH annotation uses the parent BNST term (MBA:351) without sub-nucleus
-          assignment. Sub-nucleus identity of the matching cells cannot be confirmed.
       - caveat_type: OTHER
-        description: '[AUTO_REPREDICATED_2026_05_26] Predicate auto-migrated from deprecated evidencell:PartialOverlapMatch to skos:closeMatch by `refresh_predicates.py`. Rule: rule-3b: no AT F1, DISCORDANT comparison(s), existing caveats → closeMatch. Curator review recommended.'
+        description: "Duplicate of the fresh-emit edge edge_bnst_crf_neuron_to_CS20230722_SUPT_0393 on the same taxonomy_type. Carried curator-authored caveats prior to the 2026-06-08 sweep; surfaced here as a stale-duplicate cleanup follow-up rather than as an independent candidate.\n"
     unresolved_questions:
       - >
         Do individual clusters under SUPT_0393 segregate into Calb1-high and Calb1-low
         populations? A Calb1-low, Crh-high child cluster would support confidence upgrade.
       - >
         Does SUPT_0393 show female-biased sex ratio consistent with bnst_crf_neuron?
+      - Curator removal of duplicate edge edge_bnst_crf_neuron_to_cs20230722_supt_0393 — legacy/fresh-emit ID collision on taxonomy_type CS20230722_SUPT_0393.
     proposed_experiments:
       - >
         Query precomputed expression for Calb1 across child clusters of SUPT_0393 to
@@ -1724,6 +2262,45 @@ edges:
 
     mapping_justification: semapv:UnreviewedManualMapping
     mapping_cardinality: "1:1"
+    discovery_score: &id010
+      score: 3
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:351,MBA:351,MBA:351
+      expression_detail:
+        - gene: Crh
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: -Calb1
+          val: 5.57
+          reliable: true
+          raw_tier: -1
+          applied_score: -1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.737
+      region_fraction: 0.628
+      region_fraction_100um: 0.846
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.25
+    rationale: "[tier:CUT] Legacy/fresh-emit duplicate of CS20230722_SUPT_0393 (lowercase edge id alongside fresh-emit uppercase edge); the fresh-emit edge edge_bnst_crf_neuron_to_CS20230722_SUPT_0393 carries the canonical structured evidence. Curator removal of this duplicate is the recommended follow-up.\n"
+    rationale_generated_at: '2026-06-08T18:35:25+00:00'
+    report_path: reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+    rationale_source_hash: ca3395c2
   - id: edge_bnst_crf_neuron_to_cs20230722_supt_0358
     lit_type: bnst_crf_neuron
     taxonomy_type: CS20230722_SUPT_0358
@@ -1778,19 +2355,11 @@ edges:
           may represent a distinct subpopulation within SUPT_0358.
     caveats:
       - caveat_type: AMBIGUOUS_MAPPING
-        description: >
-          Alternative or co-primary candidate to edge_bnst_crf_neuron_to_cs20230722_supt_0393.
-          SUPT_0393 (CEA-BST Rai14 Pdyn Crh Gaba_2) is the existing mapping based on direct
-          Crh expression (DEFINING_SCOPED, mean 7.96); SUPT_0358 is the BNST-Esr1+
-          supertype identified by Knoedler bulk correlation. Both may capture parts of the
-          heterogeneous BNST-CRF population; curator review needed.
+        description: "Alternative or co-primary candidate to CS20230722_SUPT_0393. Both may capture parts of the heterogeneous BNST dimorphic population; curator review needed to decide whether CS20230722_SUPT_0358 is a parallel mapping or a separate Esr1+ type.\n"
       - caveat_type: NO_DISCRIMINATING_MARKER
-        description: >
-          SUPT_0358 has no DEFINING marker for Crh in atlas metadata. The mapping rests on
-          bulk-correlation co-localisation evidence (Esr1+ proxy) only. Direct Crh expression
-          measurement at cluster level required for confidence upgrade.
+        description: "CS20230722_SUPT_0358 has no DEFINING marker for Crh in atlas metadata. The mapping rests on bulk-correlation co-localisation evidence (Esr1+ proxy) only. Direct Crh expression measurement at cluster level is required for confidence upgrade.\n"
       - caveat_type: OTHER
-        description: '[AUTO_REPREDICATED_2026_05_26] Predicate auto-migrated from deprecated evidencell:PartialOverlapMatch to skos:closeMatch by `refresh_predicates.py`. Rule: rule-3b: no AT F1, existing caveats → closeMatch. Curator review recommended.'
+        description: "Stale-edge follow-up — CS20230722_SUPT_0358 fell outside the current Stage A top-50 at rank 1 and property_comparisons were not refreshed in the 2026-06-08 sweep; warrants curator review before being relied on (cf. Cellular-Semantics/evidencell#111).\n"
     unresolved_questions:
       - >
         What fraction of SUPT_0358 cells co-express Esr1 and Crh? ISH or scRNA-seq for
@@ -1798,16 +2367,20 @@ edges:
       - >
         Is SUPT_0393 (high Crh) or SUPT_0358 (Esr1+ proxy) the better mapping for the
         sexually dimorphic anterolateral BST CRF+ population?
+      - What fraction of CS20230722_SUPT_0358 cells co-express Esr1+ and Crh+? Direct co-staining in BST would resolve this.
+      - Is CS20230722_SUPT_0393 (Crh-labelled) or CS20230722_SUPT_0358 (Esr1+ proxy) the better mapping for the sexually dimorphic anterolateral BST CRF+ population?
     proposed_experiments:
-      - >
-        ISH or MERFISH co-staining for Crh, Esr1, Calb1 in BST to identify the cluster
-        boundary between SUPT_0358 (Esr1+) and SUPT_0393 (Crh+).
-      - >
-        MapMyCells annotation transfer of published BNST scRNA-seq with Crh+ subset
-        annotations to WMBv1; expect F1 split between SUPT_0358 and SUPT_0393.
-
-    mapping_justification: semapv:UnreviewedManualMapping
+      - "ISH or MERFISH co-staining for Crh, Esr1, Calb1 in BST to identify the cluster boundary between CS20230722_SUPT_0358 (Esr1+) and CS20230722_SUPT_0393 (Crh+) and quantify their overlap.\n"
+      - "Cluster annotation transfer of published BNST transcriptomic data with Crh+ subset annotations to WMBv1; expect the Crh+ signal to split between CS20230722_SUPT_0358 and CS20230722_SUPT_0393 if both contain Crh+ subpopulations.\n"
+    mapping_justification: semapv:ManualMappingCuration
     mapping_cardinality: "1:1"
+    confidence: LOW
+    confidence_score: 0.3
+    rationale: "[tier:WEAKEST] CS20230722_SUPT_0358 is the top BST-localised signal from Knoedler 2022 Esr1+ TRAP-seq BNST_FR vs VMH_FR (PMID:35143761); 4 of the top 10 clusters by delta belong to CS20230722_SUPT_0358 (best child cluster rank 4 by Knoedler 2022 BST-FR vs VMH-FR bulk-correlation delta). CRITICAL: Knoedler sorted on Esr1+, not Crh+; co-localisation of Esr1+ and Crh+ within this supertype is not established by current evidence. Mixed-direction MFRs across child clusters (one child cluster MFR=99, extreme male bias) are inconsistent with the classical female-biased CRF population, suggesting the supertype captures a partially overlapping Esr1+ BST sexually dimorphic population rather than the Crh+ population per se.\n"
+    reconciliation_note: "Co-primary alternative to CS20230722_SUPT_0393 (the Crh-labelled supertype). Held at LOW pending direct Crh measurement; would either upgrade to a parallel mapping or be refuted. Stale-edge follow-up: this edge fell outside the current Stage A top-50 at rank 1 and its property_comparisons were not refreshed in the 2026-06-08 sweep (cf. Cellular-Semantics/evidencell#111).\n"
+    rationale_generated_at: '2026-06-08T18:35:25+00:00'
+    report_path: reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+    rationale_source_hash: ad4c31a1
   - id: edge_mea_esr1_neuron_to_cs20230722_supt_0055
     lit_type: mea_esr1_neuron
     taxonomy_type: CS20230722_SUPT_0055
@@ -1915,35 +2488,32 @@ edges:
           Best available atlas match for Cyp19a1 expression; no ARH supertype shows higher
           Cyp19a1 expression in full DB scan.
     caveats:
-      - caveat_type: MERFISH_REGISTRATION_UNCERTAINTY
-        description: >
-          The classical type is defined in MBA:223 (ARH) but SUPT_0486 is in the periventricular
-          preoptic zone. The mapping is proposed in the absence of any ARH-specific Cyp19a1-
-          positive atlas cluster. MERFISH registration artefacts at the ARH/periventricular
-          boundary, or a pan-hypothalamic aromatase transcriptomic identity, may explain the
-          discordance.
-      - caveat_type: SINGLE_DATASET
-        description: >
-          arc_aromatase_neuron is based on a single primary source (Wartenberg 2021, PMID:34561233).
-          ARH location assignment depends on this paper alone. Alternative ARH candidates
-          SUPT_0427 and SUPT_0428 (ARH-PVi Six6 Dopa-Gaba supertypes) have not had Cyp19a1
-          expression confirmed and should be assessed.
+      - caveat_type: DISCORDANT_ANATOMY
+        description: "CS20230722_SUPT_0486 is in PVpo-VMPO-MPN with no MBA:223 cells in its painted distribution; classical type is in MBA:223.\n"
+      - caveat_type: OTHER
+        description: "Edge fell outside current Stage A top-50 at rank 1; property_comparisons not refreshed in this run. Curator review warranted (cf. evidencell #111).\n"
     unresolved_questions:
       - >
         Do SUPT_0427 or SUPT_0428 (ARH Dopa-Gaba supertypes) show Cyp19a1 expression
         in the precomputed HDF5 stats?
       - >
         Is CLUS_1907 located exclusively in POA/periventricular zones in MERFISH data?
+      - "Should CS20230722_SUPT_0486 and its periventricular preoptic child cluster be re-mapped to a separate preoptic-aromatase classical node distinct from arc_aromatase_neuron?\n"
+      - "Curator review of legacy edge edge_arc_aromatase_neuron_to_cs20230722_supt_0486 — fell outside current Stage A top-50 (cf. #111).\n"
     proposed_experiments:
-      - >
-        Query Cyp19a1 expression in ARH-region supertypes (SUPT_0427, SUPT_0428, and
-        neighbouring ARH supertypes) from the precomputed HDF5.
-
+      - "Confirm whether the periventricular preoptic child cluster has any MBA:223 representation in MERFISH spatial data, or is exclusively in periventricular preoptic zones.\n"
     mapping_justification: semapv:UnspecifiedMatching
+    confidence: UNCERTAIN
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_SUPT_0486 (PVpo-VMPO-MPN Hmx2 Gaba_5) was previously proposed because its periventricular preoptic child cluster carries Cyp19a1 as a defining marker, but the supertype's painted soma distribution sits in PVpo/MPN/AVPV (no MBA:223 cells), and the legacy edge fell outside the current Stage A top-50; flagged for curator review.\n"
+    reconciliation_note: "Legacy edge from pre-emitter pass; property_comparisons not refreshed in current run. The Cyp19a1-positive periventricular preoptic child cluster may represent a separate preoptic-aromatase population rather than the arcuate aromatase neuron of Wartenberg 2021; curator decision needed.\n"
+    rationale_generated_at: '2026-06-08T18:35:26+00:00'
+    report_path: reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
+    rationale_source_hash: e4ec132e
   - id: edge_pmv_otr_neuron_to_cs20230722_supt_0607
     lit_type: pmv_otr_neuron
     taxonomy_type: CS20230722_SUPT_0607
-    relationship: evidencell:CrossCuttingMatch
+    relationship: skos:broadMatch
     evidence:
       - evidence_type: ATLAS_METADATA
         supports: SUPPORT
@@ -1955,57 +2525,39 @@ edges:
           three markers corresponding to the potentially distinct PMv subpopulations (PMv-OTR,
           PMv-DAT, PMv-PACAP). Tac1=8.95 (DEFINING atlas marker) is unexpectedly the highest-
           expressing gene but is not in the classical node definition.
-    property_comparisons:
-      - property: location_MBA1004_PMv
-        node_a_value: "MBA:1004 (Ventral premammillary nucleus)"
-        node_b_value: "MBA:1004 (PMv) n=347 (dominant location)"
-        alignment: CONSISTENT
-      - property: marker_Oxtr
-        node_a_value: "POSITIVE (transcript, defining marker)"
-        node_b_value: "precomputed mean_expression=2.0 (DEFINING_SCOPED atlas marker)"
-        alignment: CONSISTENT
-      - property: marker_Slc6a3
-        node_a_value: "POSITIVE (transcript, defining marker)"
-        node_b_value: "precomputed mean_expression=3.07 (DEFINING atlas marker)"
-        alignment: CONSISTENT
-      - property: marker_Adcyap1
-        node_a_value: "POSITIVE (defining marker)"
-        node_b_value: "precomputed mean_expression=4.8"
-        alignment: CONSISTENT
+    property_comparisons: &id013
       - property: nt_type
-        node_a_value: "not specified; DAT+ subpopulation implies dopaminergic co-release"
-        node_b_value: "Glutamatergic (PMv-TMv Pitx2 Glut)"
-        alignment: APPROXIMATE
-        notes: >
-          Glutamatergic identity likely for OTR+ and PACAP+ populations; dopaminergic
-          co-release possible for the Slc6a3+ subset.
-      - property: sex_ratio
-        node_a_value: "male-biased (PMv OTR expression higher in males, P14–P56)"
-        node_b_value: "NOT_ASSESSED — MFR absent from DB for CLUS_2470 (n=192 PMv cells)"
+        node_a_value: not asserted
+        node_b_value: not asserted
         alignment: NOT_ASSESSED
-        notes: >
-          MFR data is absent for the best child cluster CLUS_2470 (primary PMv cluster,
-          n=192). CLUS_2473 (PMv, n=86) has MFR=2.23 (mild male bias) but very low marker
-          expression. Sex bias alignment cannot currently be confirmed at cluster level.
-      - property: annotation_transfer_f1
-        node_a_value: "not applicable"
-        node_b_value: "NOT_ASSESSED"
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventral premammillary nucleus [MBA:1004]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=546 [painted]; Ventral premammillary nucleus [MBA:1004] count_100um=473 [painted]; Dorsomedial nucleus of the hypothalamus [MBA:830] count_100um=206 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.865; strict region_fraction: 0.634; region_evidence: SELF'
+      - property: marker_Oxtr
+        node_a_value: Oxtr — defining marker
+        node_b_value: no atlas expression data
         alignment: NOT_ASSESSED
-        notes: Annotation transfer not yet run for pmv_otr_neuron.
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Slc6a3
+        node_a_value: Slc6a3 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Adcyap1
+        node_a_value: Adcyap1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
     caveats:
       - caveat_type: AMBIGUOUS_MAPPING
-        description: >
-          pmv_otr_neuron acknowledges three potentially distinct subpopulations (PMv-OTR,
-          PMv-DAT, PMv-PACAP). SUPT_0607 expresses all three marker signatures simultaneously,
-          indicating the supertype aggregates neurons the classical taxonomy may treat as
-          distinct subtypes. Sister supertype SUPT_0605 (PMv-TMv Pitx2 Glut_1, DB score=2)
-          may capture an additional portion of the OTR+ male-biased population.
+        description: "Cross-cutting marker aggregation — SUPT_0607 simultaneously expresses Oxtr, Slc6a3, and Adcyap1, the three markers the classical definition treats as potentially labelling distinct PMv subpopulations (PMv-OTR, PMv-DAT, PMv-PACAP); the supertype-level mapping inherently aggregates them and a sub-supertype split may be required if curator decides the subpopulations are functionally distinct.\n"
       - caveat_type: MARKER_NOT_SPECIFIC
-        description: >
-          Tac1 is the highest-expressing DEFINING marker in SUPT_0607 (mean=8.95) but is
-          absent from the classical pmv_otr_neuron definition. SUPT_0607 may be more
-          accurately characterized as a Tac1+ PMv population with OTR/DAT/PACAP as
-          co-expressed subtype markers.
+        description: "Tac1 is tagged DEFINING on the atlas for this supertype with mean=8.95 — substantially higher than any of the three classical defining markers — and is absent from the classical pmv_otr_neuron definition; the supertype may be more accurately characterised at the atlas level as a Tac1+ PMv glutamatergic population with OTR / DAT / PACAP signatures as co-expressed subtype-level features.\n"
+      - caveat_type: OTHER
+        description: "Sister supertype 0605 PMv-TMv Pitx2 Glut_1 also resides predominantly in PMv (region_fraction_100um=0.631; strict=0.307) and may capture an additional portion of the OTR+ male-biased population not absorbed by SUPT_0607.\n"
     unresolved_questions:
       - >
         Do individual clusters within SUPT_0607 segregate by marker (Oxtr-high,
@@ -2013,14 +2565,53 @@ edges:
       - >
         Should pmv_otr_neuron be split into separate pmv_otr, pmv_dat, pmv_pacap
         sub-nodes prior to final mapping?
+      - "Do individual child clusters within SUPT_0607 segregate by marker (Oxtr-high, Slc6a3-high, Adcyap1-high), allowing sub-supertype resolution mapping?\n"
+      - "Is the atlas DEFINING marker Tac1 (mean=8.95 on SUPT_0607) a feature that should be added to the classical definition, or a co-expressed but classically irrelevant marker?\n"
     proposed_experiments:
-      - >
-        Query Oxtr, Slc6a3, Adcyap1, Tac1 expression in child clusters of SUPT_0607
-        to determine if subpopulations are resolvable at cluster level.
-
-  # --- Cluster-level edges (2026-04-26 re-mapping) ---
-
-    mapping_justification: semapv:UnreviewedManualMapping
+      - "Cluster annotation transfer of published PMv lineage transcriptomic data (Oxtr-Cre, Slc6a3-Cre, or Adcyap1-Cre profiled cells) against WMBv1, with F1 >= 0.7 to SUPT_0607 at supertype level, to provide an AnnotationTransferEvidence anchor for the classical-to-atlas relationship.\n"
+      - "Query Oxtr, Slc6a3, Adcyap1, and Tac1 expression across the child clusters of SUPT_0607 to test whether the three classical marker signatures segregate at cluster level (suggesting sub-supertype splitting) or co-occur across children (supporting the aggregated broader call).\n"
+      - "Curator decision on whether to split pmv_otr_neuron into separate pmv_otr, pmv_dat, and pmv_pacap sub-nodes, which would reframe this edge as a cross-cutting many-to-one mapping into SUPT_0607 rather than a single broader 1:n mapping.\n"
+    mapping_justification: semapv:ManualMappingCuration
+    discovery_score: &id014
+      score: 5
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:1004
+            - sex_bias=male
+      expression_detail:
+        - gene: Oxtr
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: Slc6a3
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.634
+      region_fraction_100um: 0.865
+      region_evidence: SELF
+    confidence: MODERATE
+    confidence_score: 0.62
+    rationale: "[tier:STRONGEST] PMv-resident glutamatergic supertype 0607 PMv-TMv Pitx2 Glut_3 (region_fraction_100um=0.865; strict=0.634) co-expresses all three classical defining markers (Oxtr=2.0, Slc6a3=3.07, Adcyap1=4.8) and is the highest-scoring candidate at any rank; the broader 1:n call reflects supertype aggregation of the three classical PMv-OTR / PMv-DAT / PMv-PACAP subpopulations rather than a clean 1:1.\n"
+    reconciliation_note: "Supertype-level call (CS20230722_SUPT_0607) paired with cluster-level secondary CS20230722_CLUS_2470 (LOW); the supertype absorbs marker signatures that the classical definition treats as potentially distinct subpopulations, so the natural resolution is broader at supertype level and uncertain at cluster level pending male-bias and within-cluster co-expression resolution.\n"
+    mapping_cardinality: "1:n"
+    rationale_generated_at: '2026-06-08T18:35:27+00:00'
+    report_path: reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+    rationale_source_hash: ce214db0
   - id: edge_avpv_kiss1_neuron_to_cs20230722_clus_1915
     lit_type: avpv_kiss1_neuron
     taxonomy_type: CS20230722_CLUS_1915
@@ -2129,62 +2720,81 @@ edges:
           transporter) is a DEFINING cluster marker, providing independent dopaminergic
           identity support. Three convergent signals: Th expression, female sex ratio,
           and dopaminergic NT type.
-    property_comparisons:
+    property_comparisons: &id003
       - property: nt_type
-        node_a_value: "dopaminergic (A14 group)"
-        node_b_value: "Dopa (confirmed, cluster.yaml name_in_source='Dopa')"
+        node_a_value: "dopaminergic"
+        node_b_value: Dopa
         alignment: CONSISTENT
-        notes: Full NT concordance at cluster level; supertype label (Gaba_5) resolved here.
-      - property: location_MBA272
-        node_a_value: "MBA:272 (AVPV)"
-        node_b_value: "MBA:272 (AVPV) n=1; MBA:133 PVpo n=1; MBA:1097 Hypothalamus n=3"
-        alignment: APPROXIMATE
-        notes: AVPV cells present; cluster too small to resolve sub-regional anatomy precisely.
+        notes: Stage A NT prefix-match passed.
+      - property: location
+        node_a_value: Anteroventral periventricular nucleus [MBA:272]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=214 [painted]; Periventricular hypothalamic nucleus, preoptic part [MBA:133] count_100um=210 [painted]; Medial preoptic nucleus [MBA:515] count_100um=147 [painted]
+        alignment: DISCORDANT
+        notes: 'region_fraction_100um: 0.071; strict region_fraction: 0.029; region_evidence: SELF'
       - property: marker_Th
-        node_a_value: "POSITIVE (protein, primary defining marker)"
-        node_b_value: "precomputed mean_expression=6.6; VMAT2 (Slc18a2) is a DEFINING marker"
-        alignment: CONSISTENT
-      - property: marker_Kiss1
-        node_a_value: "POSITIVE (transcript, co-expressed with Th)"
-        node_b_value: "precomputed mean_expression=2.51; Kiss1 is a cluster-level DEFINING marker"
-        alignment: CONSISTENT
-      - property: sex_ratio
-        node_a_value: "female-biased (2-4x more TH+ neurons in females)"
-        node_b_value: "male_female_ratio=0.02 (extreme female bias, ~50:1 F:M)"
-        alignment: CONSISTENT
-      - property: annotation_transfer_f1
-        node_a_value: "not applicable"
-        node_b_value: "NOT_ASSESSED"
+        node_a_value: Th — defining marker
+        node_b_value: no atlas expression data
         alignment: NOT_ASSESSED
-        notes: AT pipeline not run. Recommended experiment using Th-Cre AVPV scRNA-seq data.
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Kiss1
+        node_a_value: Kiss1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
     caveats:
       - caveat_type: LOW_CELL_COUNT
-        description: >
-          CLUS_1915 has only n=3–5 total cells. All metrics are directionally correct but
-          have limited statistical power. Confidence capped at MODERATE.
+        description: "CS20230722_CLUS_1915 retains only n approx 3-5 cells after filtering. All signals are directionally correct but statistical power is limited; confidence is capped at MODERATE.\n"
       - caveat_type: AMBIGUOUS_MAPPING
-        description: >
-          avpv_th_neuron and avpv_kiss1_neuron both map to CLUS_1915 — the two classical
-          types are substantially overlapping (most AVPV Kiss1 cells co-express Th). These
-          may be the same cell population described from different entry points in the
-          classical literature.
-      - caveat_type: OTHER
-        description: '[AUTO_REPREDICATED_2026_05_26] Predicate auto-migrated from deprecated evidencell:PartialOverlapMatch to skos:closeMatch by `refresh_predicates.py`. Rule: rule-3b: no AT F1, existing caveats → closeMatch. Curator review recommended.'
+        description: "avpv_th_neuron and avpv_kiss1_neuron both map to CS20230722_CLUS_1915; most AVPV/PeN Kiss1 cells co-express Th, and the two classical types may in fact be the same population described from different marker entry points.\n"
+      - caveat_type: DISCORDANT_ANATOMY
+        description: "region_fraction_100um=0.071 at MBA:272; bulk of cluster soma sit in adjacent MBA:133 (preoptic periventricular) and MBA:515 (medial preoptic nucleus) — interpretable as boundary scatter across the AVPV/PeN/MPO corridor rather than off-target placement.\n"
     unresolved_questions:
       - >
         Is CLUS_1915 specifically the A14 TH/Kiss1 cluster, or does it also include
         TH+ AVPV neurons that are Kiss1-negative?
+      - "Is CS20230722_CLUS_1915 specifically the A14 TH/Kiss1 cluster, or does it also include TH+ AVPV neurons that are Kiss1-negative?\n"
     proposed_experiments:
-      - >
-        MapMyCells annotation transfer of Th-Cre AVPV scRNA-seq data for F1-based
-        confirmation at cluster level.
-
-    mapping_justification: semapv:UnreviewedManualMapping
+      - "Annotation transfer of Th-Cre AVPV transgene-marked transcriptomes onto WMBv1 targeting F1 >= 0.80 at cluster CS20230722_CLUS_1915.\n"
+      - "Larger AVPV/PeN-targeted transcriptomic cohort (Th-Cre and/or Kiss1-Cre) to lift n above the small-sample ceiling currently capping cluster-level confidence.\n"
+    mapping_justification: semapv:ManualMappingCuration
     mapping_cardinality: "1:1"
+    discovery_score: &id004
+      score: 4
+      rank_in_cohort: 1
+      cohort_size: 10
+      next_best_score: 2
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 10
+          filters:
+            - region=MBA:272
+            - nt_type=dopaminergic
+            - sex_bias=female
+      expression_detail:
+        - gene: Kiss1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.029
+      region_fraction_100um: 0.071
+      region_evidence: SELF
+    confidence: MODERATE
+    confidence_score: 0.6
+    rationale: "[tier:STRONGEST] CS20230722_CLUS_1915 (rank 0, cohort rank 1 of 10 by composite score 4 vs next-best 2) is the only WMBv1 cluster simultaneously carrying high Th (precomputed=6.6), detectable Kiss1 (=2.51), a Dopa neurotransmitter annotation, Slc18a2 as a DEFINING cluster marker, and an extreme female sex bias (MFR=0.02) matching the classical AVPV Th/Kiss1 dopaminergic population. Confidence is capped at MODERATE by small cohort retention (n approx 3-5 cells after filtering) and by region_fraction_100um=0.071 at MBA:272 — boundary scatter across the adjacent MBA:133 / MBA:515 preoptic periventricular corridor rather than a clean within-AVPV placement.\n"
+    reconciliation_note: "Paired with the supertype-level call on CS20230722_SUPT_0486 (skos:broadMatch + 1:n); the cluster is the best-resolved child carrying the female-biased Th/Kiss1 profile within that supertype. Also overlaps with avpv_kiss1_neuron, which targets the same cluster — the two classical types may correspond to the same transcriptomic population entered from two marker-defined entry points.\n"
+    rationale_generated_at: '2026-06-08T18:35:20+00:00'
+    report_path: reports/sexually_dimorphic/avpv_th_neuron_summary.md
+    rationale_source_hash: 243d1ad7
   - id: edge_sdn_poa_calbindin_neuron_to_cs20230722_clus_1550
     lit_type: sdn_poa_calbindin_neuron
     taxonomy_type: CS20230722_CLUS_1550
-    relationship: skos:closeMatch
+    relationship: evidencell:UncertainRelationship
     evidence:
       - evidence_type: ATLAS_METADATA
         supports: WEAK
@@ -2197,49 +2807,33 @@ edges:
           it is not MPN-restricted. SDN-POA cannot be resolved as a subnucleus within
           MPN in WMBv1 MERFISH data.
     property_comparisons:
-      - property: location_MBA515_MPN
-        node_a_value: "MBA:515 (Medial preoptic nucleus; SDN-POA is histological subnucleus)"
-        node_b_value: "MBA:515 (MPN) n=22 (primary soma); also PVH n=9, PVHap n=4, Hypothalamus n=9"
-        alignment: APPROXIMATE
-        notes: >
-          MPN primary soma confirmed (n=22). Cluster also spans PVN-adjacent regions;
-          SDN-POA dorsomedial position within MPN cannot be confirmed from MERFISH data alone.
-      - property: marker_Calb1
-        node_a_value: "POSITIVE (protein, primary defining marker)"
-        node_b_value: "precomputed mean_expression=6.66"
-        alignment: CONSISTENT
-      - property: negative_marker_Th
-        node_a_value: "ABSENT (negative marker; no TH cell bodies in SDN-POA)"
-        node_b_value: "precomputed mean_expression=2.75"
-        alignment: DISCORDANT
-        notes: >
-          Non-zero Th expression is a concern at cluster level. May originate from
-          non-MPN cells within CLUS_1550 (PVH, PVHap components). Cannot exclude Th
-          expression in MPN cells without single-cell spatial resolution.
-      - property: sex_ratio
-        node_a_value: "male-biased (SDN-POA has more cells in males)"
-        node_b_value: "male_female_ratio=3.35 (male-biased)"
-        alignment: CONSISTENT
-      - property: annotation_transfer_f1
-        node_a_value: "not applicable"
-        node_b_value: "NOT_ASSESSED"
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
         alignment: NOT_ASSESSED
-        notes: AT pipeline not run for sdn_poa_calbindin_neuron. MapMyCells on MPN Calb1+ data recommended.
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic nucleus [MBA:515]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=46 [painted]; Medial preoptic nucleus [MBA:515] count_100um=39 [painted]; Paraventricular hypothalamic nucleus [MBA:38] count_100um=25 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.812; strict region_fraction: 0.458; region_evidence: SELF'
+      - property: marker_Calb1
+        node_a_value: Calb1 — defining marker
+        node_b_value: 'Calb1: 6.66; cohort_pct 0.704'
+        alignment: CONSISTENT
+        notes: val=6.66; cohort percentile 0.704
+      - property: negative_marker_Th
+        node_a_value: Th — ABSENT (classical negative marker)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
     caveats:
       - caveat_type: MERFISH_REGISTRATION_UNCERTAINTY
-        description: >
-          SDN-POA is a histologically defined subnucleus within MPN; WMBv1 MERFISH cannot
-          resolve it as a distinct spatial domain. CLUS_1550 represents the best available
-          MPN-primary Calb1+ male-biased atlas cluster but cannot be confirmed to occupy the
-          SDN-POA cytoarchitectonic zone specifically.
+        description: "SDN-POA is a histologically defined subnucleus within MPN; WMBv1 MERFISH cannot resolve it as a distinct spatial domain. CS20230722_CLUS_1550 is the best available MPN-primary Calb1+ male-biased cluster but cannot be confirmed to occupy the SDN-POA cytoarchitectonic zone specifically.\n"
       - caveat_type: MARKER_NOT_SPECIFIC
-        description: >
-          Th=2.75 in CLUS_1550 is discordant with the classical Th NEGATIVE assertion.
-          Spatial inspection of Th channel in MERFISH data for CLUS_1550 cells at MBA:515 is
-          needed to determine whether Th expression co-occurs with MPN cells, or whether it
-          originates from the PVH/PVHap components of this multi-region cluster.
+        description: "Th=2.75 in CS20230722_CLUS_1550 is discordant with the classical somatic-Th-negative assertion. The cluster spans MBA:515, MBA:1097, and MBA:38; the Th signal may originate from the PVH / PVHap component rather than from MPN cells, but the apportionment cannot be made without spatial channel inspection.\n"
       - caveat_type: OTHER
-        description: '[AUTO_REPREDICATED_2026_05_26] Predicate auto-migrated from deprecated evidencell:PartialOverlapMatch to skos:closeMatch by `refresh_predicates.py`. Rule: rule-3b: no AT F1, DISCORDANT comparison(s), existing caveats → closeMatch. Curator review recommended.'
+        description: "[AUTO_REPREDICATED_2026_05_26] Predicate auto-migrated from deprecated evidencell:PartialOverlapMatch to skos:closeMatch by refresh_predicates.py. Curator review recommended; this verdict leaves the predicate as evidencell:UncertainRelationship pending the spatial inspection above.\n"
     unresolved_questions:
       - >
         Do CLUS_1550 cells at MBA:515 express Th, or does Th signal originate from
@@ -2247,15 +2841,48 @@ edges:
       - >
         Can sub-regional MERFISH spatial data distinguish SDN-POA dorsomedial cells
         from other MPN Calb1+ neurons within CLUS_1550?
+      - "Do CS20230722_CLUS_1550 cells at MBA:515 express Th, or does Th signal originate from PVH / PVHap components of this cluster?\n"
+      - "Can sub-regional MERFISH spatial data distinguish SDN-POA dorsomedial cells from other MPN Calb1+ neurons within CS20230722_CLUS_1550?\n"
     proposed_experiments:
-      - >
-        MapMyCells annotation transfer of MPN Calb1+ scRNA-seq data (Calb1-Cre or
-        SDN-POA-focused dataset) to assess F1 score against CLUS_1550.
-      - >
-        MERFISH spatial channel inspection of Th in CLUS_1550 cells assigned to MBA:515.
-
+      - "MERFISH Th-channel spatial inspection of CS20230722_CLUS_1550 cells assigned to MBA:515, to determine whether Th expression co-occurs with MPN cells or originates from the PVH / PVHap component.\n"
+      - "Sub-regional MERFISH spatial analysis within MBA:515 to test whether a subset of CS20230722_CLUS_1550 cells form a dorsomedial sub-cluster consistent with the histologically defined SDN-POA position.\n"
+      - "Cluster annotation transfer of MPN Calb1+ transcriptomic data (Calb1-driver-targeted or SDN-POA-focused dataset) to assess F1 against CS20230722_CLUS_1550 (target F1 >= 0.50 at cluster level).\n"
     mapping_justification: semapv:UnreviewedManualMapping
     mapping_cardinality: "1:1"
+    discovery_score:
+      score: 6
+      rank_in_cohort: 7
+      cohort_size: 50
+      next_best_score: 7
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:515
+            - sex_bias=male
+      expression_detail:
+        - gene: Calb1
+          val: 6.66
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.704
+      region_fraction: 0.458
+      region_fraction_100um: 0.812
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.3
+    rationale: "[tier:NEXT] CS20230722_CLUS_1550 is the only child of CS20230722_SUPT_0423 whose primary soma location is MBA:515 (region_fraction_100um: 0.812; strict region_fraction: 0.458), and its MFR=3.35 male-biased sex ratio aligns with the male-biased SDN-POA dimorphism. Calb1=6.66 (cohort percentile 0.704) matches the classical defining marker. Concerns: Th=2.75 is discordant with the classical somatic-negative Th assertion, but the cluster spans MBA:515, MBA:1097, and MBA:38, so the Th signal may originate from non-MPN cells; SDN-POA cannot be resolved as a distinct MERFISH spatial domain within MPN.\n"
+    reconciliation_note: "Paired with parent supertype edge to CS20230722_SUPT_0423; see report.\n"
+    rationale_generated_at: '2026-06-08T18:35:21+00:00'
+    report_path: reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+    rationale_source_hash: fd8767a6
   - id: edge_pmv_otr_neuron_to_cs20230722_clus_2470
     lit_type: pmv_otr_neuron
     taxonomy_type: CS20230722_CLUS_2470
@@ -2271,53 +2898,39 @@ edges:
           expressing PMv cells into this cluster. MFR is absent from the DB for this cluster;
           male-biased sex ratio cannot be confirmed at cluster level. Confidence is LOW
           pending sex bias confirmation and annotation transfer.
-    property_comparisons:
-      - property: location_MBA1004_PMv
-        node_a_value: "MBA:1004 (Ventral premammillary nucleus)"
-        node_b_value: "MBA:1004 (PMv) n=192 (primary soma — dominant location)"
+    property_comparisons: &id011
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Glut
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventral premammillary nucleus [MBA:1004]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=284 [painted]; Ventral premammillary nucleus [MBA:1004] count_100um=255 [painted]; Dorsomedial nucleus of the hypothalamus [MBA:830] count_100um=99 [painted]
         alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.898; strict region_fraction: 0.676; region_evidence: SELF'
       - property: marker_Oxtr
-        node_a_value: "POSITIVE (transcript, defining marker)"
-        node_b_value: "precomputed mean_expression=4.45 (vs supertype mean 2.0)"
-        alignment: CONSISTENT
-        notes: Expression substantially above supertype mean; confirms Oxtr-enriched subpopulation.
+        node_a_value: Oxtr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
       - property: marker_Slc6a3
-        node_a_value: "POSITIVE (transcript, defining marker)"
-        node_b_value: "precomputed mean_expression=6.02 (vs supertype mean 3.07)"
-        alignment: CONSISTENT
+        node_a_value: Slc6a3 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
       - property: marker_Adcyap1
-        node_a_value: "POSITIVE (defining marker)"
-        node_b_value: "precomputed mean_expression=8.13 (vs supertype mean 4.8)"
-        alignment: CONSISTENT
-      - property: sex_ratio
-        node_a_value: "male-biased (PMv OTR expression higher in males, P14-P56)"
-        node_b_value: "NOT_ASSESSED — MFR absent from DB for CLUS_2470"
+        node_a_value: Adcyap1 — defining marker
+        node_b_value: no atlas expression data
         alignment: NOT_ASSESSED
-        notes: >
-          MFR data absent for CLUS_2470 despite n=192 cells. This is the primary gap
-          limiting confidence. CLUS_2473 (PMv, n=86, MFR=2.23) has mild male bias but
-          very low marker expression — it is a distinct PMv subtype.
-      - property: annotation_transfer_f1
-        node_a_value: "not applicable"
-        node_b_value: "NOT_ASSESSED"
-        alignment: NOT_ASSESSED
-        notes: AT pipeline not run for pmv_otr_neuron. Key experiment to confirm sex bias alignment.
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
     caveats:
       - caveat_type: OTHER
-        description: >
-          The classical pmv_otr_neuron is MALE_BIASED but MFR is absent from the DB for
-          CLUS_2470. Until sex bias is confirmed at cluster level, confidence is capped at
-          LOW. The absent MFR may reflect a DB ingest gap rather than genuine absence in
-          the precomputed stats.
+        description: "Male-bias (MFR) not retrievable for CLUS_2470 — the classical definition is explicitly male-biased ([2]) but the male/female ratio is currently absent from the precomputed-stats DB for this cluster; absence may reflect a DB ingest gap rather than a genuine signal, and confidence is capped at LOW until the male bias is confirmed.\n"
       - caveat_type: AMBIGUOUS_MAPPING
-        description: >
-          CLUS_2470 co-expresses Oxtr, Slc6a3, and Adcyap1 at levels suggesting it
-          captures the PMv-OTR, PMv-DAT, and PMv-PACAP subpopulations simultaneously.
-          If these are functionally distinct cell types, a single cluster-level edge
-          conflates them. Node splitting (pmv_otr, pmv_dat, pmv_pacap) may be required
-          before a higher-confidence cluster assignment can be made.
+        description: "Single-cluster aggregation of three potentially distinct subpopulations — CLUS_2470 co-expresses Oxtr, Slc6a3, and Adcyap1 at high levels, and if PMv-OTR, PMv-DAT, and PMv-PACAP are functionally distinct cell types within PMv, a single cluster-level edge conflates them; resolution at sub-cluster level would test whether the three marker signatures co-localise per cell or label distinct populations within the cluster.\n"
       - caveat_type: OTHER
-        description: '[AUTO_REPREDICATED_2026_05_26] Predicate auto-migrated from deprecated evidencell:PartialOverlapMatch to skos:closeMatch by `refresh_predicates.py`. Rule: rule-3b: no AT F1, existing caveats → closeMatch. Curator review recommended.'
+        description: "Sister cluster CLUS_2471 in the same supertype also sits in PMv but with lower proximity (region_fraction_100um=0.676; strict=0.341) and weaker marker co-expression in the gathered facts — it may capture additional PMv-resident OTR+ cells not in CLUS_2470, contributing to the supertype-level aggregation.\n"
     unresolved_questions:
       - >
         Why is MFR absent for CLUS_2470 (n=192 cells)? Is this a DB ingest gap or
@@ -2325,15 +2938,52 @@ edges:
       - >
         Do Oxtr, Slc6a3, and Adcyap1 co-localise within individual CLUS_2470 cells,
         or do they mark distinct subpopulations within the cluster?
+      - "Why is MFR absent for CLUS_2470 (n=192 PMv cells)? DB ingest gap or genuine absence in precomputed stats?\n"
     proposed_experiments:
-      - >
-        Query precomputed HDF5 directly for CLUS_2470 male_female_ratio to confirm
-        whether MFR is missing from DB ingest or genuinely absent.
-      - >
-        MapMyCells annotation transfer of published PMv scRNA-seq or Oxtr-Cre /
-        Slc6a3-Cre lineage data against WMBv1 for F1-based evidence on CLUS_2470.
-    mapping_justification: semapv:UnreviewedManualMapping
+      - "Direct query of the precomputed HDF5 for CLUS_2470 male/female ratio to confirm whether the male bias documented for PMv OTR+ tissue [2] is reflected at this cluster, and whether the DB-level MFR absence is a genuine signal or an ingest gap; confirmed male predominance would lift cluster confidence to MODERATE.\n"
+      - "Within-cluster single-cell inspection (or cluster-resolved gene co-expression analysis) for Oxtr, Slc6a3, and Adcyap1 to determine whether the three classical subpopulations co-occur in individual cells or segregate within CLUS_2470.\n"
+      - "Cluster annotation transfer of published PMv lineage transcriptomic data (Oxtr-Cre, Slc6a3-Cre, or Adcyap1-Cre profiled cells) against WMBv1, with F1 >= 0.6 to CLUS_2470 at cluster level, to add a direct experimental anchor.\n"
+    mapping_justification: semapv:ManualMappingCuration
     mapping_cardinality: "1:1"
+    discovery_score: &id012
+      score: 5
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 5
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:1004
+            - sex_bias=male
+      expression_detail:
+        - gene: Slc6a3
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: Adcyap1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.676
+      region_fraction_100um: 0.898
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.38
+    rationale: "[tier:NEXT] CLUS_2470 is the PMv-leading child of SUPT_0607 (region_fraction_100um=0.898; strict=0.676; 255/451 cells in PMv) and concentrates the supertype's classical-marker expression (Oxtr=4.45, Slc6a3=6.02, Adcyap1=8.13); confidence held at LOW pending male-bias confirmation (MFR missing from precomputed-stats DB) and within-cluster co-expression resolution of the three putative subpopulations.\n"
+    reconciliation_note: "Cluster-level secondary to the supertype primary (CS20230722_SUPT_0607, MODERATE broadMatch); the cluster call is non-exact (close, not exact) because the cluster appears to aggregate the three classical marker-defined subpopulations into a single transcriptomic unit.\n"
+    rationale_generated_at: '2026-06-08T18:35:27+00:00'
+    report_path: reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+    rationale_source_hash: d2e90e73
   - id: edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1301
     lit_type: avpv_kiss1_neuron
     taxonomy_type: CS20230722_CLUS_1301
@@ -2912,24 +3562,2736 @@ edges:
       - evidence_type: ATLAS_METADATA
         supports: PARTIAL
         explanation: Atlas node 0486 PVpo-VMPO-MPN Hmx2 Gaba_5; region_fraction_100um=0.061; strict region_fraction=0.043.
+    property_comparisons: *id001
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: 'DISCORDANT property comparison(s): location. Mapping has unresolved counter-evidence.'
+    discovery_score: *id002
+  - id: edge_avpv_th_neuron_to_CS20230722_CLUS_1915
+    lit_type: avpv_th_neuron
+    taxonomy_type: CS20230722_CLUS_1915
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1915 PVpo-VMPO-MPN Hmx2 Gaba_5; region_fraction_100um=0.071; strict region_fraction=0.029.
+    property_comparisons: *id003
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "Duplicate of substantive edge on CS20230722_CLUS_1915; retain the lowercase-ID edge which carries the full caveat and evidence set.\n"
+    discovery_score: *id004
+    confidence: UNCERTAIN
+    confidence_score: 0.1
+    rationale: "[tier:CUT] Duplicate fresh-emit edge against the same taxonomy_type CS20230722_CLUS_1915 as the substantive lowercase-ID edge; this stub carries only PARTIAL ATLAS_METADATA with region_fraction_100um=0.071 and no curator caveats. Surfaced for curator removal.\n"
+    rationale_generated_at: '2026-06-08T18:35:20+00:00'
+    report_path: reports/sexually_dimorphic/avpv_th_neuron_summary.md
+    unresolved_questions:
+      - "Curator removal of duplicate edge edge_avpv_th_neuron_to_CS20230722_CLUS_1915 — legacy/fresh-emit ID collision on taxonomy_type CS20230722_CLUS_1915.\n"
+    rationale_source_hash: 6577367a
+  - id: edge_avpv_th_neuron_to_CS20230722_CLUS_1469
+    lit_type: avpv_th_neuron
+    taxonomy_type: CS20230722_CLUS_1469
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1469 MPO-ADP Lhx8 Gaba_3; region_fraction_100um=0.053; strict region_fraction=0.021.
     property_comparisons:
       - property: nt_type
-        node_a_value: "GABAergic / dopaminergic (TH co-expression)"
-        node_b_value: not asserted
-        alignment: NOT_ASSESSED
-        notes: NT data missing on one side.
+        node_a_value: "dopaminergic"
+        node_b_value: Dopa
+        alignment: CONSISTENT
+        notes: Stage A NT prefix-match passed.
       - property: location
-        node_a_value: Anteroventral periventricular nucleus [MBA:272]; Periventricular hypothalamic nucleus, posterior part [MBA:126]
-        node_b_value: Hypothalamus [MBA:1097] count_100um=381 [painted]; Periventricular hypothalamic nucleus, preoptic part [MBA:133] count_100um=354 [painted]; Medial preoptic nucleus [MBA:515] count_100um=276 [painted]
+        node_a_value: Anteroventral periventricular nucleus [MBA:272]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=88 [painted]; Periventricular hypothalamic nucleus, preoptic part [MBA:133] count_100um=34 [painted]; third ventricle [MBA:129] count_100um=24 [painted]
         alignment: DISCORDANT
-        notes: 'region_fraction_100um: 0.061; strict region_fraction: 0.043; region_evidence: SELF'
+        notes: 'region_fraction_100um: 0.053; strict region_fraction: 0.021; region_evidence: SELF'
+      - property: marker_Th
+        node_a_value: Th — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
       - property: marker_Kiss1
         node_a_value: Kiss1 — defining marker
         node_b_value: no atlas expression data
         alignment: NOT_ASSESSED
         notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: DISCORDANT_ANATOMY
+        description: "region_fraction_100um=0.053 at MBA:272; soma distribution centred on MPO and the third ventricle, not AVPV.\n"
+    discovery_score:
+      score: 2
+      rank_in_cohort: 2
+      cohort_size: 10
+      next_best_score: 2
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 10
+          filters:
+            - region=MBA:272
+            - nt_type=dopaminergic
+            - sex_bias=female
+      expression_detail:
+        - gene: Th
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.021
+      region_fraction_100um: 0.053
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.15
+    rationale: "[tier:CUT] CS20230722_CLUS_1469 carries a Dopa annotation but its soma sit in the MPO/ADP (MBA:133 / third ventricle) with region_fraction_100um=0.053 at MBA:272 — too distant from the AVPV to plausibly host the classical Th/Kiss1 population, and no Th/Kiss1 expression signal stands out at the cluster level.\n"
+    rationale_generated_at: '2026-06-08T18:35:20+00:00'
+    report_path: reports/sexually_dimorphic/avpv_th_neuron_summary.md
+    rationale_source_hash: 65f0e3e9
+  - id: edge_avpv_th_neuron_to_CS20230722_CLUS_5246
+    lit_type: avpv_th_neuron
+    taxonomy_type: CS20230722_CLUS_5246
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 5246 Tanycyte NN_2; region_fraction_100um=0.148; strict region_fraction=0.049.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: "dopaminergic"
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Anteroventral periventricular nucleus [MBA:272]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=456 [painted]; third ventricle [MBA:129] count_100um=443 [painted]; Periventricular hypothalamic nucleus, intermediate part [MBA:118] count_100um=363 [painted]
+        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.148; strict region_fraction: 0.049; region_evidence: SELF'
       - property: marker_Th
         node_a_value: Th — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Kiss1
+        node_a_value: Kiss1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: OTHER
+        description: "Non-neuronal lineage (tanycyte); cannot host the classical AVPV TH neuron regardless of region overlap.\n"
+    discovery_score:
+      score: 2
+      rank_in_cohort: 3
+      cohort_size: 10
+      next_best_score: 2
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 10
+          filters:
+            - region=MBA:272
+            - nt_type=dopaminergic
+            - sex_bias=female
+      expression_detail: []
+      region_fraction: 0.049
+      region_fraction_100um: 0.148
+      region_evidence: SELF
+    confidence: REFUTED
+    confidence_score: 0.05
+    rationale: "[tier:CUT] CS20230722_CLUS_5246 is a Tanycyte NN_2 cluster (non-neuronal, ependymal lineage) with soma centred on the third ventricle and intermediate periventricular hypothalamus; incompatible with a neuronal Th/Kiss1 dopaminergic identity regardless of any partial proximity to MBA:272.\n"
+    rationale_generated_at: '2026-06-08T18:35:20+00:00'
+    report_path: reports/sexually_dimorphic/avpv_th_neuron_summary.md
+    rationale_source_hash: 9f161064
+  - id: edge_avpv_th_neuron_to_CS20230722_CLUS_1910
+    lit_type: avpv_th_neuron
+    taxonomy_type: CS20230722_CLUS_1910
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1910 PVpo-VMPO-MPN Hmx2 Gaba_4; region_fraction_100um=0.260; strict region_fraction=0.208.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: "dopaminergic"
+        node_b_value: Dopa
+        alignment: CONSISTENT
+        notes: Stage A NT prefix-match passed.
+      - property: location
+        node_a_value: Anteroventral periventricular nucleus [MBA:272]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=49 [painted]; Periventricular hypothalamic nucleus, preoptic part [MBA:133] count_100um=41 [painted]; Medial preoptic nucleus [MBA:515] count_100um=32 [painted]
+        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.260; strict region_fraction: 0.208; region_evidence: SELF'
+      - property: marker_Th
+        node_a_value: Th — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Kiss1
+        node_a_value: Kiss1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "Adjacent Hmx2-lineage cluster lacking the defining female-biased Th/Kiss1 signature on which the mapping rests.\n"
+    discovery_score:
+      score: 2
+      rank_in_cohort: 4
+      cohort_size: 10
+      next_best_score: 2
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 10
+          filters:
+            - region=MBA:272
+            - nt_type=dopaminergic
+            - sex_bias=female
+      expression_detail: []
+      region_fraction: 0.208
+      region_fraction_100um: 0.26
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_CLUS_1910 (PVpo-VMPO-MPN Hmx2 Gaba_4, sibling of the primary SUPT_0486 lineage) is Dopa-annotated and has region_fraction_100um=0.260 at MBA:272 but shows no standout Th, Kiss1, or female-bias signal at the cluster level; the dimorphic AVPV Th/Kiss1 profile that anchors the mapping sits in CS20230722_CLUS_1915, not here.\n"
+    rationale_generated_at: '2026-06-08T18:35:20+00:00'
+    report_path: reports/sexually_dimorphic/avpv_th_neuron_summary.md
+    rationale_source_hash: 09f485ba
+  - id: edge_avpv_th_neuron_to_CS20230722_CLUS_5211
+    lit_type: avpv_th_neuron
+    taxonomy_type: CS20230722_CLUS_5211
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 5211 Astro-NT NN_1; region_fraction_100um=0.035; strict region_fraction=0.030.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: "dopaminergic"
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Anteroventral periventricular nucleus [MBA:272]
+        node_b_value: Striatum [MBA:477] count_100um=403 [painted]; cranial nerves [MBA:967] count_100um=352 [painted]; Olfactory areas [MBA:698] count_100um=322 [painted]
+        alignment: DISCORDANT
+        notes: 'region_fraction_100um: 0.035; strict region_fraction: 0.030; region_evidence: SELF'
+      - property: marker_Th
+        node_a_value: Th — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Kiss1
+        node_a_value: Kiss1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: OTHER
+        description: "Non-neuronal lineage (astrocyte) and soma in striatal/olfactory regions far from MBA:272.\n"
+    discovery_score:
+      score: 1
+      rank_in_cohort: 5
+      cohort_size: 10
+      next_best_score: 2
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 10
+          filters:
+            - region=MBA:272
+            - nt_type=dopaminergic
+            - sex_bias=female
+      expression_detail: []
+      region_fraction: 0.03
+      region_fraction_100um: 0.035
+      region_evidence: SELF
+    confidence: REFUTED
+    confidence_score: 0.05
+    rationale: "[tier:CUT] CS20230722_CLUS_5211 is an Astro-NT NN_1 cluster (non-neuronal, astrocytic lineage) with soma centred on striatum, cranial nerves, and olfactory areas; incompatible with a neuronal AVPV Th/Kiss1 identity.\n"
+    rationale_generated_at: '2026-06-08T18:35:20+00:00'
+    report_path: reports/sexually_dimorphic/avpv_th_neuron_summary.md
+    rationale_source_hash: da812e81
+  - id: edge_avpv_th_neuron_to_CS20230722_SUPT_0550
+    lit_type: avpv_th_neuron
+    taxonomy_type: CS20230722_SUPT_0550
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0550 MPN-MPO-PVpo Hmx2 Glut_5; region_fraction_100um=0.733; strict region_fraction=0.612.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: "dopaminergic"
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Anteroventral periventricular nucleus [MBA:272]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=144 [painted]; Anteroventral periventricular nucleus [MBA:272] count_100um=107 [painted]; third ventricle [MBA:129] count_100um=79 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.733; strict region_fraction: 0.612; region_evidence: SELF'
+      - property: marker_Th
+        node_a_value: Th — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Kiss1
+        node_a_value: Kiss1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: NT_PREDICTION_UNCERTAIN
+        description: "Glutamatergic supertype with no dopaminergic child cluster — incompatible with the classical type's dopaminergic identity.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 1
+      cohort_size: 12
+      next_best_score: 2
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 12
+          filters:
+            - region=MBA:272
+            - nt_type=dopaminergic
+            - sex_bias=female
+      expression_detail: []
+      region_fraction: 0.612
+      region_fraction_100um: 0.733
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_SUPT_0550 (MPN-MPO-PVpo Hmx2 Glut_5) is glutamatergic and lacks any Dopa-annotated child cluster, despite a very high region_fraction_100um=0.733 at MBA:272. Without dopaminergic identity or a Th/Kiss1-carrying child cluster, region overlap alone does not place the classical AVPV TH neuron here.\n"
+    rationale_generated_at: '2026-06-08T18:35:20+00:00'
+    report_path: reports/sexually_dimorphic/avpv_th_neuron_summary.md
+    rationale_source_hash: 95633e2c
+  - id: edge_avpv_th_neuron_to_CS20230722_SUPT_1172
+    lit_type: avpv_th_neuron
+    taxonomy_type: CS20230722_SUPT_1172
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1172 Tanycyte NN_1; region_fraction_100um=0.243; strict region_fraction=0.098.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: "dopaminergic"
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Anteroventral periventricular nucleus [MBA:272]
+        node_b_value: third ventricle [MBA:129] count_100um=455 [painted]; Hypothalamus [MBA:1097] count_100um=317 [painted]; lateral ventricle [MBA:81] count_100um=219 [painted]
+        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.243; strict region_fraction: 0.098; region_evidence: SELF'
+      - property: marker_Th
+        node_a_value: Th — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Kiss1
+        node_a_value: Kiss1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: OTHER
+        description: "Non-neuronal lineage (tanycyte); cannot host the classical AVPV TH neuron.\n"
+    discovery_score:
+      score: 2
+      rank_in_cohort: 2
+      cohort_size: 12
+      next_best_score: 2
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 12
+          filters:
+            - region=MBA:272
+            - nt_type=dopaminergic
+            - sex_bias=female
+      expression_detail: []
+      region_fraction: 0.098
+      region_fraction_100um: 0.243
+      region_evidence: SELF
+    confidence: REFUTED
+    confidence_score: 0.05
+    rationale: "[tier:CUT] CS20230722_SUPT_1172 (Tanycyte NN_1) is non-neuronal (ependymal tanycyte lineage); incompatible with a neuronal Th/Kiss1 dopaminergic identity regardless of partial periventricular overlap.\n"
+    rationale_generated_at: '2026-06-08T18:35:20+00:00'
+    report_path: reports/sexually_dimorphic/avpv_th_neuron_summary.md
+    rationale_source_hash: d25a79f4
+  - id: edge_avpv_th_neuron_to_CS20230722_SUPT_0419
+    lit_type: avpv_th_neuron
+    taxonomy_type: CS20230722_SUPT_0419
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0419 PVR Six3 Sox3 Gaba_9; region_fraction_100um=0.348; strict region_fraction=0.171.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: "dopaminergic"
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Anteroventral periventricular nucleus [MBA:272]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=249 [painted]; Medial preoptic area [MBA:523] count_100um=153 [painted]; Pallidum [MBA:803] count_100um=103 [painted]
+        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.348; strict region_fraction: 0.171; region_evidence: SELF'
+      - property: marker_Th
+        node_a_value: Th — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Kiss1
+        node_a_value: Kiss1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: NT_PREDICTION_UNCERTAIN
+        description: "GABAergic supertype with no dopaminergic child cluster; lacks the defining classical-type Th/Kiss1 dopaminergic identity.\n"
+    discovery_score:
+      score: 2
+      rank_in_cohort: 3
+      cohort_size: 12
+      next_best_score: 2
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 12
+          filters:
+            - region=MBA:272
+            - nt_type=dopaminergic
+            - sex_bias=female
+      expression_detail: []
+      region_fraction: 0.171
+      region_fraction_100um: 0.348
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.15
+    rationale: "[tier:CUT] CS20230722_SUPT_0419 (PVR Six3 Sox3 Gaba_9) is a periventricular GABAergic supertype without dopaminergic identity or a Th/Kiss1-defining child cluster, and region_fraction_100um=0.348 at MBA:272 reflects preoptic overlap rather than AVPV-specific placement.\n"
+    rationale_generated_at: '2026-06-08T18:35:20+00:00'
+    report_path: reports/sexually_dimorphic/avpv_th_neuron_summary.md
+    rationale_source_hash: 3bb566e2
+  - id: edge_avpv_th_neuron_to_CS20230722_SUPT_0485
+    lit_type: avpv_th_neuron
+    taxonomy_type: CS20230722_SUPT_0485
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0485 PVpo-VMPO-MPN Hmx2 Gaba_4; region_fraction_100um=0.372; strict region_fraction=0.339.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: "dopaminergic"
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Anteroventral periventricular nucleus [MBA:272]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=109 [painted]; Periventricular hypothalamic nucleus, preoptic part [MBA:133] count_100um=78 [painted]; Medial preoptic nucleus [MBA:515] count_100um=67 [painted]
+        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.372; strict region_fraction: 0.339; region_evidence: SELF'
+      - property: marker_Th
+        node_a_value: Th — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Kiss1
+        node_a_value: Kiss1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "Sibling Hmx2-lineage supertype without the defining female-biased Th/Kiss1 dopaminergic child cluster.\n"
+    discovery_score:
+      score: 2
+      rank_in_cohort: 4
+      cohort_size: 12
+      next_best_score: 2
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 12
+          filters:
+            - region=MBA:272
+            - nt_type=dopaminergic
+            - sex_bias=female
+      expression_detail: []
+      region_fraction: 0.339
+      region_fraction_100um: 0.372
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_SUPT_0485 (PVpo-VMPO-MPN Hmx2 Gaba_4) is the immediate Hmx2-lineage sibling of the primary SUPT_0486 anchor but lacks a Dopa-annotated Th/Kiss1-carrying child cluster equivalent to CS20230722_CLUS_1915; the AVPV Th/Kiss1 dimorphic signal is concentrated in the SUPT_0486 lineage, not here.\n"
+    rationale_generated_at: '2026-06-08T18:35:20+00:00'
+    report_path: reports/sexually_dimorphic/avpv_th_neuron_summary.md
+    rationale_source_hash: 5a22bd75
+  - id: edge_avpv_th_neuron_to_CS20230722_SUPT_0400
+    lit_type: avpv_th_neuron
+    taxonomy_type: CS20230722_SUPT_0400
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0400 SI-MPO-LPO Lhx8 Gaba_5; region_fraction_100um=0.022; strict region_fraction=0.007.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: "dopaminergic"
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Anteroventral periventricular nucleus [MBA:272]
+        node_b_value: Pallidum [MBA:803] count_100um=172 [painted]; Hypothalamus [MBA:1097] count_100um=166 [painted]; Substantia innominata [MBA:342] count_100um=119 [painted]
+        alignment: DISCORDANT
+        notes: 'region_fraction_100um: 0.022; strict region_fraction: 0.007; region_evidence: SELF'
+      - property: marker_Th
+        node_a_value: Th — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Kiss1
+        node_a_value: Kiss1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: DISCORDANT_ANATOMY
+        description: "region_fraction_100um=0.022 at MBA:272; soma centred on substantia innominata and lateral preoptic area, far from AVPV.\n"
+    discovery_score:
+      score: 1
+      rank_in_cohort: 5
+      cohort_size: 12
+      next_best_score: 2
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 12
+          filters:
+            - region=MBA:272
+            - nt_type=dopaminergic
+            - sex_bias=female
+      expression_detail: []
+      region_fraction: 0.007
+      region_fraction_100um: 0.022
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_SUPT_0400 (SI-MPO-LPO Lhx8 Gaba_5) is centred on substantia innominata / MPO / LPO with region_fraction_100um=0.022 at MBA:272 — too distant from the AVPV — and lacks any dopaminergic or Th/Kiss1 signal.\n"
+    rationale_generated_at: '2026-06-08T18:35:20+00:00'
+    report_path: reports/sexually_dimorphic/avpv_th_neuron_summary.md
+    rationale_source_hash: 6ac876cb
+  - id: edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1304
+    lit_type: sdn_poa_calbindin_neuron
+    taxonomy_type: CS20230722_CLUS_1304
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1304 MEA-BST Lhx6 Nfib Gaba_5; region_fraction_100um=0.605; strict region_fraction=0.581.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic nucleus [MBA:515]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=28 [painted]; Medial preoptic nucleus [MBA:515] count_100um=26 [painted]; Bed nuclei of the stria terminalis [MBA:351] count_100um=16 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.605; strict region_fraction: 0.581; region_evidence: SELF'
+      - property: marker_Calb1
+        node_a_value: Calb1 — defining marker
+        node_b_value: 'Calb1: 10.28; cohort_pct 0.997'
+        alignment: CONSISTENT
+        notes: val=10.28; cohort percentile 0.997
+      - property: negative_marker_Th
+        node_a_value: Th — ABSENT (classical negative marker)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 7
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 7
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:515
+            - sex_bias=male
+      expression_detail:
+        - gene: Calb1
+          val: 10.28
+          reliable: true
+          raw_tier: 2
+          applied_score: 2.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.997
+      region_fraction: 0.581
+      region_fraction_100um: 0.605
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_CLUS_1304 belongs to the MEA-BST Lhx6 Nfib Gaba lineage rather than the BST-MPN Six3 Nrgn Gaba lineage that anchors the MPN-primary candidates; although Calb1=10.28 is high and region_fraction_100um: 0.605 includes MBA:515, the dominant anatomical assignment is non-MPN and the subclass is inconsistent with the classical SDN-POA's medial preoptic identity.\n"
+    rationale_generated_at: '2026-06-08T18:35:21+00:00'
+    report_path: reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+    rationale_source_hash: 33fe5792
+  - id: edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1305
+    lit_type: sdn_poa_calbindin_neuron
+    taxonomy_type: CS20230722_CLUS_1305
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1305 MEA-BST Lhx6 Nfib Gaba_5; region_fraction_100um=0.600; strict region_fraction=0.250.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic nucleus [MBA:515]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=19 [painted]; Medial preoptic nucleus [MBA:515] count_100um=12 [painted]; Anteroventral periventricular nucleus [MBA:272] count_100um=7 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.600; strict region_fraction: 0.250; region_evidence: SELF'
+      - property: marker_Calb1
+        node_a_value: Calb1 — defining marker
+        node_b_value: 'Calb1: 8.89; cohort_pct 0.959'
+        alignment: CONSISTENT
+        notes: val=8.89; cohort percentile 0.959
+      - property: negative_marker_Th
+        node_a_value: Th — ABSENT (classical negative marker)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 7
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 7
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:515
+            - sex_bias=male
+      expression_detail:
+        - gene: Calb1
+          val: 8.89
+          reliable: true
+          raw_tier: 2
+          applied_score: 2.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.959
+      region_fraction: 0.25
+      region_fraction_100um: 0.6
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_CLUS_1305 belongs to the MEA-BST Lhx6 Nfib Gaba lineage and its secondary soma cohort is in MBA:272 (anteroventral periventricular nucleus), a female-biased structure distinct from the male-biased SDN-POA; Calb1=8.89 alone does not rescue the subclass mismatch.\n"
+    rationale_generated_at: '2026-06-08T18:35:21+00:00'
+    report_path: reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+    rationale_source_hash: f72c790c
+  - id: edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1303
+    lit_type: sdn_poa_calbindin_neuron
+    taxonomy_type: CS20230722_CLUS_1303
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1303 MEA-BST Lhx6 Nfib Gaba_4; region_fraction_100um=0.727; strict region_fraction=0.364.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic nucleus [MBA:515]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=11 [painted]; Medial preoptic nucleus [MBA:515] count_100um=8 [painted]; Posterodorsal preoptic nucleus [MBA:914] count_100um=6 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.727; strict region_fraction: 0.364; region_evidence: SELF'
+      - property: marker_Calb1
+        node_a_value: Calb1 — defining marker
+        node_b_value: 'Calb1: 8.52; cohort_pct 0.929'
+        alignment: CONSISTENT
+        notes: val=8.52; cohort percentile 0.929
+      - property: negative_marker_Th
+        node_a_value: Th — ABSENT (classical negative marker)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 6
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 7
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:515
+            - sex_bias=male
+      expression_detail:
+        - gene: Calb1
+          val: 8.52
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.929
+      region_fraction: 0.364
+      region_fraction_100um: 0.727
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_CLUS_1303 belongs to the MEA-BST Lhx6 Nfib Gaba lineage with a secondary soma cohort in MBA:914 (posterodorsal preoptic nucleus); the lineage and dominant anatomical signal are inconsistent with the classical SDN-POA's medial preoptic identity despite Calb1=8.52.\n"
+    rationale_generated_at: '2026-06-08T18:35:21+00:00'
+    report_path: reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+    rationale_source_hash: a3c09aec
+  - id: edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1310
+    lit_type: sdn_poa_calbindin_neuron
+    taxonomy_type: CS20230722_CLUS_1310
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1310 MEA-BST Lhx6 Nfib Gaba_5; region_fraction_100um=0.649; strict region_fraction=0.427.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic nucleus [MBA:515]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=89 [painted]; Medial preoptic nucleus [MBA:515] count_100um=63 [painted]; Pallidum [MBA:803] count_100um=28 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.649; strict region_fraction: 0.427; region_evidence: SELF'
+      - property: marker_Calb1
+        node_a_value: Calb1 — defining marker
+        node_b_value: 'Calb1: 7.37; cohort_pct 0.785'
+        alignment: CONSISTENT
+        notes: val=7.37; cohort percentile 0.785
+      - property: negative_marker_Th
+        node_a_value: Th — ABSENT (classical negative marker)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 6
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 7
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:515
+            - sex_bias=male
+      expression_detail:
+        - gene: Calb1
+          val: 7.37
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.785
+      region_fraction: 0.427
+      region_fraction_100um: 0.649
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_CLUS_1310 belongs to the MEA-BST Lhx6 Nfib Gaba lineage with a secondary soma cohort in MBA:803 (pallidum), distant from the classical SDN-POA in the medial preoptic nucleus; subclass mismatch not rescued by Calb1=7.37.\n"
+    rationale_generated_at: '2026-06-08T18:35:21+00:00'
+    report_path: reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+    rationale_source_hash: 112d9aa7
+  - id: edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1542
+    lit_type: sdn_poa_calbindin_neuron
+    taxonomy_type: CS20230722_CLUS_1542
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1542 BST-MPN Six3 Nrgn Gaba_3; region_fraction_100um=0.576; strict region_fraction=0.273.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic nucleus [MBA:515]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=33 [painted]; Anterior hypothalamic nucleus [MBA:88] count_100um=28 [painted]; Medial preoptic nucleus [MBA:515] count_100um=19 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.576; strict region_fraction: 0.273; region_evidence: SELF'
+      - property: marker_Calb1
+        node_a_value: Calb1 — defining marker
+        node_b_value: 'Calb1: 3.26; cohort_pct 0.408'
+        alignment: APPROXIMATE
+        notes: val=3.26; cohort percentile 0.408
+      - property: negative_marker_Th
+        node_a_value: Th — ABSENT (classical negative marker)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 6
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 7
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:515
+            - sex_bias=male
+      expression_detail:
+        - gene: Calb1
+          val: 3.26
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.408
+      region_fraction: 0.273
+      region_fraction_100um: 0.576
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_CLUS_1542 sits in the correct BST-MPN Six3 Nrgn Gaba lineage but Calb1=3.26 (cohort percentile 0.408) is below the cohort median, and the tertiary anatomical assignment to MBA:515 (after MBA:1097 and MBA:88) is weaker than its siblings.\n"
+    rationale_generated_at: '2026-06-08T18:35:21+00:00'
+    report_path: reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+    rationale_source_hash: 2dac93c5
+  - id: edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0360
+    lit_type: sdn_poa_calbindin_neuron
+    taxonomy_type: CS20230722_SUPT_0360
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0360 MEA-BST Lhx6 Nfib Gaba_4; region_fraction_100um=0.619; strict region_fraction=0.414.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic nucleus [MBA:515]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=94 [painted]; Medial preoptic nucleus [MBA:515] count_100um=70 [painted]; Periventricular hypothalamic nucleus, preoptic part [MBA:133] count_100um=45 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.619; strict region_fraction: 0.414; region_evidence: SELF'
+      - property: marker_Calb1
+        node_a_value: Calb1 — defining marker
+        node_b_value: 'Calb1: 8.68; cohort_pct 0.971; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=8.68; cohort percentile 0.971; child-cluster coverage 1.000
+      - property: negative_marker_Th
+        node_a_value: Th — ABSENT (classical negative marker)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 5
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 4
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:515
+            - sex_bias=male
+      expression_detail:
+        - gene: Calb1
+          val: 8.68
+          reliable: true
+          raw_tier: 2
+          applied_score: 2.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.971
+          coverage: 1.0
+      region_fraction: 0.414
+      region_fraction_100um: 0.619
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_SUPT_0360 carries high Calb1=8.68 (cohort percentile 0.971; child-coverage 1.000) but belongs to the MEA-BST Lhx6 Nfib Gaba lineage rather than the MPN-primary BST-MPN Six3 Nrgn Gaba lineage; the dominant soma cohort sits outside the medial preoptic nucleus.\n"
+    rationale_generated_at: '2026-06-08T18:35:21+00:00'
+    report_path: reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+    rationale_source_hash: d8d99562
+  - id: edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0420
+    lit_type: sdn_poa_calbindin_neuron
+    taxonomy_type: CS20230722_SUPT_0420
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0420 BST-MPN Six3 Nrgn Gaba_1; region_fraction_100um=0.903; strict region_fraction=0.759.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic nucleus [MBA:515]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=315 [painted]; Medial preoptic nucleus [MBA:515] count_100um=289 [painted]; Medial preoptic area [MBA:523] count_100um=78 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.903; strict region_fraction: 0.759; region_evidence: SELF'
+      - property: marker_Calb1
+        node_a_value: Calb1 — defining marker
+        node_b_value: 'Calb1: 6.53; cohort_pct 0.790; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=6.53; cohort percentile 0.790; child-cluster coverage 1.000
+      - property: negative_marker_Th
+        node_a_value: Th — ABSENT (classical negative marker)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: MERFISH_REGISTRATION_UNCERTAINTY
+        description: "SDN-POA is a histologically defined subnucleus within MPN that cannot be resolved as a distinct spatial domain in WMBv1 MERFISH data. The strong MPN concentration of CS20230722_SUPT_0420 does not specifically identify SDN-POA cells.\n"
+      - caveat_type: MARKER_NOT_SPECIFIC
+        description: "Calb1 is broadly expressed across hypothalamic and limbic GABAergic populations; its presence on CS20230722_SUPT_0420 is consistent with but not specific for SDN-POA identity.\n"
+    discovery_score:
+      score: 4
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 4
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:515
+            - sex_bias=male
+      expression_detail:
+        - gene: Calb1
+          val: 6.53
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.79
+          coverage: 1.0
+      region_fraction: 0.759
+      region_fraction_100um: 0.903
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.25
+    rationale: "[tier:WEAKEST] CS20230722_SUPT_0420 has the highest MPN concentration of any audited candidate (region_fraction_100um: 0.903; strict region_fraction: 0.759) with Calb1=6.53 (cohort percentile 0.790; child-coverage 1.000). No child-cluster breakdown was carried into this audit and no sex-ratio assessment is available at supertype level, so the male-biased dimorphism of the classical SDN-POA cannot be confirmed; SDN-POA cannot be resolved as a distinct MERFISH spatial domain within MPN.\n"
+    proposed_experiments:
+      - "Audit of CS20230722_SUPT_0420 child clusters at MBA:515 for male-biased MFR, to test whether a specific child cluster matches the male-biased SDN-POA dimorphism.\n"
+      - "Cluster annotation transfer of an MPN / SDN-POA Calb1+ transcriptomic dataset to the WMBv1 taxonomy to test whether source cells land on CS20230722_SUPT_0420 vs CS20230722_SUPT_0423.\n"
+    rationale_generated_at: '2026-06-08T18:35:21+00:00'
+    report_path: reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+    unresolved_questions:
+      - "Which children of CS20230722_SUPT_0420 in MBA:515 show male-biased sex ratio consistent with the SDN-POA dimorphism?\n"
+    rationale_source_hash: 713de243
+  - id: edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0422
+    lit_type: sdn_poa_calbindin_neuron
+    taxonomy_type: CS20230722_SUPT_0422
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0422 BST-MPN Six3 Nrgn Gaba_3; region_fraction_100um=0.768; strict region_fraction=0.583.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic nucleus [MBA:515]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=512 [painted]; Medial preoptic nucleus [MBA:515] count_100um=401 [painted]; Anterior hypothalamic nucleus [MBA:88] count_100um=194 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.768; strict region_fraction: 0.583; region_evidence: SELF'
+      - property: marker_Calb1
+        node_a_value: Calb1 — defining marker
+        node_b_value: 'Calb1: 5.49; cohort_pct 0.686; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=5.49; cohort percentile 0.686; child-cluster coverage 1.000
+      - property: negative_marker_Th
+        node_a_value: Th — ABSENT (classical negative marker)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 4
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 4
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:515
+            - sex_bias=male
+      expression_detail:
+        - gene: Calb1
+          val: 5.49
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.686
+          coverage: 1.0
+      region_fraction: 0.583
+      region_fraction_100um: 0.768
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_SUPT_0422 sits in the BST-MPN Six3 Nrgn Gaba lineage with MPN-primary location (region_fraction_100um: 0.768) but Calb1=5.49 (cohort percentile 0.686) is lower than its sibling supertypes CS20230722_SUPT_0420 and CS20230722_SUPT_0423, and no sex-ratio audit was carried at supertype level.\n"
+    rationale_generated_at: '2026-06-08T18:35:21+00:00'
+    report_path: reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+    rationale_source_hash: 433316c4
+  - id: edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0421
+    lit_type: sdn_poa_calbindin_neuron
+    taxonomy_type: CS20230722_SUPT_0421
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0421 BST-MPN Six3 Nrgn Gaba_2; region_fraction_100um=0.671; strict region_fraction=0.489.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic nucleus [MBA:515]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=119 [painted]; Medial preoptic nucleus [MBA:515] count_100um=94 [painted]; Medial preoptic area [MBA:523] count_100um=53 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.671; strict region_fraction: 0.489; region_evidence: SELF'
+      - property: marker_Calb1
+        node_a_value: Calb1 — defining marker
+        node_b_value: 'Calb1: 4.86; cohort_pct 0.590; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=4.86; cohort percentile 0.590; child-cluster coverage 1.000
+      - property: negative_marker_Th
+        node_a_value: Th — ABSENT (classical negative marker)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 4
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 4
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:515
+            - sex_bias=male
+      expression_detail:
+        - gene: Calb1
+          val: 4.86
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.59
+          coverage: 1.0
+      region_fraction: 0.489
+      region_fraction_100um: 0.671
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_SUPT_0421 sits in the BST-MPN Six3 Nrgn Gaba lineage with MPN-primary location (region_fraction_100um: 0.671) but Calb1=4.86 (cohort percentile 0.590) is modest, and the supertype is less anatomically concentrated in MBA:515 than CS20230722_SUPT_0420 or CS20230722_SUPT_0423.\n"
+    rationale_generated_at: '2026-06-08T18:35:21+00:00'
+    report_path: reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+    rationale_source_hash: d434645d
+  - id: edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0486
+    lit_type: sdn_poa_calbindin_neuron
+    taxonomy_type: CS20230722_SUPT_0486
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0486 PVpo-VMPO-MPN Hmx2 Gaba_5; region_fraction_100um=0.697; strict region_fraction=0.197.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic nucleus [MBA:515]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=381 [painted]; Periventricular hypothalamic nucleus, preoptic part [MBA:133] count_100um=354 [painted]; Medial preoptic nucleus [MBA:515] count_100um=276 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.697; strict region_fraction: 0.197; region_evidence: SELF'
+      - property: marker_Calb1
+        node_a_value: Calb1 — defining marker
+        node_b_value: 'Calb1: 4.16; cohort_pct 0.486; child-coverage 1.000'
+        alignment: APPROXIMATE
+        notes: val=4.16; cohort percentile 0.486; child-cluster coverage 1.000
+      - property: negative_marker_Th
+        node_a_value: Th — ABSENT (classical negative marker)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 4
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 4
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:515
+            - sex_bias=male
+      expression_detail:
+        - gene: Calb1
+          val: 4.16
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.486
+          coverage: 1.0
+      region_fraction: 0.197
+      region_fraction_100um: 0.697
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_SUPT_0486 (PVpo-VMPO-MPN Hmx2 Gaba_5) is primarily a periventricular preoptic supertype with its largest soma cohort outside MBA:515 (strict region_fraction: 0.197); Calb1=4.16 (cohort percentile 0.486; APPROXIMATE alignment) is below the cohort median.\n"
+    rationale_generated_at: '2026-06-08T18:35:21+00:00'
+    report_path: reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+    rationale_source_hash: c47f8f2e
+  - id: edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1466
+    lit_type: mpoa_esr1_neuron
+    taxonomy_type: CS20230722_CLUS_1466
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1466 MPO-ADP Lhx8 Gaba_3; region_fraction_100um=0.529; strict region_fraction=0.301.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic area [MBA:523]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=299 [painted]; Medial preoptic area [MBA:523] count_100um=174 [painted]; Pallidum [MBA:803] count_100um=112 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.529; strict region_fraction: 0.301; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 4
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 4
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:523
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.301
+      region_fraction_100um: 0.529
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_CLUS_1466 sits in MPO-ADP with region_fraction_100um=0.529 but carries no atlas-side expression for Esr1, Ar, or Pgr; anatomical proximity alone is insufficient to map a steroid-receptor-defined classical type.\n"
+    rationale_generated_at: '2026-06-08T18:35:22+00:00'
+    report_path: reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+    rationale_source_hash: cfdc1cd0
+  - id: edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1536
+    lit_type: mpoa_esr1_neuron
+    taxonomy_type: CS20230722_CLUS_1536
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1536 PVR Six3 Sox3 Gaba_9; region_fraction_100um=0.694; strict region_fraction=0.468.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic area [MBA:523]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=50 [painted]; Medial preoptic area [MBA:523] count_100um=43 [painted]; Anterodorsal preoptic nucleus [MBA:72] count_100um=29 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.694; strict region_fraction: 0.468; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 4
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 4
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:523
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.468
+      region_fraction_100um: 0.694
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_CLUS_1536 (PVR Six3 Sox3 Gaba_9) carries only an anatomical proximity signal (region_fraction_100um=0.694) with no atlas-side Esr1, Ar, or Pgr expression.\n"
+    rationale_generated_at: '2026-06-08T18:35:22+00:00'
+    report_path: reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+    rationale_source_hash: edc63230
+  - id: edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1885
+    lit_type: mpoa_esr1_neuron
+    taxonomy_type: CS20230722_CLUS_1885
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1885 PVpo-VMPO-MPN Hmx2 Gaba_1; region_fraction_100um=0.750; strict region_fraction=0.500.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic area [MBA:523]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=8 [painted]; Medial preoptic area [MBA:523] count_100um=6 [painted]; Anteroventral preoptic nucleus [MBA:263] count_100um=4 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.750; strict region_fraction: 0.500; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 4
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 4
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:523
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.5
+      region_fraction_100um: 0.75
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_CLUS_1885 (PVpo-VMPO-MPN Hmx2 Gaba_1) sits in the preoptic region (region_fraction_100um=0.750) but lacks atlas-side expression for the defining markers Esr1, Ar, Pgr.\n"
+    rationale_generated_at: '2026-06-08T18:35:22+00:00'
+    report_path: reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+    rationale_source_hash: 5561f826
+  - id: edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1887
+    lit_type: mpoa_esr1_neuron
+    taxonomy_type: CS20230722_CLUS_1887
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1887 PVpo-VMPO-MPN Hmx2 Gaba_1; region_fraction_100um=0.612; strict region_fraction=0.315.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic area [MBA:523]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=119 [painted]; Medial preoptic area [MBA:523] count_100um=79 [painted]; Anterior hypothalamic nucleus [MBA:88] count_100um=61 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.612; strict region_fraction: 0.315; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 4
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 4
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:523
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.315
+      region_fraction_100um: 0.612
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_CLUS_1887 (PVpo-VMPO-MPN Hmx2 Gaba_1) region_fraction_100um=0.612 but carries no atlas-side Esr1, Ar, or Pgr expression.\n"
+    rationale_generated_at: '2026-06-08T18:35:22+00:00'
+    report_path: reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+    rationale_source_hash: 4efc9526
+  - id: edge_mpoa_esr1_neuron_to_CS20230722_CLUS_2118
+    lit_type: mpoa_esr1_neuron
+    taxonomy_type: CS20230722_CLUS_2118
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 2118 ADP-MPO Trp73 Glut_1; region_fraction_100um=0.818; strict region_fraction=0.582.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Glut
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic area [MBA:523]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=55 [painted]; Medial preoptic area [MBA:523] count_100um=45 [painted]; Medial preoptic nucleus [MBA:515] count_100um=34 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.818; strict region_fraction: 0.582; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 4
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 4
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:523
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.582
+      region_fraction_100um: 0.818
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_CLUS_2118 (ADP-MPO Trp73 Glut_1) sits largely within MPO (region_fraction_100um=0.818) but lacks atlas-side expression for the defining steroid-receptor markers Esr1, Ar, Pgr.\n"
+    rationale_generated_at: '2026-06-08T18:35:22+00:00'
+    report_path: reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+    rationale_source_hash: 2bfbba1b
+  - id: edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0419
+    lit_type: mpoa_esr1_neuron
+    taxonomy_type: CS20230722_SUPT_0419
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0419 PVR Six3 Sox3 Gaba_9; region_fraction_100um=0.560; strict region_fraction=0.271.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic area [MBA:523]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=249 [painted]; Medial preoptic area [MBA:523] count_100um=153 [painted]; Pallidum [MBA:803] count_100um=103 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.560; strict region_fraction: 0.271; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 3
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:523
+      expression_detail: []
+      region_fraction: 0.271
+      region_fraction_100um: 0.56
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_SUPT_0419 (PVR Six3 Sox3 Gaba_9) carries anatomical proximity (region_fraction_100um=0.560) without atlas-side Esr1, Ar, or Pgr expression.\n"
+    rationale_generated_at: '2026-06-08T18:35:22+00:00'
+    report_path: reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+    rationale_source_hash: b3d2d713
+  - id: edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0403
+    lit_type: mpoa_esr1_neuron
+    taxonomy_type: CS20230722_SUPT_0403
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0403 MPO-ADP Lhx8 Gaba_2; region_fraction_100um=0.641; strict region_fraction=0.421.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic area [MBA:523]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=384 [painted]; Medial preoptic area [MBA:523] count_100um=280 [painted]; Pallidum [MBA:803] count_100um=190 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.641; strict region_fraction: 0.421; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 3
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:523
+      expression_detail: []
+      region_fraction: 0.421
+      region_fraction_100um: 0.641
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_SUPT_0403 (MPO-ADP Lhx8 Gaba_2) region_fraction_100um=0.641 with no atlas-side defining-marker expression.\n"
+    rationale_generated_at: '2026-06-08T18:35:22+00:00'
+    report_path: reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+    rationale_source_hash: 8d9767d5
+  - id: edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0401
+    lit_type: mpoa_esr1_neuron
+    taxonomy_type: CS20230722_SUPT_0401
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0401 SI-MPO-LPO Lhx8 Gaba_6; region_fraction_100um=0.812; strict region_fraction=0.312.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic area [MBA:523]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=16 [painted]; Lateral preoptic area [MBA:226] count_100um=16 [painted]; Medial preoptic area [MBA:523] count_100um=13 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.812; strict region_fraction: 0.312; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 3
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:523
+      expression_detail: []
+      region_fraction: 0.312
+      region_fraction_100um: 0.812
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_SUPT_0401 (SI-MPO-LPO Lhx8 Gaba_6) sits largely within preoptic zones (region_fraction_100um=0.812) but carries no atlas-side Esr1, Ar, or Pgr expression.\n"
+    rationale_generated_at: '2026-06-08T18:35:22+00:00'
+    report_path: reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+    rationale_source_hash: b1432974
+  - id: edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0348
+    lit_type: mpoa_esr1_neuron
+    taxonomy_type: CS20230722_SUPT_0348
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0348 MEA-BST Lhx6 Sp9 Gaba_2; region_fraction_100um=0.203; strict region_fraction=0.107.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic area [MBA:523]
+        node_b_value: Pallidum [MBA:803] count_100um=304 [painted]; Bed nuclei of the stria terminalis [MBA:351] count_100um=301 [painted]; Hypothalamus [MBA:1097] count_100um=270 [painted]
+        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.203; strict region_fraction: 0.107; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 3
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:523
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.107
+      region_fraction_100um: 0.203
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.15
+    rationale: "[tier:CUT] CS20230722_SUPT_0348 (MEA-BST Lhx6 Sp9 Gaba_2) is a medial-amygdala / BNST resident supertype with region_fraction_100um=0.203 (off-target); irrelevant to classical MPOA Esr1+ neurons.\n"
+    rationale_generated_at: '2026-06-08T18:35:22+00:00'
+    report_path: reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+    rationale_source_hash: f540f9e1
+  - id: edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0398
+    lit_type: mpoa_esr1_neuron
+    taxonomy_type: CS20230722_SUPT_0398
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0398 SI-MPO-LPO Lhx8 Gaba_3; region_fraction_100um=0.568; strict region_fraction=0.293.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Medial preoptic area [MBA:523]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=366 [painted]; Medial preoptic area [MBA:523] count_100um=239 [painted]; Medial preoptic nucleus [MBA:515] count_100um=163 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.568; strict region_fraction: 0.293; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 3
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:523
+      expression_detail: []
+      region_fraction: 0.293
+      region_fraction_100um: 0.568
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_SUPT_0398 (SI-MPO-LPO Lhx8 Gaba_3) region_fraction_100um=0.568 with no atlas-side defining-marker expression.\n"
+    rationale_generated_at: '2026-06-08T18:35:22+00:00'
+    report_path: reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+    rationale_source_hash: c7cc6ed6
+  - id: edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2290
+    lit_type: vmhvl_esr1_pr_neuron
+    taxonomy_type: CS20230722_CLUS_2290
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 2290 VMH Fezf1 Glut_1; region_fraction_100um=0.817; strict region_fraction=0.317.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Glut
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventromedial hypothalamic nucleus [MBA:693]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=60 [painted]; Tuberal nucleus [MBA:614] count_100um=50 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=49 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.817; strict region_fraction: 0.317; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Nkx2-1
+        node_a_value: Nkx2-1 — defining marker
+        node_b_value: 'Nkx2-1: 6.69; cohort_pct 0.989; atlas category: MERFISH'
+        alignment: CONSISTENT
+        notes: val=6.69; cohort percentile 0.989
+      - property: marker_Tac1
+        node_a_value: Tac1 — defining marker
+        node_b_value: 'Tac1: 6.07; cohort_pct 0.901; atlas category: NEUROPEPTIDE'
+        alignment: CONSISTENT
+        notes: val=6.07; cohort percentile 0.901
+      - property: neuropeptide_Tac1
+        node_a_value: Tac1 — neuropeptide (classical)
+        node_b_value: 'Tac1: 6.07; cohort_pct 0.901; atlas category: NEUROPEPTIDE'
+        alignment: CONSISTENT
+        notes: val=6.07; cohort percentile 0.901
+    caveats:
+      - caveat_type: TAXONOMY_LEVEL_MISMATCH
+        description: "CS20230722_CLUS_2290 represents the female-biased lordosis signal that is the basis for the edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563 cross-cutting mapping; treating it as a separate cluster-level target would double-count the SUPT_0563 evidence.\n"
+    discovery_score:
+      score: 7
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 7
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:693
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: Nkx2-1
+          val: 6.69
+          reliable: true
+          raw_tier: 2
+          applied_score: 2.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.989
+        - gene: Tac1
+          val: 6.07
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.901
+      region_fraction: 0.317
+      region_fraction_100um: 0.817
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.3
+    rationale: "[tier:CUT] CS20230722_CLUS_2290 is a SUPT_0563 child cluster (Nkx2-1=6.69 cohort pct 0.989, Tac1=6.07 cohort pct 0.901, region_fraction_100um: 0.817, MFR=0.08) and is among the top bulk-correlation hits (delta rank 2 / 5322 in the Knoedler 2022 PMID:35143761 VMH-FR vs BNST-FR contrast). The cluster-level signal is represented through the parent supertype edge edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563 rather than as an independent cluster-level mapping target.\n"
+    rationale_generated_at: '2026-06-08T18:35:23+00:00'
+    report_path: reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+    rationale_source_hash: 2f1d1e38
+  - id: edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2292
+    lit_type: vmhvl_esr1_pr_neuron
+    taxonomy_type: CS20230722_CLUS_2292
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 2292 VMH Fezf1 Glut_1; region_fraction_100um=1.000; strict region_fraction=0.500.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Glut
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventromedial hypothalamic nucleus [MBA:693]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=4 [painted]; Tuberal nucleus [MBA:614] count_100um=4 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=4 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 1.000; strict region_fraction: 0.500; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Nkx2-1
+        node_a_value: Nkx2-1 — defining marker
+        node_b_value: 'Nkx2-1: 6.28; cohort_pct 0.949; atlas category: MERFISH'
+        alignment: CONSISTENT
+        notes: val=6.28; cohort percentile 0.949
+      - property: marker_Tac1
+        node_a_value: Tac1 — defining marker
+        node_b_value: 'Tac1: 8.62; cohort_pct 0.964; atlas category: NEUROPEPTIDE'
+        alignment: CONSISTENT
+        notes: val=8.62; cohort percentile 0.964
+      - property: neuropeptide_Tac1
+        node_a_value: Tac1 — neuropeptide (classical)
+        node_b_value: 'Tac1: 8.62; cohort_pct 0.964; atlas category: NEUROPEPTIDE'
+        alignment: CONSISTENT
+        notes: val=8.62; cohort percentile 0.964
+    caveats:
+      - caveat_type: TAXONOMY_LEVEL_MISMATCH
+        description: "CS20230722_CLUS_2292 is a child of CS20230722_SUPT_0563 and contributes to the supertype-level cross-cutting mapping; not treated as an independent cluster-level target.\n"
+    discovery_score:
+      score: 7
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 7
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:693
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: Nkx2-1
+          val: 6.28
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.949
+        - gene: Tac1
+          val: 8.62
+          reliable: true
+          raw_tier: 2
+          applied_score: 2.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.964
+      region_fraction: 0.5
+      region_fraction_100um: 1.0
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.3
+    rationale: "[tier:CUT] CS20230722_CLUS_2292 is a SUPT_0563 child cluster (Nkx2-1=6.28 cohort pct 0.949, Tac1=8.62 cohort pct 0.964, region_fraction_100um: 1.000, MFR=0.12) and ranks at delta rank 4 of 5322 in the Knoedler 2022 PMID:35143761 VMH-FR vs BNST-FR contrast. The cluster-level signal is represented through the parent supertype edge edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563.\n"
+    rationale_generated_at: '2026-06-08T18:35:23+00:00'
+    report_path: reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+    rationale_source_hash: 3adf268c
+  - id: edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_1959
+    lit_type: vmhvl_esr1_pr_neuron
+    taxonomy_type: CS20230722_CLUS_1959
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1959 DMH Hmx2 Gaba_6; region_fraction_100um=0.522; strict region_fraction=0.189.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventromedial hypothalamic nucleus [MBA:693]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=186 [painted]; Dorsomedial nucleus of the hypothalamus [MBA:830] count_100um=119 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=97 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.522; strict region_fraction: 0.189; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Nkx2-1
+        node_a_value: Nkx2-1 — defining marker
+        node_b_value: 'Nkx2-1: 0.26; cohort_pct 0.423'
+        alignment: APPROXIMATE
+        notes: val=0.26; cohort percentile 0.423
+      - property: marker_Tac1
+        node_a_value: Tac1 — defining marker
+        node_b_value: 'Tac1: 0.36; cohort_pct 0.321'
+        alignment: APPROXIMATE
+        notes: val=0.36; cohort percentile 0.321
+      - property: neuropeptide_Tac1
+        node_a_value: Tac1 — neuropeptide (classical)
+        node_b_value: 'Tac1: 0.36; cohort_pct 0.321'
+        alignment: APPROXIMATE
+        notes: val=0.36; cohort percentile 0.321
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "DMH-anchored GABAergic cluster; defining markers Nkx2-1 and Tac1 are near-absent; wrong anatomical and NT context for vmhvl_esr1_pr_neuron.\n"
+    discovery_score:
+      score: 6
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 7
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:693
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: Nkx2-1
+          val: 0.26
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.423
+        - gene: Tac1
+          val: 0.36
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.321
+      region_fraction: 0.189
+      region_fraction_100um: 0.522
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.05
+    rationale: "[tier:CUT] CS20230722_CLUS_1959 (DMH Hmx2 Gaba_6) is a GABAergic dorsomedial-hypothalamus cluster with Nkx2-1=0.26 (cohort pct 0.423) and Tac1=0.36 (cohort pct 0.321) — both defining markers near-absent — and region_fraction_100um: 0.522 with DMH [MBA:830] dominant over VMH [MBA:693]. Wrong subclass (DMH GABAergic) for the VMHvl glutamatergic classical type.\n"
+    rationale_generated_at: '2026-06-08T18:35:23+00:00'
+    report_path: reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+    rationale_source_hash: 228492b9
+  - id: edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2295
+    lit_type: vmhvl_esr1_pr_neuron
+    taxonomy_type: CS20230722_CLUS_2295
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 2295 VMH Fezf1 Glut_2; region_fraction_100um=0.889; strict region_fraction=0.742.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Glut
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventromedial hypothalamic nucleus [MBA:693]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=287 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=255 [painted]; Tuberal nucleus [MBA:614] count_100um=81 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.889; strict region_fraction: 0.742; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Nkx2-1
+        node_a_value: Nkx2-1 — defining marker
+        node_b_value: 'Nkx2-1: 6.16; cohort_pct 0.942; atlas category: TF'
+        alignment: CONSISTENT
+        notes: val=6.16; cohort percentile 0.942
+      - property: marker_Tac1
+        node_a_value: Tac1 — defining marker
+        node_b_value: 'Tac1: 1.87; cohort_pct 0.752'
+        alignment: CONSISTENT
+        notes: val=1.87; cohort percentile 0.752
+      - property: neuropeptide_Tac1
+        node_a_value: Tac1 — neuropeptide (classical)
+        node_b_value: 'Tac1: 1.87; cohort_pct 0.752'
+        alignment: CONSISTENT
+        notes: val=1.87; cohort percentile 0.752
+    caveats:
+      - caveat_type: TAXONOMY_LEVEL_MISMATCH
+        description: "CS20230722_CLUS_2295 is a child of CS20230722_SUPT_0564 and contributes to the supertype-level cross-cutting mapping; not treated as an independent cluster-level target.\n"
+    discovery_score:
+      score: 6
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 7
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:693
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: Nkx2-1
+          val: 6.16
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.942
+        - gene: Tac1
+          val: 1.87
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.752
+      region_fraction: 0.742
+      region_fraction_100um: 0.889
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.3
+    rationale: "[tier:CUT] CS20230722_CLUS_2295 is a SUPT_0564 child cluster (Nkx2-1=6.16 cohort pct 0.942, Tac1=1.87 cohort pct 0.752, region_fraction_100um: 0.889). The cluster carries the cleanest VMH region signal among SUPT_0564 children but its mapping is represented through the parent supertype edge edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564 rather than as an independent cluster-level target.\n"
+    rationale_generated_at: '2026-06-08T18:35:23+00:00'
+    report_path: reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+    rationale_source_hash: 5b6b8086
+  - id: edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2297
+    lit_type: vmhvl_esr1_pr_neuron
+    taxonomy_type: CS20230722_CLUS_2297
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 2297 VMH Fezf1 Glut_2; region_fraction_100um=0.737; strict region_fraction=0.455.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Glut
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventromedial hypothalamic nucleus [MBA:693]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=155 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=115 [painted]; Tuberal nucleus [MBA:614] count_100um=70 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.737; strict region_fraction: 0.455; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Nkx2-1
+        node_a_value: Nkx2-1 — defining marker
+        node_b_value: 'Nkx2-1: 3.80; cohort_pct 0.763; atlas category: MERFISH'
+        alignment: CONSISTENT
+        notes: val=3.80; cohort percentile 0.763
+      - property: marker_Tac1
+        node_a_value: Tac1 — defining marker
+        node_b_value: 'Tac1: 1.45; cohort_pct 0.730'
+        alignment: CONSISTENT
+        notes: val=1.45; cohort percentile 0.730
+      - property: neuropeptide_Tac1
+        node_a_value: Tac1 — neuropeptide (classical)
+        node_b_value: 'Tac1: 1.45; cohort_pct 0.730'
+        alignment: CONSISTENT
+        notes: val=1.45; cohort percentile 0.730
+    caveats:
+      - caveat_type: TAXONOMY_LEVEL_MISMATCH
+        description: "CS20230722_CLUS_2297 is a child of CS20230722_SUPT_0564; not treated as an independent cluster-level target.\n"
+    discovery_score:
+      score: 6
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 7
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:693
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: Nkx2-1
+          val: 3.8
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.763
+        - gene: Tac1
+          val: 1.45
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.73
+      region_fraction: 0.455
+      region_fraction_100um: 0.737
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.25
+    rationale: "[tier:CUT] CS20230722_CLUS_2297 is a SUPT_0564 child cluster (Nkx2-1=3.80 cohort pct 0.763, Tac1=1.45 cohort pct 0.730, region_fraction_100um: 0.737). Marker concordance is weaker than its sibling CS20230722_CLUS_2295; the supertype-level edge edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564 carries the mapping.\n"
+    rationale_generated_at: '2026-06-08T18:35:23+00:00'
+    report_path: reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+    rationale_source_hash: 5e76ee98
+  - id: edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0557
+    lit_type: vmhvl_esr1_pr_neuron
+    taxonomy_type: CS20230722_SUPT_0557
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0557 ARH-PVp Tbx3 Glut_4; region_fraction_100um=0.808; strict region_fraction=0.483.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventromedial hypothalamic nucleus [MBA:693]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=120 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=97 [painted]; Dorsomedial nucleus of the hypothalamus [MBA:830] count_100um=37 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.808; strict region_fraction: 0.483; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Nkx2-1
+        node_a_value: Nkx2-1 — defining marker
+        node_b_value: 'Nkx2-1: 6.11; cohort_pct 0.969; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=6.11; cohort percentile 0.969; child-cluster coverage 1.000
+      - property: marker_Tac1
+        node_a_value: Tac1 — defining marker
+        node_b_value: 'Tac1: 7.16; cohort_pct 0.979; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=7.16; cohort percentile 0.979; child-cluster coverage 1.000
+      - property: neuropeptide_Tac1
+        node_a_value: Tac1 — neuropeptide (classical)
+        node_b_value: 'Tac1: 7.16; cohort_pct 0.979; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=7.16; cohort percentile 0.979; child-cluster coverage 1.000
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "ARH-PVp Tbx3 supertype with Tuberal/Hypothalamus-catchall anatomical distribution; not the VMHvl-specific signature of vmhvl_esr1_pr_neuron.\n"
+    discovery_score:
+      score: 7
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 7
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:693
+      expression_detail:
+        - gene: Nkx2-1
+          val: 6.11
+          reliable: true
+          raw_tier: 2
+          applied_score: 2.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.969
+          coverage: 1.0
+        - gene: Tac1
+          val: 7.16
+          reliable: true
+          raw_tier: 2
+          applied_score: 2.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.979
+          coverage: 1.0
+      region_fraction: 0.483
+      region_fraction_100um: 0.808
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.2
+    rationale: "[tier:CUT] CS20230722_SUPT_0557 (ARH-PVp Tbx3 Glut_4) carries Nkx2-1=6.11 (cohort pct 0.969) and Tac1=7.16 (cohort pct 0.979) with child-cluster coverage 1.00 but region_fraction_100um: 0.808 is dominated by Hypothalamus catchall n=120 and Tuberal nucleus n=37 with VMH n=97 — the supertype is ARH-PVp/Tuberal-leaning by name and metadata, not VMHvl-specific. Wrong region context for the VMHvl classical type.\n"
+    rationale_generated_at: '2026-06-08T18:35:23+00:00'
+    report_path: reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+    rationale_source_hash: 014f43de
+  - id: edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0563
+    lit_type: vmhvl_esr1_pr_neuron
+    taxonomy_type: CS20230722_SUPT_0563
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0563 VMH Fezf1 Glut_1; region_fraction_100um=0.712; strict region_fraction=0.424.
+    property_comparisons: *id005
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "Duplicate edge — same taxonomy_type CS20230722_SUPT_0563 is targeted by both edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563 (legacy, substantive) and this fresh-emit edge (impoverished). Curator removal of one is recommended.\n"
+    discovery_score: *id006
+    confidence: LOW
+    confidence_score: 0.3
+    rationale: "[tier:CUT] Duplicate fresh-emit edge to CS20230722_SUPT_0563 — the substantive supertype mapping is encoded on the legacy edge edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563 (lowercase ID) which carries the populated bulk-correlation evidence from corr_run_20260428_knoedler_esr1_wmbv1, the co-primary cross-cutting designation, and the property_comparisons. This uppercase-ID fresh-emit edge carries only ATLAS_METADATA and a stub property_comparison set; recommend curator removal to resolve the duplicate.\n"
+    rationale_generated_at: '2026-06-08T18:35:23+00:00'
+    report_path: reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+    unresolved_questions:
+      - "Curator removal of duplicate edge edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0563 — legacy/fresh-emit ID collision on taxonomy_type CS20230722_SUPT_0563.\n"
+    rationale_source_hash: 0bcce430
+  - id: edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0439
+    lit_type: vmhvl_esr1_pr_neuron
+    taxonomy_type: CS20230722_SUPT_0439
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0439 DMH Prdm13 Gaba_1; region_fraction_100um=0.151; strict region_fraction=0.056.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventromedial hypothalamic nucleus [MBA:693]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=232 [painted]; Dorsomedial nucleus of the hypothalamus [MBA:830] count_100um=230 [painted]; Periventricular hypothalamic nucleus, intermediate part [MBA:118] count_100um=82 [painted]
+        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.151; strict region_fraction: 0.056; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Nkx2-1
+        node_a_value: Nkx2-1 — defining marker
+        node_b_value: 'Nkx2-1: 5.92; cohort_pct 0.959; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=5.92; cohort percentile 0.959; child-cluster coverage 1.000
+      - property: marker_Tac1
+        node_a_value: Tac1 — defining marker
+        node_b_value: 'Tac1: 0.36; cohort_pct 0.309; child-coverage 1.000'
+        alignment: APPROXIMATE
+        notes: val=0.36; cohort percentile 0.309; child-cluster coverage 1.000
+      - property: neuropeptide_Tac1
+        node_a_value: Tac1 — neuropeptide (classical)
+        node_b_value: 'Tac1: 0.36; cohort_pct 0.309; child-coverage 1.000'
+        alignment: APPROXIMATE
+        notes: val=0.36; cohort percentile 0.309; child-cluster coverage 1.000
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "DMH GABAergic supertype; Tac1 near-absent; minimal VMH footprint (region_fraction_100um: 0.151).\n"
+    discovery_score:
+      score: 5
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 7
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:693
+      expression_detail:
+        - gene: Nkx2-1
+          val: 5.92
+          reliable: true
+          raw_tier: 2
+          applied_score: 2.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.959
+          coverage: 1.0
+        - gene: Tac1
+          val: 0.36
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.309
+          coverage: 1.0
+      region_fraction: 0.056
+      region_fraction_100um: 0.151
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.05
+    rationale: "[tier:CUT] CS20230722_SUPT_0439 (DMH Prdm13 Gaba_1) is a GABAergic dorsomedial-hypothalamus supertype with region_fraction_100um: 0.151 (DMH dominant) and Tac1=0.36 (cohort pct 0.309, near-absent). Wrong region and wrong NT for the VMHvl glutamatergic classical type.\n"
+    rationale_generated_at: '2026-06-08T18:35:23+00:00'
+    report_path: reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+    rationale_source_hash: bfc62ec6
+  - id: edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0569
+    lit_type: vmhvl_esr1_pr_neuron
+    taxonomy_type: CS20230722_SUPT_0569
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0569 VMH Nr5a1 Glut_4; region_fraction_100um=0.913; strict region_fraction=0.756.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventromedial hypothalamic nucleus [MBA:693]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=519 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=475 [painted]; Arcuate hypothalamic nucleus [MBA:223] count_100um=85 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.913; strict region_fraction: 0.756; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Nkx2-1
+        node_a_value: Nkx2-1 — defining marker
+        node_b_value: 'Nkx2-1: 4.96; cohort_pct 0.866; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=4.96; cohort percentile 0.866; child-cluster coverage 1.000
+      - property: marker_Tac1
+        node_a_value: Tac1 — defining marker
+        node_b_value: 'Tac1: 1.52; cohort_pct 0.680; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=1.52; cohort percentile 0.680; child-cluster coverage 1.000
+      - property: neuropeptide_Tac1
+        node_a_value: Tac1 — neuropeptide (classical)
+        node_b_value: 'Tac1: 1.52; cohort_pct 0.680; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=1.52; cohort percentile 0.680; child-cluster coverage 1.000
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "VMH Nr5a1 lineage — distinct VMH developmental lineage from VMH Fezf1; not the canonical correlate of the VMHvl Esr1/Pgr classical population.\n"
+    discovery_score:
+      score: 5
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 7
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:693
+      expression_detail:
+        - gene: Nkx2-1
+          val: 4.96
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.866
+          coverage: 1.0
+        - gene: Tac1
+          val: 1.52
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.68
+          coverage: 1.0
+      region_fraction: 0.756
+      region_fraction_100um: 0.913
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.15
+    rationale: "[tier:CUT] CS20230722_SUPT_0569 (VMH Nr5a1 Glut_4) carries Nkx2-1=4.96 (cohort pct 0.866) and Tac1=1.52 (cohort pct 0.680) with VMH region_fraction_100um: 0.913, but the supertype belongs to the VMH Nr5a1 lineage (distinct from the VMH Fezf1 lineage that contains SUPT_0563/SUPT_0564). Nr5a1+ VMHdm/c populations are anatomically and functionally distinct from the VMHvl Esr1/Pgr classical type.\n"
+    rationale_generated_at: '2026-06-08T18:35:23+00:00'
+    report_path: reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+    rationale_source_hash: 74c46ef7
+  - id: edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0568
+    lit_type: vmhvl_esr1_pr_neuron
+    taxonomy_type: CS20230722_SUPT_0568
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0568 VMH Nr5a1 Glut_3; region_fraction_100um=0.898; strict region_fraction=0.779.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventromedial hypothalamic nucleus [MBA:693]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=2536 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=2282 [painted]; Arcuate hypothalamic nucleus [MBA:223] count_100um=354 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.898; strict region_fraction: 0.779; region_evidence: SELF'
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Pgr
+        node_a_value: Pgr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Nkx2-1
+        node_a_value: Nkx2-1 — defining marker
+        node_b_value: 'Nkx2-1: 3.49; cohort_pct 0.732; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=3.49; cohort percentile 0.732; child-cluster coverage 1.000
+      - property: marker_Tac1
+        node_a_value: Tac1 — defining marker
+        node_b_value: 'Tac1: 1.83; cohort_pct 0.722; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=1.83; cohort percentile 0.722; child-cluster coverage 1.000
+      - property: neuropeptide_Tac1
+        node_a_value: Tac1 — neuropeptide (classical)
+        node_b_value: 'Tac1: 1.83; cohort_pct 0.722; child-coverage 1.000'
+        alignment: CONSISTENT
+        notes: val=1.83; cohort percentile 0.722; child-cluster coverage 1.000
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "VMH Nr5a1 lineage — distinct VMH developmental lineage from VMH Fezf1; not the canonical correlate of the VMHvl Esr1/Pgr classical population.\n"
+    discovery_score:
+      score: 5
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 7
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:693
+      expression_detail:
+        - gene: Nkx2-1
+          val: 3.49
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.732
+          coverage: 1.0
+        - gene: Tac1
+          val: 1.83
+          reliable: true
+          raw_tier: 1
+          applied_score: 1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.722
+          coverage: 1.0
+      region_fraction: 0.779
+      region_fraction_100um: 0.898
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.15
+    rationale: "[tier:CUT] CS20230722_SUPT_0568 (VMH Nr5a1 Glut_3) carries Nkx2-1=3.49 (cohort pct 0.732) and Tac1=1.83 (cohort pct 0.722) with VMH region_fraction_100um: 0.898, but is part of the VMH Nr5a1 lineage rather than the VMH Fezf1 lineage that contains SUPT_0563/SUPT_0564. Nr5a1+ VMH populations sit primarily in VMHdm/c and do not align with the VMHvl Esr1/Pgr classical type.\n"
+    rationale_generated_at: '2026-06-08T18:35:23+00:00'
+    report_path: reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+    rationale_source_hash: c2e2938b
+  - id: edge_pvn_crfr1_neuron_to_CS20230722_CLUS_2366
+    lit_type: pvn_crfr1_neuron
+    taxonomy_type: CS20230722_CLUS_2366
+    relationship: skos:closeMatch
+    mapping_justification: semapv:ManualMappingCuration
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 2366 PVH-SO-PVa Otp Glut_1; region_fraction_100um=0.810; strict region_fraction=0.619.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Glut
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Paraventricular hypothalamic nucleus [MBA:38]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=21 [painted]; Paraventricular hypothalamic nucleus [MBA:38] count_100um=17 [painted]; Paraventricular hypothalamic nucleus, descending division [MBA:63] count_100um=15 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.810; strict region_fraction: 0.619; region_evidence: SELF'
+      - property: marker_Crhr1
+        node_a_value: Crhr1 — defining marker
         node_b_value: no atlas expression data
         alignment: NOT_ASSESSED
         notes: Gene absent from Stage A expression_detail and from precomputed_expression.
@@ -2938,14 +6300,571 @@ edges:
         node_b_value: no atlas expression data
         alignment: NOT_ASSESSED
         notes: Gene absent from Stage A expression_detail and from precomputed_expression.
-      - property: neuropeptide_Kiss1
-        node_a_value: Kiss1 — neuropeptide (classical)
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
         node_b_value: no atlas expression data
         alignment: NOT_ASSESSED
         notes: Gene absent from Stage A expression_detail and from precomputed_expression.
     caveats:
       - caveat_type: AMBIGUOUS_MAPPING
-        description: 'DISCORDANT property comparison(s): location. Mapping has unresolved counter-evidence.'
+        description: "Cluster-level Crhr1 / Esr1 / Ar means and male/female ratio are not available in property_comparisons; cannot confirm this cluster carries the receptor-defined male-biased subset rather than another fraction of SUPT_0585.\n"
+      - caveat_type: SINGLE_DATASET
+        description: "Inherits the SINGLE_DATASET cap of the classical node (Rosinger 2019 only).\n"
+    discovery_score:
+      score: 4
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:38
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.619
+      region_fraction_100um: 0.81
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.3
+    rationale: "[tier:NEXT] Best child cluster of the primary supertype SUPT_0585 by PVN proximity (region_fraction_100um=0.810; 17 of 64 cells in MBA:38); selected as the cluster-level entry point for the primary mapping pending direct receptor-targeted evidence.\n"
+    reconciliation_note: "Paired with primary survivor SUPT_0585 (parent supertype, broadMatch 1:n). Cluster-level call rests on location alone; no atlas expression data for Crhr1, Esr1, or Ar on this cluster.\n"
+    mapping_cardinality: "1:1"
+    proposed_experiments:
+      - "Per-cluster Crhr1, Esr1, Ar expression and male/female ratio pull for all children of SUPT_0585, comparing CLUS_2366 against siblings.\n"
+      - "Crhr1-targeted annotation transfer (see primary edge); confirm CLUS_2366 as best cluster at F1 >= 0.5.\n"
+    rationale_generated_at: '2026-06-08T18:35:24+00:00'
+    report_path: reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
+    unresolved_questions:
+      - "Does CLUS_2366 specifically capture the male-biased CRFR1+ subset of SUPT_0585, or is the subset distributed across multiple sibling clusters?\n"
+    rationale_source_hash: cd8dfc22
+  - id: edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1549
+    lit_type: pvn_crfr1_neuron
+    taxonomy_type: CS20230722_CLUS_1549
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1549 BST-MPN Six3 Nrgn Gaba_4; region_fraction_100um=0.821; strict region_fraction=0.357.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Paraventricular hypothalamic nucleus [MBA:38]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=56 [painted]; Paraventricular hypothalamic nucleus [MBA:38] count_100um=46 [painted]; Medial preoptic nucleus [MBA:515] count_100um=40 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.821; strict region_fraction: 0.357; region_evidence: SELF'
+      - property: marker_Crhr1
+        node_a_value: Crhr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "GABAergic and predominantly BST / medial preoptic; not the PVN glutamatergic CRFR1+ population. Survives only on location proximity.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:38
+      expression_detail: []
+      region_fraction: 0.357
+      region_fraction_100um: 0.821
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.1
+    rationale: "[tier:CUT] GABAergic cluster in the BST-MPN Six3 Nrgn Gaba_4 supertype; wrong subclass for a PVN glutamatergic CRFR1+ neuroendocrine type. PVN proximity (region_fraction_100um=0.821) reflects BST-MPN adjacency rather than identity.\n"
+    rationale_generated_at: '2026-06-08T18:35:24+00:00'
+    report_path: reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
+    rationale_source_hash: 0029593a
+  - id: edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1550
+    lit_type: pvn_crfr1_neuron
+    taxonomy_type: CS20230722_CLUS_1550
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1550 BST-MPN Six3 Nrgn Gaba_4; region_fraction_100um=0.521; strict region_fraction=0.250.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Paraventricular hypothalamic nucleus [MBA:38]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=46 [painted]; Medial preoptic nucleus [MBA:515] count_100um=39 [painted]; Paraventricular hypothalamic nucleus [MBA:38] count_100um=25 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.521; strict region_fraction: 0.250; region_evidence: SELF'
+      - property: marker_Crhr1
+        node_a_value: Crhr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "GABAergic; primary spatial signal in medial preoptic nucleus rather than PVN.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:38
+      expression_detail: []
+      region_fraction: 0.25
+      region_fraction_100um: 0.521
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.08
+    rationale: "[tier:CUT] GABAergic cluster in the BST-MPN Six3 Nrgn Gaba_4 supertype; wrong subclass and primary location is medial preoptic rather than PVN (region_fraction_100um=0.521).\n"
+    rationale_generated_at: '2026-06-08T18:35:24+00:00'
+    report_path: reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
+    rationale_source_hash: cc03386e
+  - id: edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1561
+    lit_type: pvn_crfr1_neuron
+    taxonomy_type: CS20230722_CLUS_1561
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1561 BST-MPN Six3 Nrgn Gaba_6; region_fraction_100um=0.378; strict region_fraction=0.083.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Paraventricular hypothalamic nucleus [MBA:38]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=34 [painted]; Medial preoptic nucleus [MBA:515] count_100um=31 [painted]; Paraventricular hypothalamic nucleus [MBA:38] count_100um=14 [painted]
+        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.378; strict region_fraction: 0.083; region_evidence: SELF'
+      - property: marker_Crhr1
+        node_a_value: Crhr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "GABAergic; primary spatial signal in medial preoptic rather than PVN.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:38
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.083
+      region_fraction_100um: 0.378
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.05
+    rationale: "[tier:CUT] GABAergic cluster in BST-MPN Six3 Nrgn Gaba_6 supertype; wrong subclass and weak PVN proximity (region_fraction_100um=0.378 with strict region_fraction=0.083 — boundary scatter).\n"
+    rationale_generated_at: '2026-06-08T18:35:24+00:00'
+    report_path: reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
+    rationale_source_hash: f07d309b
+  - id: edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1563
+    lit_type: pvn_crfr1_neuron
+    taxonomy_type: CS20230722_CLUS_1563
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1563 BST-MPN Six3 Nrgn Gaba_6; region_fraction_100um=0.111; strict region_fraction=0.037.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Paraventricular hypothalamic nucleus [MBA:38]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=18 [painted]; Medial preoptic nucleus [MBA:515] count_100um=12 [painted]; Striatum [MBA:477] count_100um=9 [painted]
+        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.111; strict region_fraction: 0.037; region_evidence: SELF'
+      - property: marker_Crhr1
+        node_a_value: Crhr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "GABAergic; spatial distribution into striatum is inconsistent with the PVN neuroendocrine identity.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:38
+      expression_detail:
+        - gene: Esr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.037
+      region_fraction_100um: 0.111
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.03
+    rationale: "[tier:CUT] GABAergic cluster in BST-MPN Six3 Nrgn Gaba_6 supertype; wrong subclass and very weak PVN proximity (region_fraction_100um=0.111; striatum among top-3 locations).\n"
+    rationale_generated_at: '2026-06-08T18:35:24+00:00'
+    report_path: reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
+    rationale_source_hash: 5653597b
+  - id: edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0585
+    lit_type: pvn_crfr1_neuron
+    taxonomy_type: CS20230722_SUPT_0585
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0585 PVH-SO-PVa Otp Glut_1; region_fraction_100um=0.665; strict region_fraction=0.383.
+    property_comparisons: *id007
+    caveats:
+      - caveat_type: OTHER
+        description: "Duplicate edge — same taxonomy_type as edge_pvn_crfr1_neuron_to_cs20230722_supt_0585. Schedule for curator removal.\n"
+    discovery_score: *id008
+    confidence: UNCERTAIN
+    confidence_score: 0.05
+    rationale: "[tier:CUT] Impoverished duplicate of edge_pvn_crfr1_neuron_to_cs20230722_supt_0585 (same taxonomy_type CS20230722_SUPT_0585; legacy/fresh-emit ID collision). Carries only location data; the lowercase-id edge carries the substantive Esr1/Ar/Crh atlas evidence and curator-authored caveats. Cut pending curator removal.\n"
+    rationale_generated_at: '2026-06-08T18:35:24+00:00'
+    report_path: reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
+    unresolved_questions:
+      - "Curator removal of duplicate edge edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0585 (uppercase id) in favour of legacy edge with substantive evidence.\n"
+    rationale_source_hash: 60844eed
+  - id: edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0587
+    lit_type: pvn_crfr1_neuron
+    taxonomy_type: CS20230722_SUPT_0587
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0587 PVH-SO-PVa Otp Glut_3; region_fraction_100um=0.975; strict region_fraction=0.833.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Paraventricular hypothalamic nucleus [MBA:38]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=482 [painted]; Paraventricular hypothalamic nucleus [MBA:38] count_100um=472 [painted]; Paraventricular hypothalamic nucleus, descending division [MBA:63] count_100um=139 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.975; strict region_fraction: 0.833; region_evidence: SELF'
+      - property: marker_Crhr1
+        node_a_value: Crhr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "No atlas-side Esr1/Ar/Crh expression carried on this edge to bridge to Rosinger 2019 steroid-receptor profile. Location alone is insufficient because the cell type is defined by receptor expression, not by region.\n"
+      - caveat_type: SINGLE_DATASET
+        description: "Inherits the SINGLE_DATASET cap of the classical node (Rosinger 2019 only).\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:38
+      expression_detail: []
+      region_fraction: 0.833
+      region_fraction_100um: 0.975
+      region_evidence: SELF
+    confidence: LOW
+    confidence_score: 0.25
+    rationale: "[tier:WEAKEST] Highest PVN spatial enrichment (region_fraction_100um =0.975; 472/2093 PVN cells) of any candidate, but lacks the steroid-receptor expression bridge that supports the primary SUPT_0585 call. Co-equal location candidate pending atlas Crhr1/Esr1/Ar pull.\n"
+    reconciliation_note: "Alternative to primary SUPT_0585 within the same PVH-SO-PVa Otp Glut subclass. If atlas Esr1/Ar means on SUPT_0587 are also elevated, this candidate rises to co-equal; in that case the primary edge predicate may need migration to skos:broadMatch onto the subclass.\n"
+    proposed_experiments:
+      - "Pull atlas-internal Crhr1, Esr1, Ar means and child-cluster sex ratios for SUPT_0587, comparable to the data on SUPT_0585.\n"
+      - "Crhr1-targeted annotation transfer (see primary edge); if cells distribute across SUPT_0585 and SUPT_0587, migrate primary predicate to broadMatch onto the parent subclass.\n"
+    rationale_generated_at: '2026-06-08T18:35:24+00:00'
+    report_path: reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
+    unresolved_questions:
+      - "Is SUPT_0587 a co-equal candidate to SUPT_0585 once atlas steroid-receptor expression is assessed?\n"
+    rationale_source_hash: 5467b02a
+  - id: edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0586
+    lit_type: pvn_crfr1_neuron
+    taxonomy_type: CS20230722_SUPT_0586
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0586 PVH-SO-PVa Otp Glut_2; region_fraction_100um=0.610; strict region_fraction=0.361.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Paraventricular hypothalamic nucleus [MBA:38]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=373 [painted]; Paraventricular hypothalamic nucleus [MBA:38] count_100um=228 [painted]; Paraventricular hypothalamic nucleus, descending division [MBA:63] count_100um=197 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.610; strict region_fraction: 0.361; region_evidence: SELF'
+      - property: marker_Crhr1
+        node_a_value: Crhr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "Same PVH-SO-PVa Otp Glut subclass as primary SUPT_0585; could carry part of the CRFR1+ population but no atlas marker evidence to support.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:38
+      expression_detail: []
+      region_fraction: 0.361
+      region_fraction_100um: 0.61
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.15
+    rationale: "[tier:CUT] Sister supertype within the PVH-SO-PVa Otp Glut subclass with PVN location (region_fraction_100um=0.610) but no steroid-receptor expression evidence carried on this edge; without a marker bridge to Rosinger 2019, location alone is insufficient for a receptor-defined type.\n"
+    rationale_generated_at: '2026-06-08T18:35:24+00:00'
+    report_path: reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
+    unresolved_questions:
+      - "Does the CRFR1+ population also include SUPT_0586 (broader subclass-level mapping)?\n"
+    rationale_source_hash: ba1d79f8
+  - id: edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0414
+    lit_type: pvn_crfr1_neuron
+    taxonomy_type: CS20230722_SUPT_0414
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0414 PVR Six3 Sox3 Gaba_4; region_fraction_100um=0.040; strict region_fraction=0.011.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Paraventricular hypothalamic nucleus [MBA:38]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=335 [painted]; Striatum [MBA:477] count_100um=278 [painted]; Pallidum [MBA:803] count_100um=212 [painted]
+        alignment: DISCORDANT
+        notes: 'region_fraction_100um: 0.040; strict region_fraction: 0.011; region_evidence: SELF'
+      - property: marker_Crhr1
+        node_a_value: Crhr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "DISCORDANT location; striatum / pallidum dominant.\n"
+    discovery_score:
+      score: 2
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:38
+      expression_detail:
+        - gene: Crhr1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.011
+      region_fraction_100um: 0.04
+      region_evidence: SELF
+    confidence: REFUTED
+    confidence_score: 0.02
+    rationale: "[tier:CUT] DISCORDANT location — primary painted locations are striatum and pallidum rather than PVN (region_fraction_100um=0.040; strict region_fraction=0.011). Not a PVN-resident population.\n"
+    rationale_generated_at: '2026-06-08T18:35:24+00:00'
+    report_path: reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
+    rationale_source_hash: 855a2e6d
+  - id: edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0486
+    lit_type: pvn_crfr1_neuron
+    taxonomy_type: CS20230722_SUPT_0486
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0486 PVpo-VMPO-MPN Hmx2 Gaba_5; region_fraction_100um=0.020; strict region_fraction=0.011.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Paraventricular hypothalamic nucleus [MBA:38]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=381 [painted]; Periventricular hypothalamic nucleus, preoptic part [MBA:133] count_100um=354 [painted]; Medial preoptic nucleus [MBA:515] count_100um=276 [painted]
+        alignment: DISCORDANT
+        notes: 'region_fraction_100um: 0.020; strict region_fraction: 0.011; region_evidence: SELF'
+      - property: marker_Crhr1
+        node_a_value: Crhr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Esr1
+        node_a_value: Esr1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Ar
+        node_a_value: Ar — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "DISCORDANT location; preoptic rather than paraventricular.\n"
     discovery_score:
       score: 2
       rank_in_cohort: 5
@@ -2958,9 +6877,7 @@ edges:
           rank: 1
           n_members: 50
           filters:
-            - region=MBA:272,MBA:126
-            - nt_type=GABAergic / dopaminergic (TH co-expression)
-            - sex_bias=female
+            - region=MBA:38
       expression_detail:
         - gene: Esr1
           val:
@@ -2969,6 +6886,1827 @@ edges:
           applied_score: 1.0
           source: METADATA
           percentiles: []
-      region_fraction: 0.043
-      region_fraction_100um: 0.061
+      region_fraction: 0.011
+      region_fraction_100um: 0.02
       region_evidence: SELF
+    confidence: REFUTED
+    confidence_score: 0.02
+    rationale: "[tier:CUT] DISCORDANT location — primary painted locations are periventricular preoptic and medial preoptic (region_fraction_100um=0.020). Not PVN.\n"
+    rationale_generated_at: '2026-06-08T18:35:24+00:00'
+    report_path: reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
+    rationale_source_hash: bc887325
+  - id: edge_bnst_crf_neuron_to_CS20230722_CLUS_1409
+    lit_type: bnst_crf_neuron
+    taxonomy_type: CS20230722_CLUS_1409
+    relationship: skos:closeMatch
+    mapping_justification: semapv:ManualMappingCuration
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1409 CEA-BST Rai14 Pdyn Crh Gaba_2; region_fraction_100um=0.794; strict region_fraction=0.506.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]
+        node_b_value: Pallidum [MBA:803] count_100um=129 [painted]; Bed nuclei of the stria terminalis [MBA:351] count_100um=123 [painted]; Striatum [MBA:477] count_100um=71 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.794; strict region_fraction: 0.506; region_evidence: SELF'
+      - property: marker_Crh
+        node_a_value: Crh — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: negative_marker_Calb1
+        node_a_value: Calb1 — ABSENT (classical negative marker)
+        node_b_value: 'Calb1: 3.57; cohort_pct 0.517'
+        alignment: DISCORDANT
+        notes: val=3.57; cohort percentile 0.517
+      - property: neuropeptide_Crh
+        node_a_value: Crh — neuropeptide (classical)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: MARKER_NOT_SPECIFIC
+        description: "Calb1 cohort percentile 0.517 at CS20230722_CLUS_1409 remains DISCORDANT with the classical Calb1-absent expectation, though lower than at the parent supertype. Direct Crh quantification is required to confirm CS20230722_CLUS_1409 as the Calb1-low, Crh-high subpopulation.\n"
+      - caveat_type: MERFISH_REGISTRATION_UNCERTAINTY
+        description: "Sub-nucleus identity (dlBNST, ovBNST, alBNST) of CS20230722_CLUS_1409 cells cannot be confirmed from WMBv1 spatial registration, which uses the parent BNST term (MBA:351).\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:351,MBA:351,MBA:351
+      expression_detail:
+        - gene: Crh
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: -Calb1
+          val: 3.57
+          reliable: true
+          raw_tier: -1
+          applied_score: -1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.517
+      region_fraction: 0.506
+      region_fraction_100um: 0.794
+      region_evidence: SELF
+    confidence: MODERATE
+    confidence_score: 0.55
+    rationale: "[tier:NEXT] CS20230722_CLUS_1409 (191 cells, region_fraction_100um=0.794 onto MBA:351, GABA NT) is the best-child within CS20230722_SUPT_0393. Calb1 cohort percentile 0.517 is below median (lower than sibling CS20230722_CLUS_1410 at cohort percentile 0.855), making CS20230722_CLUS_1409 the more parsimonious candidate for the classical Calb1-low Crh-high dlBNST CRF type. Direct Crh expression at this cluster is NOT_ASSESSED in current facts.\n"
+    reconciliation_note: "Paired with CS20230722_SUPT_0393 (best-child within supertype). Supertype carries 1:n broadMatch; this cluster edge carries 1:1 closeMatch.\n"
+    mapping_cardinality: "1:1"
+    proposed_experiments:
+      - "Sex-stratified analysis of CS20230722_CLUS_1409 versus sibling CS20230722_CLUS_1410; target detection of female-bias signature matching the classical type's dimorphism.\n"
+      - "Direct Crh measurement at CS20230722_CLUS_1409 (e.g. ISH or MERFISH co-staining for Crh, Esr1, Calb1) to confirm cluster-level Crh expression and parsimoniously identify the Calb1-low subset.\n"
+    rationale_generated_at: '2026-06-08T18:35:25+00:00'
+    report_path: reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+    unresolved_questions:
+      - What fraction of CS20230722_CLUS_1409 cells co-express Crh+ and are Calb1-low? A subset analysis is needed to confirm parsimony with the classical type.
+    rationale_source_hash: b4729e70
+  - id: edge_bnst_crf_neuron_to_CS20230722_CLUS_1410
+    lit_type: bnst_crf_neuron
+    taxonomy_type: CS20230722_CLUS_1410
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1410 CEA-BST Rai14 Pdyn Crh Gaba_2; region_fraction_100um=0.851; strict region_fraction=0.649.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]
+        node_b_value: Pallidum [MBA:803] count_100um=139 [painted]; Bed nuclei of the stria terminalis [MBA:351] count_100um=131 [painted]; Striatum [MBA:477] count_100um=63 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.851; strict region_fraction: 0.649; region_evidence: SELF'
+      - property: marker_Crh
+        node_a_value: Crh — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: negative_marker_Calb1
+        node_a_value: Calb1 — ABSENT (classical negative marker)
+        node_b_value: 'Calb1: 7.57; cohort_pct 0.855'
+        alignment: DISCORDANT
+        notes: val=7.57; cohort percentile 0.855
+      - property: neuropeptide_Crh
+        node_a_value: Crh — neuropeptide (classical)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: "DISCORDANT negative_marker_Calb1 at cohort percentile 0.855; sibling CS20230722_CLUS_1409 carries the candidate role at lower Calb1.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:351,MBA:351,MBA:351
+      expression_detail:
+        - gene: Crh
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: -Calb1
+          val: 7.57
+          reliable: true
+          raw_tier: -1
+          applied_score: -1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.855
+      region_fraction: 0.649
+      region_fraction_100um: 0.851
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.15
+    rationale: "[tier:CUT] Sibling of CS20230722_CLUS_1409 within CS20230722_SUPT_0393, but Calb1 cohort percentile 0.855 is well above the classical Calb1-absent expectation and above sibling CS20230722_CLUS_1409 (cohort percentile 0.517). CS20230722_CLUS_1409 is the more parsimonious best-child; CS20230722_CLUS_1410 is eliminated on cohort-relative Calb1 grounds.\n"
+    rationale_generated_at: '2026-06-08T18:35:25+00:00'
+    report_path: reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+    rationale_source_hash: 192cc3bf
+  - id: edge_bnst_crf_neuron_to_CS20230722_CLUS_1475
+    lit_type: bnst_crf_neuron
+    taxonomy_type: CS20230722_CLUS_1475
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1475 MPO-ADP Lhx8 Gaba_4; region_fraction_100um=0.864; strict region_fraction=0.545.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]
+        node_b_value: Pallidum [MBA:803] count_100um=96 [painted]; Hypothalamus [MBA:1097] count_100um=95 [painted]; Bed nuclei of the stria terminalis [MBA:351] count_100um=95 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.864; strict region_fraction: 0.545; region_evidence: SELF'
+      - property: marker_Crh
+        node_a_value: Crh — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: negative_marker_Calb1
+        node_a_value: Calb1 — ABSENT (classical negative marker)
+        node_b_value: 'Calb1: 0.68; cohort_pct 0.167'
+        alignment: DISCORDANT
+        notes: val=0.68; cohort percentile 0.167
+      - property: neuropeptide_Crh
+        node_a_value: Crh — neuropeptide (classical)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: MPO-ADP Lhx8 lineage straddling Hypothalamus and BST; not Crh lineage.
+    discovery_score:
+      score: 3
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:351,MBA:351,MBA:351
+      expression_detail:
+        - gene: Crh
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: -Calb1
+          val: 0.68
+          reliable: true
+          raw_tier: -1
+          applied_score: -1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.167
+      region_fraction: 0.545
+      region_fraction_100um: 0.864
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.15
+    rationale: "[tier:CUT] CS20230722_CLUS_1475 is a child of 0405 MPO-ADP Lhx8 Gaba_4. While region_fraction_100um=0.864 onto MBA:351 is high, the supertype is an MPO-ADP Lhx8 lineage spanning Hypothalamus and BST; the supertype identity does not match the classical Crh+ defining marker.\n"
+    rationale_generated_at: '2026-06-08T18:35:25+00:00'
+    report_path: reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+    rationale_source_hash: e6a4a317
+  - id: edge_bnst_crf_neuron_to_CS20230722_CLUS_1476
+    lit_type: bnst_crf_neuron
+    taxonomy_type: CS20230722_CLUS_1476
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1476 MPO-ADP Lhx8 Gaba_4; region_fraction_100um=0.669; strict region_fraction=0.453.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=133 [painted]; Pallidum [MBA:803] count_100um=112 [painted]; Bed nuclei of the stria terminalis [MBA:351] count_100um=101 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.669; strict region_fraction: 0.453; region_evidence: SELF'
+      - property: marker_Crh
+        node_a_value: Crh — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: negative_marker_Calb1
+        node_a_value: Calb1 — ABSENT (classical negative marker)
+        node_b_value: 'Calb1: 1.29; cohort_pct 0.291'
+        alignment: DISCORDANT
+        notes: val=1.29; cohort percentile 0.291
+      - property: neuropeptide_Crh
+        node_a_value: Crh — neuropeptide (classical)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: MPO-ADP Lhx8 lineage, not Crh lineage.
+    discovery_score:
+      score: 3
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:351,MBA:351,MBA:351
+      expression_detail:
+        - gene: Crh
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: -Calb1
+          val: 1.29
+          reliable: true
+          raw_tier: -1
+          applied_score: -1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.291
+      region_fraction: 0.453
+      region_fraction_100um: 0.669
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.15
+    rationale: "[tier:CUT] Sibling of CS20230722_CLUS_1475 within 0405 MPO-ADP Lhx8 Gaba_4. Same MPO-ADP Lhx8 lineage elimination.\n"
+    rationale_generated_at: '2026-06-08T18:35:25+00:00'
+    report_path: reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+    rationale_source_hash: 39ad3a26
+  - id: edge_bnst_crf_neuron_to_CS20230722_CLUS_1499
+    lit_type: bnst_crf_neuron
+    taxonomy_type: CS20230722_CLUS_1499
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1499 BST Tac2 Gaba_2; region_fraction_100um=0.762; strict region_fraction=0.613.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: GABA
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]
+        node_b_value: Pallidum [MBA:803] count_100um=68 [painted]; Bed nuclei of the stria terminalis [MBA:351] count_100um=61 [painted]; Hypothalamus [MBA:1097] count_100um=32 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.762; strict region_fraction: 0.613; region_evidence: SELF'
+      - property: marker_Crh
+        node_a_value: Crh — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: negative_marker_Calb1
+        node_a_value: Calb1 — ABSENT (classical negative marker)
+        node_b_value: 'Calb1: 3.49; cohort_pct 0.504'
+        alignment: DISCORDANT
+        notes: val=3.49; cohort percentile 0.504
+      - property: neuropeptide_Crh
+        node_a_value: Crh — neuropeptide (classical)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: Tac2 lineage, not Crh lineage.
+    discovery_score:
+      score: 3
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:351,MBA:351,MBA:351
+      expression_detail:
+        - gene: Crh
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: -Calb1
+          val: 3.49
+          reliable: true
+          raw_tier: -1
+          applied_score: -1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.504
+      region_fraction: 0.613
+      region_fraction_100um: 0.762
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.15
+    rationale: "[tier:CUT] Child of CS20230722_SUPT_0410 (BST Tac2 Gaba_2 lineage). Same wrong-lineage elimination as the parent supertype; Calb1 cohort percentile 0.504 is mid-range.\n"
+    rationale_generated_at: '2026-06-08T18:35:25+00:00'
+    report_path: reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+    rationale_source_hash: 217acfda
+  - id: edge_bnst_crf_neuron_to_CS20230722_SUPT_0410
+    lit_type: bnst_crf_neuron
+    taxonomy_type: CS20230722_SUPT_0410
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0410 BST Tac2 Gaba_2; region_fraction_100um=0.569; strict region_fraction=0.482.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]
+        node_b_value: Pallidum [MBA:803] count_100um=340 [painted]; Bed nuclei of the stria terminalis [MBA:351] count_100um=223 [painted]; Hypothalamus [MBA:1097] count_100um=109 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.569; strict region_fraction: 0.482; region_evidence: SELF'
+      - property: marker_Crh
+        node_a_value: Crh — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: negative_marker_Calb1
+        node_a_value: Calb1 — ABSENT (classical negative marker)
+        node_b_value: 'Calb1: 3.40; cohort_pct 0.492'
+        alignment: DISCORDANT
+        notes: val=3.40; cohort percentile 0.492
+      - property: neuropeptide_Crh
+        node_a_value: Crh — neuropeptide (classical)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: Tac2-defined supertype, not Crh-defined; eliminated on marker lineage.
+    discovery_score:
+      score: 3
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:351,MBA:351,MBA:351
+      expression_detail:
+        - gene: Crh
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: -Calb1
+          val: 3.4
+          reliable: true
+          raw_tier: -1
+          applied_score: -1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.492
+      region_fraction: 0.482
+      region_fraction_100um: 0.569
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.15
+    rationale: "[tier:CUT] CS20230722_SUPT_0410 is the BST-located 0410 BST Tac2 Gaba_2 supertype, not a Crh-labelled supertype. region_fraction_100um=0.569 onto MBA:351 is positive but the supertype identity (Tac2+ Gaba) does not match the classical Crh+ defining marker and Calb1 cohort percentile 0.492 is mid-range. Eliminated as a wrong-supertype-lineage candidate.\n"
+    rationale_generated_at: '2026-06-08T18:35:25+00:00'
+    report_path: reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+    rationale_source_hash: 68abab42
+  - id: edge_bnst_crf_neuron_to_CS20230722_SUPT_0393
+    lit_type: bnst_crf_neuron
+    taxonomy_type: CS20230722_SUPT_0393
+    relationship: skos:broadMatch
+    mapping_justification: semapv:ManualMappingCuration
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0393 CEA-BST Rai14 Pdyn Crh Gaba_2; region_fraction_100um=0.846; strict region_fraction=0.628.
+    property_comparisons: *id009
+    caveats:
+      - caveat_type: MARKER_NOT_SPECIFIC
+        description: "CS20230722_SUPT_0393 shows Calb1 cohort percentile 0.737 despite bnst_crf_neuron having Calb1 as a NEGATIVE marker. This supertype likely aggregates multiple BST GABAergic subtypes; child cluster CS20230722_CLUS_1409 shows lower Calb1 (cohort percentile 0.517) and is the more specific mapping candidate.\n"
+      - caveat_type: MERFISH_REGISTRATION_UNCERTAINTY
+        description: "The classical type is defined at sub-nucleus resolution (dlBNST, ovBNST, alBNST). WMBv1 transcriptomic annotation uses the parent BNST term (MBA:351) without sub-nucleus assignment. Sub-nucleus identity of the matching cells cannot be confirmed from atlas metadata.\n"
+    discovery_score: *id010
+    confidence: MODERATE
+    confidence_score: 0.55
+    rationale: "[tier:STRONGEST] CS20230722_SUPT_0393 is the BST-localised Crh-labelled GABAergic supertype (region_fraction_100um=0.846 onto MBA:351; Crh appears in the supertype taxonomy label). Calb1 cohort percentile 0.737 at supertype level is DISCORDANT with the classical Calb1-negative dlBNST CRF type; the best-child CS20230722_CLUS_1409 shows lower Calb1 (cohort percentile 0.517) and pairs with this edge as a 1:1 closeMatch at cluster level.\n"
+    reconciliation_note: "Paired with CS20230722_CLUS_1409 as the best-child within this supertype; both surfaced as primary candidates. CS20230722_SUPT_0358 (Knoedler Esr1+ BST signal) is a co-primary alternative at LOW confidence pending direct Crh measurement.\n"
+    mapping_cardinality: "1:n"
+    proposed_experiments:
+      - "Direct Crh expression measurement at cluster level within CS20230722_SUPT_0393 (CS20230722_CLUS_1409 and CS20230722_CLUS_1410); target detectable Crh above background and a Calb1-low subset within CS20230722_CLUS_1409. Expected output: property-comparison evidence with direct Crh quantification replacing current NOT_ASSESSED.\n"
+      - "Cluster annotation transfer from a published BNST transcriptomic dataset with Crh+ subset annotations to WMBv1; target F1 >= 0.50 at supertype level localising the dlBNST CRF subset onto CS20230722_SUPT_0393.\n"
+    rationale_generated_at: '2026-06-08T18:35:25+00:00'
+    report_path: reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+    unresolved_questions:
+      - Do individual clusters under CS20230722_SUPT_0393 segregate into Calb1-high and Calb1-low populations? A Calb1-low, Crh-high child cluster would support confidence upgrade.
+      - Does CS20230722_SUPT_0393 (or specifically CS20230722_CLUS_1409) show female-biased sex ratio consistent with bnst_crf_neuron?
+    rationale_source_hash: 8247840e
+  - id: edge_bnst_crf_neuron_to_CS20230722_SUPT_0343
+    lit_type: bnst_crf_neuron
+    taxonomy_type: CS20230722_SUPT_0343
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0343 MEA-BST Sox6 Gaba_7; region_fraction_100um=0.548; strict region_fraction=0.423.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]
+        node_b_value: Pallidum [MBA:803] count_100um=473 [painted]; Bed nuclei of the stria terminalis [MBA:351] count_100um=431 [painted]; Hypothalamus [MBA:1097] count_100um=403 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.548; strict region_fraction: 0.423; region_evidence: SELF'
+      - property: marker_Crh
+        node_a_value: Crh — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: negative_marker_Calb1
+        node_a_value: Calb1 — ABSENT (classical negative marker)
+        node_b_value: 'Calb1: 7.28; cohort_pct 0.894'
+        alignment: DISCORDANT
+        notes: val=7.28; cohort percentile 0.894
+      - property: neuropeptide_Crh
+        node_a_value: Crh — neuropeptide (classical)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: Calb1 cohort percentile 0.894 is among the highest in the cohort; MEA-Sox6 lineage, not Crh lineage.
+    discovery_score:
+      score: 2
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:351,MBA:351,MBA:351
+      expression_detail:
+        - gene: -Calb1
+          val: 7.28
+          reliable: true
+          raw_tier: -1
+          applied_score: -1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.894
+      region_fraction: 0.423
+      region_fraction_100um: 0.548
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_SUPT_0343 (0343 MEA-BST Sox6 Gaba_7) is an MEA-BST Sox6 lineage with Calb1 cohort percentile 0.894 — strongly DISCORDANT with the classical Calb1-negative expectation. MEA-dominant distribution and the Sox6 lineage do not match Crh+ defining marker.\n"
+    rationale_generated_at: '2026-06-08T18:35:25+00:00'
+    report_path: reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+    rationale_source_hash: eaf527ab
+  - id: edge_bnst_crf_neuron_to_CS20230722_SUPT_0379
+    lit_type: bnst_crf_neuron
+    taxonomy_type: CS20230722_SUPT_0379
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0379 CEA-AAA-BST Six3 Sp9 Gaba_7; region_fraction_100um=0.519; strict region_fraction=0.372.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]
+        node_b_value: Pallidum [MBA:803] count_100um=101 [painted]; Striatum [MBA:477] count_100um=92 [painted]; Bed nuclei of the stria terminalis [MBA:351] count_100um=81 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.519; strict region_fraction: 0.372; region_evidence: SELF'
+      - property: marker_Crh
+        node_a_value: Crh — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: negative_marker_Calb1
+        node_a_value: Calb1 — ABSENT (classical negative marker)
+        node_b_value: 'Calb1: 2.00; cohort_pct 0.352'
+        alignment: DISCORDANT
+        notes: val=2.00; cohort percentile 0.352
+      - property: neuropeptide_Crh
+        node_a_value: Crh — neuropeptide (classical)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: CEA-AAA-BST Six3/Sp9 lineage, not Crh lineage.
+    discovery_score:
+      score: 2
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:351,MBA:351,MBA:351
+      expression_detail:
+        - gene: -Calb1
+          val: 2.0
+          reliable: true
+          raw_tier: -1
+          applied_score: -1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.352
+      region_fraction: 0.372
+      region_fraction_100um: 0.519
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_SUPT_0379 (0379 CEA-AAA-BST Six3 Sp9 Gaba_7) is a CEA-AAA-BST Six3/Sp9 lineage; the supertype identity does not match Crh+ defining marker and the soma distribution is CEA/AAA-dominant rather than BST-dominant (region_fraction_100um=0.519).\n"
+    rationale_generated_at: '2026-06-08T18:35:25+00:00'
+    report_path: reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+    rationale_source_hash: 731fe684
+  - id: edge_bnst_crf_neuron_to_CS20230722_SUPT_0383
+    lit_type: bnst_crf_neuron
+    taxonomy_type: CS20230722_SUPT_0383
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0383 ACB-BST-FS D1 Gaba_3; region_fraction_100um=0.812; strict region_fraction=0.587.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]; Bed nuclei of the stria terminalis [MBA:351]
+        node_b_value: Pallidum [MBA:803] count_100um=677 [painted]; Bed nuclei of the stria terminalis [MBA:351] count_100um=605 [painted]; Striatum [MBA:477] count_100um=516 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.812; strict region_fraction: 0.587; region_evidence: SELF'
+      - property: marker_Crh
+        node_a_value: Crh — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: negative_marker_Calb1
+        node_a_value: Calb1 — ABSENT (classical negative marker)
+        node_b_value: 'Calb1: 1.86; cohort_pct 0.309'
+        alignment: DISCORDANT
+        notes: val=1.86; cohort percentile 0.309
+      - property: neuropeptide_Crh
+        node_a_value: Crh — neuropeptide (classical)
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: Striatal D1 medium spiny lineage, not BNST CRF lineage.
+    discovery_score:
+      score: 2
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:351,MBA:351,MBA:351
+      expression_detail:
+        - gene: -Calb1
+          val: 1.86
+          reliable: true
+          raw_tier: -1
+          applied_score: -1.0
+          source: EXPRESSION
+          percentiles:
+            - context_id: cohort
+              pct: 0.309
+      region_fraction: 0.587
+      region_fraction_100um: 0.812
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_SUPT_0383 (0383 ACB-BST-FS D1 Gaba_3) is an ACB-BST-FS D1 medium spiny lineage; the supertype identity (D1 Gaba) does not match Crh+ defining marker. Eliminated as wrong subclass (striatal D1 lineage).\n"
+    rationale_generated_at: '2026-06-08T18:35:25+00:00'
+    report_path: reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+    rationale_source_hash: 59d25500
+  - id: edge_arc_aromatase_neuron_to_CS20230722_CLUS_5303
+    lit_type: arc_aromatase_neuron
+    taxonomy_type: CS20230722_CLUS_5303
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 5303 VLMC NN_4; region_fraction_100um=0.692; strict region_fraction=0.317.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Arcuate hypothalamic nucleus [MBA:223]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=150 [painted]; Median eminence [MBA:10671] count_100um=133 [painted]; Arcuate hypothalamic nucleus [MBA:223] count_100um=119 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.692; strict region_fraction: 0.317; region_evidence: SELF'
+      - property: marker_Cyp19a1
+        node_a_value: Cyp19a1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: OTHER
+        description: "VLMC NN_4 is a non-neuronal vascular leptomeningeal cluster.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:223
+      expression_detail: []
+      region_fraction: 0.317
+      region_fraction_100um: 0.692
+      region_evidence: SELF
+    confidence: REFUTED
+    confidence_score: 0.05
+    rationale: "[tier:CUT] CS20230722_CLUS_5303 (5303 VLMC NN_4) is a vascular leptomeningeal cluster, not a neuronal population; identity with a Cyp19a1-positive neurochemical arcuate neuron is excluded by cell class.\n"
+    proposed_experiments: []
+    rationale_generated_at: '2026-06-08T18:35:26+00:00'
+    report_path: reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
+    rationale_source_hash: 7b764c92
+  - id: edge_arc_aromatase_neuron_to_CS20230722_CLUS_1569
+    lit_type: arc_aromatase_neuron
+    taxonomy_type: CS20230722_CLUS_1569
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1569 ARH-PVi Six6 Dopa-Gaba_1; region_fraction_100um=0.789; strict region_fraction=0.526.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Dopa
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Arcuate hypothalamic nucleus [MBA:223]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=19 [painted]; Arcuate hypothalamic nucleus [MBA:223] count_100um=15 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=11 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.789; strict region_fraction: 0.526; region_evidence: SELF'
+      - property: marker_Cyp19a1
+        node_a_value: Cyp19a1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: NO_DISCRIMINATING_MARKER
+        description: "Cyp19a1 has no atlas-side cluster-level expression record on CS20230722_CLUS_1569.\n"
+      - caveat_type: OTHER
+        description: "Six6-Dopa-Gaba is the canonical transcriptomic identity for the ARH-PVi tubero-infundibular dopamine neurons; Wartenberg 2021's arcuate aromatase neurons are described as a distinct, Kiss1-adjacent population.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:223
+      expression_detail: []
+      region_fraction: 0.526
+      region_fraction_100um: 0.789
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.25
+    rationale: "[tier:WEAKEST] CS20230722_CLUS_1569 is the leading ARH child of CS20230722_SUPT_0427 by strict region_fraction (0.526; region_fraction_100um: 0.789) with Dopa as the assigned transmitter. Cyp19a1 is absent from the atlas expression panel at cluster level, and the Six6-Dopa-Gaba identity is canonical for the tubero-infundibular dopaminergic neurons rather than for an aromatase population; relationship remains evidencell:UncertainRelationship.\n"
+    reconciliation_note: "Sibling clusters CLUS_1570 and CLUS_1571 share the same supertype with weaker ARH fractions; CLUS_1569 is the best ARH representative of the set. Identity with the classical aromatase node is not supported by transcriptomic evidence currently available.\n"
+    proposed_experiments:
+      - "Query Cyp19a1 expression in the precomputed expression HDF5 for CS20230722_CLUS_1569 and sibling clusters CS20230722_CLUS_1570 and CS20230722_CLUS_1571.\n"
+    rationale_generated_at: '2026-06-08T18:35:26+00:00'
+    report_path: reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
+    unresolved_questions:
+      - "Does CS20230722_CLUS_1569 (or any sibling in CS20230722_SUPT_0427) carry Cyp19a1 at detectable levels?\n"
+    rationale_source_hash: 59d9ef81
+  - id: edge_arc_aromatase_neuron_to_CS20230722_CLUS_1570
+    lit_type: arc_aromatase_neuron
+    taxonomy_type: CS20230722_CLUS_1570
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1570 ARH-PVi Six6 Dopa-Gaba_1; region_fraction_100um=0.779; strict region_fraction=0.545.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Dopa
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Arcuate hypothalamic nucleus [MBA:223]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=76 [painted]; Arcuate hypothalamic nucleus [MBA:223] count_100um=60 [painted]; third ventricle [MBA:129] count_100um=41 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.779; strict region_fraction: 0.545; region_evidence: SELF'
+      - property: marker_Cyp19a1
+        node_a_value: Cyp19a1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: NO_DISCRIMINATING_MARKER
+        description: "Cyp19a1 not represented in atlas expression panel for CS20230722_CLUS_1570.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:223
+      expression_detail: []
+      region_fraction: 0.545
+      region_fraction_100um: 0.779
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.15
+    rationale: "[tier:CUT] CS20230722_CLUS_1570 is a sibling of CS20230722_CLUS_1569 in the same supertype with a lower strict region_fraction (0.545 with region_fraction_100um: 0.779) and no Cyp19a1 atlas expression data; superseded by CS20230722_CLUS_1569 as the best ARH-resident child.\n"
+    proposed_experiments: []
+    rationale_generated_at: '2026-06-08T18:35:26+00:00'
+    report_path: reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
+    rationale_source_hash: 52cf7303
+  - id: edge_arc_aromatase_neuron_to_CS20230722_CLUS_1571
+    lit_type: arc_aromatase_neuron
+    taxonomy_type: CS20230722_CLUS_1571
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1571 ARH-PVi Six6 Dopa-Gaba_1; region_fraction_100um=0.690; strict region_fraction=0.338.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Dopa
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Arcuate hypothalamic nucleus [MBA:223]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=71 [painted]; Arcuate hypothalamic nucleus [MBA:223] count_100um=49 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=39 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.690; strict region_fraction: 0.338; region_evidence: SELF'
+      - property: marker_Cyp19a1
+        node_a_value: Cyp19a1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: NO_DISCRIMINATING_MARKER
+        description: "Cyp19a1 not represented in atlas expression panel for CS20230722_CLUS_1571.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:223
+      expression_detail: []
+      region_fraction: 0.338
+      region_fraction_100um: 0.69
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.15
+    rationale: "[tier:CUT] CS20230722_CLUS_1571 is a sibling of CS20230722_CLUS_1569 in the same supertype with a lower strict region_fraction (0.338) and no Cyp19a1 atlas expression data; superseded by CS20230722_CLUS_1569 as the best ARH-resident child.\n"
+    proposed_experiments: []
+    rationale_generated_at: '2026-06-08T18:35:26+00:00'
+    report_path: reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
+    rationale_source_hash: c1eb6156
+  - id: edge_arc_aromatase_neuron_to_CS20230722_CLUS_1683
+    lit_type: arc_aromatase_neuron
+    taxonomy_type: CS20230722_CLUS_1683
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1683 SBPV-PVa Six6 Satb2 Gaba_1; region_fraction_100um=0.506; strict region_fraction=0.346.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Dopa
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Arcuate hypothalamic nucleus [MBA:223]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=81 [painted]; Arcuate hypothalamic nucleus [MBA:223] count_100um=41 [painted]; Medial preoptic nucleus [MBA:515] count_100um=30 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.506; strict region_fraction: 0.346; region_evidence: SELF'
+      - property: marker_Cyp19a1
+        node_a_value: Cyp19a1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: DISCORDANT_ANATOMY
+        description: "SBPV-PVa Six6 Satb2 Gaba_1 occupancy of MBA:223 is partial; primary soma distribution is in preoptic/periventricular zones.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 3
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:223
+      expression_detail: []
+      region_fraction: 0.346
+      region_fraction_100um: 0.506
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.1
+    rationale: "[tier:CUT] CS20230722_CLUS_1683 (SBPV-PVa Six6 Satb2 Gaba_1) is centred on the suprachiasmatic preoptic and periventricular anterior zones rather than the arcuate (region_fraction_100um: 0.506; strict region_fraction: 0.346, with substantial Medial preoptic nucleus occupancy), and carries no Cyp19a1 atlas expression data.\n"
+    proposed_experiments: []
+    rationale_generated_at: '2026-06-08T18:35:26+00:00'
+    report_path: reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
+    rationale_source_hash: 7e54ecb5
+  - id: edge_arc_aromatase_neuron_to_CS20230722_SUPT_1190
+    lit_type: arc_aromatase_neuron
+    taxonomy_type: CS20230722_SUPT_1190
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1190 VLMC NN_4; region_fraction_100um=0.692; strict region_fraction=0.317.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Arcuate hypothalamic nucleus [MBA:223]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=150 [painted]; Median eminence [MBA:10671] count_100um=133 [painted]; Arcuate hypothalamic nucleus [MBA:223] count_100um=119 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.692; strict region_fraction: 0.317; region_evidence: SELF'
+      - property: marker_Cyp19a1
+        node_a_value: Cyp19a1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: OTHER
+        description: "VLMC NN_4 supertype is non-neuronal.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:223
+      expression_detail: []
+      region_fraction: 0.317
+      region_fraction_100um: 0.692
+      region_evidence: SELF
+    confidence: REFUTED
+    confidence_score: 0.05
+    rationale: "[tier:CUT] CS20230722_SUPT_1190 (1190 VLMC NN_4) is a vascular leptomeningeal supertype, not a neuronal population; excluded by cell class.\n"
+    proposed_experiments: []
+    rationale_generated_at: '2026-06-08T18:35:26+00:00'
+    report_path: reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
+    rationale_source_hash: 7f0e9948
+  - id: edge_arc_aromatase_neuron_to_CS20230722_SUPT_1173
+    lit_type: arc_aromatase_neuron
+    taxonomy_type: CS20230722_SUPT_1173
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1173 Tanycyte NN_2; region_fraction_100um=0.732; strict region_fraction=0.342.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Arcuate hypothalamic nucleus [MBA:223]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=1825 [painted]; third ventricle [MBA:129] count_100um=1515 [painted]; Arcuate hypothalamic nucleus [MBA:223] count_100um=1371 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.732; strict region_fraction: 0.342; region_evidence: SELF'
+      - property: marker_Cyp19a1
+        node_a_value: Cyp19a1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: OTHER
+        description: "Tanycyte NN_2 is non-neuronal.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:223
+      expression_detail: []
+      region_fraction: 0.342
+      region_fraction_100um: 0.732
+      region_evidence: SELF
+    confidence: REFUTED
+    confidence_score: 0.05
+    rationale: "[tier:CUT] CS20230722_SUPT_1173 (1173 Tanycyte NN_2) is a tanycyte supertype, not a neuronal population; identity with the arcuate aromatase neuron is excluded by cell class even though tanycytes populate MBA:223 abundantly.\n"
+    proposed_experiments: []
+    rationale_generated_at: '2026-06-08T18:35:26+00:00'
+    report_path: reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
+    rationale_source_hash: 94aacd25
+  - id: edge_arc_aromatase_neuron_to_CS20230722_SUPT_1174
+    lit_type: arc_aromatase_neuron
+    taxonomy_type: CS20230722_SUPT_1174
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 1174 Tanycyte NN_3; region_fraction_100um=0.743; strict region_fraction=0.508.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Arcuate hypothalamic nucleus [MBA:223]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=487 [painted]; Median eminence [MBA:10671] count_100um=374 [painted]; Arcuate hypothalamic nucleus [MBA:223] count_100um=362 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.743; strict region_fraction: 0.508; region_evidence: SELF'
+      - property: marker_Cyp19a1
+        node_a_value: Cyp19a1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: OTHER
+        description: "Tanycyte NN_3 is non-neuronal.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:223
+      expression_detail: []
+      region_fraction: 0.508
+      region_fraction_100um: 0.743
+      region_evidence: SELF
+    confidence: REFUTED
+    confidence_score: 0.05
+    rationale: "[tier:CUT] CS20230722_SUPT_1174 (1174 Tanycyte NN_3) is a tanycyte supertype, not a neuronal population; excluded by cell class.\n"
+    proposed_experiments: []
+    rationale_generated_at: '2026-06-08T18:35:26+00:00'
+    report_path: reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
+    rationale_source_hash: ab31b74f
+  - id: edge_arc_aromatase_neuron_to_CS20230722_SUPT_0427
+    lit_type: arc_aromatase_neuron
+    taxonomy_type: CS20230722_SUPT_0427
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0427 ARH-PVi Six6 Dopa-Gaba_1; region_fraction_100um=0.741; strict region_fraction=0.427.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Arcuate hypothalamic nucleus [MBA:223]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=143 [painted]; Arcuate hypothalamic nucleus [MBA:223] count_100um=106 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=79 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.741; strict region_fraction: 0.427; region_evidence: SELF'
+      - property: marker_Cyp19a1
+        node_a_value: Cyp19a1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: NO_DISCRIMINATING_MARKER
+        description: "Cyp19a1 defining marker has no atlas-side expression data on CS20230722_SUPT_0427 or any of its child clusters in the current property_comparisons. The mapping rests on anatomy alone.\n"
+      - caveat_type: SINGLE_DATASET
+        description: "Classical node arc_aromatase_neuron is supported by a single primary source (Wartenberg 2021, PMID:34561233); marker, location, and sex-bias assertions all depend on this paper.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:223
+      expression_detail: []
+      region_fraction: 0.427
+      region_fraction_100um: 0.741
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.3
+    rationale: "[tier:STRONGEST] CS20230722_SUPT_0427 painted soma distribution centres on MBA:223 (region_fraction_100um: 0.741; strict region_fraction: 0.427), the strongest ARH-resident candidate among neuronal supertypes in the current top-K. The defining marker Cyp19a1 is not represented in the atlas precomputed expression panel for this supertype, so the diagnostic marker cannot be cross-checked; mapping is left as evidencell:UncertainRelationship.\n"
+    reconciliation_note: "Cyp19a1 absent from atlas expression panel across all ARH candidates in current top-K; predicate cannot be committed until atlas-side aromatase expression is queried (see proposed_experiments).\n"
+    proposed_experiments:
+      - "Query Cyp19a1 expression in the precomputed expression HDF5 for CS20230722_SUPT_0427 and its child clusters (CLUS_1569, CLUS_1570, CLUS_1571).\n"
+      - "Extend the Cyp19a1 query to all ARH-region (MBA:223) supertypes including the sister TIDA supertype and CS20230722_SUPT_0495 to identify any ARH-resident cluster with non-trivial aromatase expression.\n"
+    rationale_generated_at: '2026-06-08T18:35:26+00:00'
+    report_path: reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
+    unresolved_questions:
+      - "Does Cyp19a1 show detectable expression in any ARH supertype in the WMBv1 precomputed expression panel?\n"
+      - "Is there a Kiss1-neighbouring ARH cluster carrying Cyp19a1, matching the Wartenberg 2021 description of arcuate aromatase neurons adjacent to kisspeptin neurons?\n"
+    rationale_source_hash: ea01270a
+  - id: edge_arc_aromatase_neuron_to_CS20230722_SUPT_0495
+    lit_type: arc_aromatase_neuron
+    taxonomy_type: CS20230722_SUPT_0495
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0495 ARH-PVp Tbx3 Gaba_3; region_fraction_100um=0.917; strict region_fraction=0.665.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Arcuate hypothalamic nucleus [MBA:223]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=515 [painted]; Arcuate hypothalamic nucleus [MBA:223] count_100um=472 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=216 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.917; strict region_fraction: 0.665; region_evidence: SELF'
+      - property: marker_Cyp19a1
+        node_a_value: Cyp19a1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: NO_DISCRIMINATING_MARKER
+        description: "Cyp19a1 has no atlas-side expression record on CS20230722_SUPT_0495; candidate retained on anatomical proximity alone.\n"
+      - caveat_type: OTHER
+        description: "Tbx3-defined posterior arcuate populations are most often associated with feeding-circuit neurons (POMC/AgRP neighbourhood) rather than with neurosteroid biosynthesis; identity with Wartenberg 2021's Cyp19a1-positive arcuate cluster is not implied by anatomy alone.\n"
+    discovery_score:
+      score: 3
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:223
+      expression_detail: []
+      region_fraction: 0.665
+      region_fraction_100um: 0.917
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.25
+    rationale: "[tier:NEXT] CS20230722_SUPT_0495 has the highest arcuate proximity in the survival cohort (region_fraction_100um: 0.917; strict region_fraction: 0.665), but Cyp19a1 is absent from the atlas precomputed expression panel for this supertype, so the defining marker is unassessed and the relationship cannot be committed.\n"
+    reconciliation_note: "Strongest pure anatomical match for MBA:223 in the cohort; lineage (Tbx3-defined posterior arcuate) does not by itself predict an aromatase-positive identity.\n"
+    proposed_experiments:
+      - "Query Cyp19a1 expression in the precomputed expression HDF5 for CS20230722_SUPT_0495 and its child clusters.\n"
+    rationale_generated_at: '2026-06-08T18:35:26+00:00'
+    report_path: reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
+    unresolved_questions:
+      - "Is the Tbx3-defined posterior arcuate population aromatase-expressing at any of its child clusters?\n"
+    rationale_source_hash: c6c3a914
+  - id: edge_pmv_otr_neuron_to_CS20230722_CLUS_2471
+    lit_type: pmv_otr_neuron
+    taxonomy_type: CS20230722_CLUS_2471
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 2471 PMv-TMv Pitx2 Glut_3; region_fraction_100um=0.676; strict region_fraction=0.341.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Glut
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventral premammillary nucleus [MBA:1004]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=135 [painted]; Ventral premammillary nucleus [MBA:1004] count_100um=92 [painted]; Periventricular hypothalamic nucleus, posterior part [MBA:126] count_100um=25 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.676; strict region_fraction: 0.341; region_evidence: SELF'
+      - property: marker_Oxtr
+        node_a_value: Oxtr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Slc6a3
+        node_a_value: Slc6a3 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Adcyap1
+        node_a_value: Adcyap1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 5
+      rank_in_cohort: 1
+      cohort_size: 50
+      next_best_score: 5
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:1004
+            - sex_bias=male
+      expression_detail:
+        - gene: Slc6a3
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+        - gene: Adcyap1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.341
+      region_fraction_100um: 0.676
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.22
+    rationale: "[tier:CUT] Sibling cluster of CLUS_2470 in SUPT_0607 with lower PMv proximity (region_fraction_100um=0.676; strict=0.341) and weaker marker support than its sister; eliminated in favour of CLUS_2470 as the best PMv-resident child.\n"
+    rationale_generated_at: '2026-06-08T18:35:27+00:00'
+    report_path: reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+    rationale_source_hash: 04a252e6
+  - id: edge_pmv_otr_neuron_to_CS20230722_CLUS_2470
+    lit_type: pmv_otr_neuron
+    taxonomy_type: CS20230722_CLUS_2470
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 2470 PMv-TMv Pitx2 Glut_3; region_fraction_100um=0.898; strict region_fraction=0.676.
+    property_comparisons: *id011
+    caveats: []
+    discovery_score: *id012
+    confidence: UNCERTAIN
+    confidence_score: 0.1
+    rationale: "[tier:CUT] Fresh-emit duplicate of the legacy cluster edge edge_pmv_otr_neuron_to_cs20230722_clus_2470, carrying only discovery_score and stub property comparisons; the substantive evidence lives on the legacy edge and this duplicate is recorded for curator removal.\n"
+    rationale_generated_at: '2026-06-08T18:35:27+00:00'
+    report_path: reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+    rationale_source_hash: 5d3220eb
+  - id: edge_pmv_otr_neuron_to_CS20230722_CLUS_2314
+    lit_type: pmv_otr_neuron
+    taxonomy_type: CS20230722_CLUS_2314
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 2314 VMH Nr5a1 Glut_4; region_fraction_100um=0.018; strict region_fraction=0.018.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Glut
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventral premammillary nucleus [MBA:1004]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=113 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=95 [painted]; Tuberal nucleus [MBA:614] count_100um=25 [painted]
+        alignment: DISCORDANT
+        notes: 'region_fraction_100um: 0.018; strict region_fraction: 0.018; region_evidence: SELF'
+      - property: marker_Oxtr
+        node_a_value: Oxtr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Slc6a3
+        node_a_value: Slc6a3 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Adcyap1
+        node_a_value: Adcyap1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: 'DISCORDANT property comparison(s): location. Mapping has unresolved counter-evidence.'
+    discovery_score:
+      score: 4
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 5
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:1004
+            - sex_bias=male
+      expression_detail:
+        - gene: Adcyap1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.018
+      region_fraction_100um: 0.018
+      region_evidence: SELF
+    confidence: REFUTED
+    confidence_score: 0.05
+    rationale: "[tier:CUT] Wrong region — CS20230722_CLUS_2314 is a VMH Nr5a1 glutamatergic cluster dominant in the ventromedial hypothalamic nucleus (region_fraction_100um=0.018 against PMv), not PMv.\n"
+    rationale_generated_at: '2026-06-08T18:35:27+00:00'
+    report_path: reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+    rationale_source_hash: d451798e
+  - id: edge_pmv_otr_neuron_to_CS20230722_CLUS_2575
+    lit_type: pmv_otr_neuron
+    taxonomy_type: CS20230722_CLUS_2575
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 2575 MM Foxb1 Glut_2; region_fraction_100um=0.029; strict region_fraction=0.007.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Glut
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventral premammillary nucleus [MBA:1004]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=138 [painted]; Medial mammillary nucleus, lateral part [MBA:606826647] count_100um=133 [painted]; Medial mammillary nucleus [MBA:491] count_100um=133 [painted]
+        alignment: DISCORDANT
+        notes: 'region_fraction_100um: 0.029; strict region_fraction: 0.007; region_evidence: SELF'
+      - property: marker_Oxtr
+        node_a_value: Oxtr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Slc6a3
+        node_a_value: Slc6a3 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Adcyap1
+        node_a_value: Adcyap1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: 'DISCORDANT property comparison(s): location. Mapping has unresolved counter-evidence.'
+    discovery_score:
+      score: 4
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 5
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:1004
+            - sex_bias=male
+      expression_detail:
+        - gene: Adcyap1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.007
+      region_fraction_100um: 0.029
+      region_evidence: SELF
+    confidence: REFUTED
+    confidence_score: 0.05
+    rationale: "[tier:CUT] Wrong region — CS20230722_CLUS_2575 is a medial mammillary Foxb1 glutamatergic cluster (region_fraction_100um=0.029 against PMv), not PMv.\n"
+    rationale_generated_at: '2026-06-08T18:35:27+00:00'
+    report_path: reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+    rationale_source_hash: 6eaa9f89
+  - id: edge_pmv_otr_neuron_to_CS20230722_CLUS_2395
+    lit_type: pmv_otr_neuron
+    taxonomy_type: CS20230722_CLUS_2395
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 2395 PH-ant-LHA Otp Bsx Glut_2; region_fraction_100um=0.596; strict region_fraction=0.304.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: Glut
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventral premammillary nucleus [MBA:1004]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=47 [painted]; Ventral premammillary nucleus [MBA:1004] count_100um=28 [painted]; Tuberomammillary nucleus, ventral part [MBA:1] count_100um=18 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.596; strict region_fraction: 0.304; region_evidence: SELF'
+      - property: marker_Oxtr
+        node_a_value: Oxtr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Slc6a3
+        node_a_value: Slc6a3 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Adcyap1
+        node_a_value: Adcyap1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 4
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 5
+      rank: 0
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 0
+          n_members: 50
+          filters:
+            - region=MBA:1004
+            - sex_bias=male
+      expression_detail:
+        - gene: Adcyap1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.304
+      region_fraction_100um: 0.596
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.18
+    rationale: "[tier:CUT] PH-ant-LHA Otp Bsx glutamatergic cluster with moderate PMv proximity (region_fraction_100um=0.596) but no atlas-side confirmation of the classical defining markers; weaker than the PMv-TMv Pitx2 Glut_3 lineage and eliminated.\n"
+    rationale_generated_at: '2026-06-08T18:35:27+00:00'
+    report_path: reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+    rationale_source_hash: 2f18e773
+  - id: edge_pmv_otr_neuron_to_CS20230722_SUPT_0607
+    lit_type: pmv_otr_neuron
+    taxonomy_type: CS20230722_SUPT_0607
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0607 PMv-TMv Pitx2 Glut_3; region_fraction_100um=0.865; strict region_fraction=0.634.
+    property_comparisons: *id013
+    caveats: []
+    discovery_score: *id014
+    confidence: UNCERTAIN
+    confidence_score: 0.1
+    rationale: "[tier:CUT] Fresh-emit duplicate of the legacy supertype edge edge_pmv_otr_neuron_to_cs20230722_supt_0607, carrying only discovery_score and stub property comparisons; the substantive evidence lives on the legacy edge and this duplicate is recorded for curator removal.\n"
+    rationale_generated_at: '2026-06-08T18:35:27+00:00'
+    report_path: reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+    rationale_source_hash: 7b563d22
+  - id: edge_pmv_otr_neuron_to_CS20230722_SUPT_0605
+    lit_type: pmv_otr_neuron
+    taxonomy_type: CS20230722_SUPT_0605
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0605 PMv-TMv Pitx2 Glut_1; region_fraction_100um=0.631; strict region_fraction=0.307.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventral premammillary nucleus [MBA:1004]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=265 [painted]; Ventral premammillary nucleus [MBA:1004] count_100um=169 [painted]; Dorsomedial nucleus of the hypothalamus [MBA:830] count_100um=108 [painted]
+        alignment: CONSISTENT
+        notes: 'region_fraction_100um: 0.631; strict region_fraction: 0.307; region_evidence: SELF'
+      - property: marker_Oxtr
+        node_a_value: Oxtr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Slc6a3
+        node_a_value: Slc6a3 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Adcyap1
+        node_a_value: Adcyap1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 3
+      rank_in_cohort: 2
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:1004
+            - sex_bias=male
+      expression_detail: []
+      region_fraction: 0.307
+      region_fraction_100um: 0.631
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.25
+    rationale: "[tier:CUT] Sister supertype to SUPT_0607 with PMv residency (region_fraction_100um=0.631; strict=0.307) but no atlas-side confirmation of the classical defining markers in the gathered facts; flagged as a possible carrier of additional OTR+ population but eliminated at this round pending direct marker evidence.\n"
+    rationale_generated_at: '2026-06-08T18:35:27+00:00'
+    report_path: reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+    rationale_source_hash: 2704db15
+  - id: edge_pmv_otr_neuron_to_CS20230722_SUPT_0557
+    lit_type: pmv_otr_neuron
+    taxonomy_type: CS20230722_SUPT_0557
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0557 ARH-PVp Tbx3 Glut_4; region_fraction_100um=0.067; strict region_fraction=0.033.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventral premammillary nucleus [MBA:1004]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=120 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=97 [painted]; Dorsomedial nucleus of the hypothalamus [MBA:830] count_100um=37 [painted]
+        alignment: DISCORDANT
+        notes: 'region_fraction_100um: 0.067; strict region_fraction: 0.033; region_evidence: SELF'
+      - property: marker_Oxtr
+        node_a_value: Oxtr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Slc6a3
+        node_a_value: Slc6a3 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Adcyap1
+        node_a_value: Adcyap1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats:
+      - caveat_type: AMBIGUOUS_MAPPING
+        description: 'DISCORDANT property comparison(s): location. Mapping has unresolved counter-evidence.'
+    discovery_score:
+      score: 2
+      rank_in_cohort: 3
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:1004
+            - sex_bias=male
+      expression_detail:
+        - gene: Adcyap1
+          val:
+          reliable:
+          raw_tier: 1
+          applied_score: 1.0
+          source: METADATA
+          percentiles: []
+      region_fraction: 0.033
+      region_fraction_100um: 0.067
+      region_evidence: SELF
+    confidence: REFUTED
+    confidence_score: 0.05
+    rationale: "[tier:CUT] Wrong region — ARH-PVp Tbx3 glutamatergic supertype dominant in VMH (region_fraction_100um=0.067 against PMv), not PMv.\n"
+    rationale_generated_at: '2026-06-08T18:35:27+00:00'
+    report_path: reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+    rationale_source_hash: 681f6c58
+  - id: edge_pmv_otr_neuron_to_CS20230722_SUPT_0429
+    lit_type: pmv_otr_neuron
+    taxonomy_type: CS20230722_SUPT_0429
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0429 TMv-PMv Tbx3 Hist-Gaba_1; region_fraction_100um=0.247; strict region_fraction=0.077.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventral premammillary nucleus [MBA:1004]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=460 [painted]; Tuberal nucleus [MBA:614] count_100um=122 [painted]; Tuberomammillary nucleus, ventral part [MBA:1] count_100um=122 [painted]
+        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.247; strict region_fraction: 0.077; region_evidence: SELF'
+      - property: marker_Oxtr
+        node_a_value: Oxtr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Slc6a3
+        node_a_value: Slc6a3 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Adcyap1
+        node_a_value: Adcyap1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 2
+      rank_in_cohort: 4
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:1004
+            - sex_bias=male
+      expression_detail: []
+      region_fraction: 0.077
+      region_fraction_100um: 0.247
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.12
+    rationale: "[tier:CUT] TMv-PMv histaminergic GABAergic supertype with boundary PMv overlap (region_fraction_100um=0.247) and a histaminergic GABA identity inconsistent with the glutamatergic PMv-OTR / DAT / PACAP populations described in the literature.\n"
+    rationale_generated_at: '2026-06-08T18:35:27+00:00'
+    report_path: reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+    rationale_source_hash: 5a37047c
+  - id: edge_pmv_otr_neuron_to_CS20230722_SUPT_0430
+    lit_type: pmv_otr_neuron
+    taxonomy_type: CS20230722_SUPT_0430
+    relationship: evidencell:UncertainRelationship
+    mapping_justification: semapv:UnreviewedManualMapping
+    evidence:
+      - evidence_type: ATLAS_METADATA
+        supports: PARTIAL
+        explanation: Atlas node 0430 TMv-PMv Tbx3 Hist-Gaba_2; region_fraction_100um=0.157; strict region_fraction=0.094.
+    property_comparisons:
+      - property: nt_type
+        node_a_value: not asserted
+        node_b_value: not asserted
+        alignment: NOT_ASSESSED
+        notes: NT data missing on one side.
+      - property: location
+        node_a_value: Ventral premammillary nucleus [MBA:1004]
+        node_b_value: Hypothalamus [MBA:1097] count_100um=159 [painted]; Ventromedial hypothalamic nucleus [MBA:693] count_100um=58 [painted]; Tuberal nucleus [MBA:614] count_100um=34 [painted]
+        alignment: APPROXIMATE
+        notes: 'region_fraction_100um: 0.157; strict region_fraction: 0.094; region_evidence: SELF'
+      - property: marker_Oxtr
+        node_a_value: Oxtr — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Slc6a3
+        node_a_value: Slc6a3 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+      - property: marker_Adcyap1
+        node_a_value: Adcyap1 — defining marker
+        node_b_value: no atlas expression data
+        alignment: NOT_ASSESSED
+        notes: Gene absent from Stage A expression_detail and from precomputed_expression.
+    caveats: []
+    discovery_score:
+      score: 2
+      rank_in_cohort: 5
+      cohort_size: 50
+      next_best_score: 3
+      rank: 1
+      contexts:
+        - id: cohort
+          kind: SURVIVAL_COHORT
+          rank: 1
+          n_members: 50
+          filters:
+            - region=MBA:1004
+            - sex_bias=male
+      expression_detail: []
+      region_fraction: 0.094
+      region_fraction_100um: 0.157
+      region_evidence: SELF
+    confidence: UNCERTAIN
+    confidence_score: 0.12
+    rationale: "[tier:CUT] TMv-PMv histaminergic GABAergic supertype with boundary PMv overlap (region_fraction_100um=0.157) and a histaminergic GABA identity inconsistent with the glutamatergic PMv-OTR / DAT / PACAP populations described in the literature.\n"
+    rationale_generated_at: '2026-06-08T18:35:27+00:00'
+    report_path: reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+    rationale_source_hash: fc25170d

--- a/reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
+++ b/reports/sexually_dimorphic/arc_aromatase_neuron_summary.md
@@ -1,153 +1,156 @@
 # Arcuate aromatase neuron — WMBv1 Mapping Report
-*draft · 2026-04-25 · Source: `kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
-
-**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+*2026-04-25 · Source: `kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
 
 ---
 
 ## Introduction
 
-### Classical type
+The arcuate aromatase neuron is a sexually dimorphic, male-biased neurochemical population defined by expression of *Cyp19a1* (aromatase) within the arcuate hypothalamic nucleus, located adjacent to kisspeptin neurons. Wartenberg and colleagues identified this population as part of a broader aromatase neuronal network of roughly 6000 neurons spanning the hypothalamus and amygdala, with the arcuate cluster becoming sexually dimorphic by birth and contributing to local estrogenic regulation of kisspeptin neuron activity [1].
 
-**Arcuate aromatase neuron** is defined by neurochemical criteria: Cyp19a1 (aromatase)
-expression in a sexually dimorphic, male-biased cluster located in the arcuate hypothalamic
-nucleus, adjacent to kisspeptin neurons. The population is part of a broader aromatase
-neuronal network spanning hypothalamus and amygdala (~6,000 neurons at birth). Functionally,
-male arcuate aromatase neurons convert testosterone to estrogen and regulate kisspeptin
-neuron activity. Evidence derives from a single primary source (Wartenberg et al. 2021 [1]);
-no CL term is currently assigned and the type is a candidate for a new term. NT type and
-negative markers are not reported.
+### Classical type table
 
 | Property | Value | References |
 |---|---|---|
-| Soma location | Arcuate hypothalamic nucleus [MBA:223] (adjacent to kisspeptin neurons, per source) | [1] |
-| Defining markers | Cyp19a1 (aromatase, transcript) | [1] |
+| Soma location | Arcuate hypothalamic nucleus [MBA:223] | [1] |
+| Defining markers | Cyp19a1 | [1] |
+| NT type | not asserted | — |
+| Negative markers | none documented | — |
+| Neuropeptides | none documented | — |
+| Sex bias | male-biased dimorphism | [1] |
 
 <details>
-<summary>Literature support — expand for verbatim quotes</summary>
+<summary>Details — source evidence for classical type properties</summary>
 
-**[1] Wartenberg et al. 2021 · PMID:34561233 — Neuronal Markers and Molecular Characteristics**
-
-> We identified an aromatase neuronal network comprising ~6000 neurons in the hypothalamus and amygdala. By birth, this network has become sexually dimorphic in a cluster of aromatase neurons in the arcuate nucleus adjacent to kisspeptin neurons. We demonstrate that male arcuate aromatase neurons convert testosterone to estrogen to regulate kisspeptin neuron activity.
-> — Wartenberg et al. 2021, Neuronal Markers and Molecular Characteristics · [1] <!-- quote_key: 237626479_5aec04ab -->
+- **Soma location:** asta_report · *Mus musculus* · [1]
+  > We identified an aromatase neuronal network comprising 6000 neurons in the hypothalamus and amygdala. By birth, this network has become sexually dimorphic in a cluster of aromatase neurons in the arcuate nucleus adjacent to kisspeptin neurons. We demonstrate that male arcuate aromatase neurons convert testosterone to estrogen to regulate kisspeptin neuron activity.
+  > — Wartenberg et al. 2021, Neuronal Markers and Molecular Characteristics · [1] <!-- quote_key: 237626479_5aec04ab -->
+- **Defining marker Cyp19a1:** asta_report · *Mus musculus* · [1] (same quote as above)
 
 </details>
+
+### Cell Ontology mapping
+
+No Cell Ontology term currently covers this type — candidate for a new CL term.
 
 ---
 
 ## Results
 
-**Primary finding (null result).** A complete scan of WMBv1 (CCN20230722) confirmed that
-no supertype or cluster located in Arcuate hypothalamic nucleus [MBA:223] carries Cyp19a1
-as a defining marker. All Cyp19a1-expressing clusters identified by the DB scan reside in
-preoptic area (POA) and periventricular zones, not in MBA:223. The best available atlas
-match — 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] — is in the periventricular
-preoptic zone (PVpo n=64; MPN n=37; AVPV n=16) with **no MBA:223 cells**, and is proposed
-only because its child cluster CLUS_1907 carries Cyp19a1 as a defining marker (supertype
-mean Cyp19a1=1.15). The arc_aromatase_neuron edge is therefore classified UNCERTAIN, and
-the apparent transcriptomic signal is anatomically discordant with the classical type's
-defining ARH location.
+A complete scan of CCN20230722 candidates at supertype (rank 1) and cluster (rank 0) ranks within MBA:223 (arcuate hypothalamic nucleus) found no atlas node carrying *Cyp19a1* as a defining marker or with atlas-side expression evidence at this resolution. The previously proposed best Cyp19a1-expressing candidate at the supertype level, 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486], is located in periventricular preoptic zones (PVpo, MPN, AVPV) rather than the arcuate nucleus and is no longer in the current Stage A top-50 at rank 1 (see candidates table). All remaining candidates for the arcuate aromatase neuron are anatomically plausible ARH or peri-ARH residents but lack atlas-side *Cyp19a1* expression data, so the mapping is currently UNCERTAIN across the cohort.
 
-### Mapping candidates
+### 0427 ARH-PVi Six6 Dopa-Gaba_1 [CS20230722_SUPT_0427] · ⚪ UNCERTAIN
 
-| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
-|---|---|---|---|---|---|---|
-| — | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] | (self) | 178 | ⚪ UNCERTAIN | Cyp19a1 APPROXIMATE; location DISCORDANT | Eliminated |
-1 edge total. Relationship type: UNCERTAIN.
+The canonical ARH-PVi GABAergic supertype with dopamine cotransmission. It is one of the few survey-cohort supertypes whose painted soma distribution centres on the arcuate nucleus (region_fraction_100um: 0.741; strict region_fraction: 0.427), making it the strongest anatomical candidate among ARH residents. However, *Cyp19a1* is absent from Stage A expression detail and from the precomputed expression panel on this supertype, so the defining marker cannot be checked.
 
-### Property alignment — primary candidate (SUPT_0486)
-
-**Table 1 — Property comparison.**
+**Table 1 — Property comparison (CS20230722_SUPT_0427).**
 
 | Property | Classical | Supertype | Best cluster | Alignment |
 |---|---|---|---|---|
-| Soma location | Arcuate hypothalamic nucleus [MBA:223] | MBA:133 PVpo n=64; MBA:515 MPN n=37; MBA:272 AVPV n=16 — no MBA:223 cells | not assessed | DISCORDANT |
-| Cyp19a1 expression | POSITIVE (transcript, primary defining marker) | precomputed mean_expression=1.15; child CLUS_1907 has Cyp19a1 as defining marker | not assessed | APPROXIMATE |
-| Sex ratio | Male-biased (not quantitatively documented in classical source) | not available | not assessed | NOT_ASSESSED |
+| Soma location | Arcuate hypothalamic nucleus [MBA:223] | MBA:223 cells present (region_fraction_100um=0.741) | best child CLUS_1571 region_fraction_100um=0.690 | CONSISTENT |
+| NT type | not asserted | not asserted | Dopa (child CLUS_1569/1570/1571) | NOT_ASSESSED |
+| Cyp19a1 expression | defining marker | no atlas expression data | no atlas expression data | NOT_ASSESSED |
 
 **Table 2 — Evidence support.**
 
 | Evidence | Type | Supports | Headline | Source |
 |---|---|---|---|---|
-| Atlas DB scan for Cyp19a1 in ARH (MBA:223) | Atlas metadata | WEAK | No MBA:223 supertype carries Cyp19a1 as defining marker; SUPT_0486 best available (mean=1.15) but in PVpo-VMPO-MPN | atlas-internal |
+| Atlas region match | Atlas metadata | PARTIAL | region_fraction_100um=0.741 | atlas-internal |
 
-*(Child-cluster breakdown not assessed — see proposed experiments. CLUS_1907 is flagged
-in atlas metadata as carrying Cyp19a1 as a defining marker, but its MERFISH spatial
-distribution within SUPT_0486's preoptic/periventricular footprint has not been verified
-against MBA:223.)*
+*(3 of the supertype's child clusters in this cohort — CLUS_1569, CLUS_1570, CLUS_1571 — show MBA:223 cells in their painted distributions; none have Cyp19a1 atlas expression data. Best child by strict region_fraction: CLUS_1569, region_fraction=0.526.)*
+
+**Supporting evidence**
+- Atlas metadata locates a substantial fraction of this supertype's soma in or near MBA:223 (region_fraction_100um=0.741; strict region_fraction=0.427); region_evidence: SELF.
+
+**Marker evidence provenance**
+- *Cyp19a1* on the classical node is anchored to a single primary citation [1]. Aromatase is documented at the level of immunohistochemistry and reporter mouse work in that paper; the transcript-level signal for the arcuate cluster has not been quantified in WMBv1 at this resolution. The atlas precomputed expression panel does not carry *Cyp19a1* for this supertype, so the property cannot be cross-checked here. Targeted query of the precomputed expression HDF5 for *Cyp19a1* across ARH supertypes is the natural next step.
+
+**Concerns**
+- *Cyp19a1* expression on this supertype is unknown (NOT_ASSESSED). Without atlas-side aromatase data, anatomical concordance is necessary but not sufficient.
+- The supertype's transmitter annotation (Dopa) is consistent with the well-described ARH-PVi dopaminergic population; the classical aromatase node has no NT assertion, so this is an open property rather than a contradiction.
+
+**What would upgrade confidence**
+- Query *Cyp19a1* expression in the precomputed HDF5 stats for SUPT_0427, neighbouring ARH supertypes (SUPT_0428, SUPT_0495), and their child clusters. If *Cyp19a1* is detectable in any ARH supertype, that supertype should be tested as the primary candidate.
+
+### 0495 ARH-PVp Tbx3 Gaba_3 [CS20230722_SUPT_0495] · ⚪ UNCERTAIN
+
+A large arcuate-and-periventricular-posterior GABAergic supertype (n_cells = 1460) with the highest arcuate proximity in the survival cohort (region_fraction_100um: 0.917; strict region_fraction: 0.665). The Tbx3 lineage is well-documented in the posterior arcuate, and the soma distribution centres tightly on MBA:223. As with the other candidates, the atlas precomputed expression panel does not record *Cyp19a1*, so the defining marker is unassessed.
+
+**Table 1 — Property comparison (CS20230722_SUPT_0495).**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Arcuate hypothalamic nucleus [MBA:223] | MBA:223 cells present (region_fraction_100um=0.917; n_arc≈472) | not assessed | CONSISTENT |
+| NT type | not asserted | not asserted | not assessed | NOT_ASSESSED |
+| Cyp19a1 expression | defining marker | no atlas expression data | not assessed | NOT_ASSESSED |
+
+**Table 2 — Evidence support.**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas region match | Atlas metadata | PARTIAL | region_fraction_100um=0.917 | atlas-internal |
+
+*(Child-cluster breakdown not assessed — see proposed experiments.)*
+
+**Supporting evidence**
+- The painted soma distribution is dominated by MBA:223 and immediately adjacent hypothalamic / VMH cells; this is the tightest arcuate-proximity candidate in the survival cohort.
+
+**Concerns**
+- *Cyp19a1* expression on this supertype is unknown; the candidate's biological plausibility rests on anatomy alone.
+- Tbx3-defined posterior arcuate populations are typically associated with feeding-related circuitry (POMC / AgRP neighbourhoods) rather than with neurosteroid biosynthesis in the published literature available here. Anatomical proximity does not by itself imply a Cyp19a1-positive identity.
+
+**What would upgrade confidence**
+- Query *Cyp19a1* expression in the precomputed HDF5 stats for SUPT_0495 and its child clusters. A non-trivial expression value would substantially strengthen the case; near-zero would effectively refute it.
+
+### 1569 ARH-PVi Six6 Dopa-Gaba_1 [CS20230722_CLUS_1569] · ⚪ UNCERTAIN
+
+The leading child cluster of SUPT_0427 by strict arcuate-region fraction (region_fraction_100um: 0.789; strict region_fraction: 0.526), with Dopa as the assigned transmitter. Of all the candidates in the current top-K, this is the cluster-rank node whose painted distribution is most concentrated in MBA:223. Like the parent supertype, it carries no atlas-side *Cyp19a1* expression, so the call remains UNCERTAIN.
+
+**Table 1 — Property comparison (CS20230722_CLUS_1569).**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Arcuate hypothalamic nucleus [MBA:223] | SUPT_0427 region_fraction_100um=0.741 | region_fraction_100um=0.789 | CONSISTENT |
+| NT type | not asserted | not asserted | Dopa | NOT_ASSESSED |
+| Cyp19a1 expression | defining marker | no atlas expression data | no atlas expression data | NOT_ASSESSED |
+
+**Table 2 — Evidence support.**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas region match | Atlas metadata | PARTIAL | region_fraction_100um=0.789 | atlas-internal |
+
+**Supporting evidence**
+- Cluster-level painted distribution centres on MBA:223 (region_fraction_100um=0.789; strict region_fraction=0.526), the highest strict arcuate fraction among the top-K cluster-rank candidates.
+- Sibling clusters in the same supertype (CLUS_1570, CLUS_1571) show similar but less concentrated arcuate occupancy, consistent with a coherent ARH-PVi Dopa-Gaba child set whose best ARH representative is CLUS_1569.
+
+**Concerns**
+- *Cyp19a1* not represented in atlas expression data at cluster level.
+- The Six6-Dopa-Gaba transcriptomic identity is canonical for the ARH-PVi dopaminergic population (the tubero-infundibular dopamine neurons that regulate prolactin), which is biologically distinct from the aromatase neurons reported by Wartenberg et al. as adjacent to kisspeptin neurons. Cluster-level anatomical proximity therefore does not imply identity with the classical aromatase population.
+
+**What would upgrade confidence**
+- Cross-check *Cyp19a1* in the precomputed HDF5 for CLUS_1569 and its siblings.
+- Examine whether any ARH cluster outside the current top-K (notably any Kiss1-adjacent cluster) carries *Cyp19a1*; the classical type is reported as adjacent to kisspeptin neurons, so a Kiss1-neighbouring cluster is a higher-priority candidate than the ARH-PVi Dopa-Gaba set if such a cluster exists.
 
 ---
 
+<details>
+<summary>Candidates audited (full top-K)</summary>
 
+| WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key evidence | Verdict |
+|---|---|---:|---|---|---|
+| 0427 ARH-PVi Six6 Dopa-Gaba_1 [CS20230722_SUPT_0427] | — | 659 | ⚪ UNCERTAIN | ARH proximity, no Cyp19a1 data | Primary |
+| 0495 ARH-PVp Tbx3 Gaba_3 [CS20230722_SUPT_0495] | — | 1460 | ⚪ UNCERTAIN | Highest ARH proximity, no Cyp19a1 data | Secondary |
+| 1569 ARH-PVi Six6 Dopa-Gaba_1 [CS20230722_CLUS_1569] | 0427 ARH-PVi Six6 Dopa-Gaba_1 | 176 | ⚪ UNCERTAIN | Best ARH cluster fraction, no Cyp19a1 data | Secondary |
+| 1570 ARH-PVi Six6 Dopa-Gaba_1 [CS20230722_CLUS_1570] | 0427 ARH-PVi Six6 Dopa-Gaba_1 | 204 | ⚪ UNCERTAIN | ARH sibling cluster, no Cyp19a1 data | Eliminated (sibling of CLUS_1569, lower ARH fraction) |
+| 1571 ARH-PVi Six6 Dopa-Gaba_1 [CS20230722_CLUS_1571] | 0427 ARH-PVi Six6 Dopa-Gaba_1 | 279 | ⚪ UNCERTAIN | ARH sibling cluster, no Cyp19a1 data | Eliminated (sibling of CLUS_1569, lower ARH fraction) |
+| 1683 SBPV-PVa Six6 Satb2 Gaba_1 [CS20230722_CLUS_1683] | 0453 SBPV-PVa Six6 Satb2 Gaba_1 | 268 | ⚪ UNCERTAIN | SBPV/PVa, not ARH-centred | Eliminated (off-region, SBPV-PVa) |
+| 5303 VLMC NN_4 [CS20230722_CLUS_5303] | 1190 VLMC NN_4 | 76 | ⚪ UNCERTAIN | Vascular leptomeningeal, not neuronal | Eliminated (non-neuronal) |
+| 1190 VLMC NN_4 [CS20230722_SUPT_1190] | — | 76 | ⚪ UNCERTAIN | Vascular leptomeningeal supertype | Eliminated (non-neuronal) |
+| 1173 Tanycyte NN_2 [CS20230722_SUPT_1173] | — | 896 | ⚪ UNCERTAIN | Tanycyte, not neuronal | Eliminated (non-neuronal) |
+| 1174 Tanycyte NN_3 [CS20230722_SUPT_1174] | — | 41 | ⚪ UNCERTAIN | Tanycyte, not neuronal | Eliminated (non-neuronal) |
+| 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] | — | 933 | ⚪ UNCERTAIN | CLUS_1907 child carries Cyp19a1 (defining), but soma in periventricular preoptic | Eliminated (off-region; outside current Stage A top-50) |
 
-### Eliminated candidates
-
-**Shared disqualifying signal:** the only edge on this classical node is UNCERTAIN, and
-the disqualifying property is **anatomical location**. Cyp19a1 expression is detectable
-at supertype level in SUPT_0486 (mean=1.15) and at child-cluster level in CLUS_1907
-(defining marker), but the supertype's MERFISH soma distribution places its cells in
-MBA:133 (PVpo, n=64), MBA:515 (MPN, n=37), and MBA:272 (AVPV, n=16) with **zero cells in
-MBA:223 (ARH)**. The defining ARH location of arc_aromatase_neuron is therefore not
-recovered by any Cyp19a1-positive WMBv1 supertype.
-
-### 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] · ⚪ UNCERTAIN
-
-**Disqualifying evidence**
-
-- **Location DISCORDANT — distant region.** Classical type is in Arcuate hypothalamic
-  nucleus [MBA:223]; SUPT_0486 cells are distributed across the periventricular preoptic
-  zone (MBA:133 PVpo, MBA:515 MPN, MBA:272 AVPV) with no cells recorded in MBA:223. POA
-  and ARH are anatomically distinct hypothalamic nuclei separated by intervening
-  periventricular and tuberal zones. *(distant region — stronger counter-evidence;
-  classical type may still be a member of this T-type's broader aromatase network but
-  not the ARH population specifically)*
-- **Cyp19a1 alignment is APPROXIMATE only.** SUPT_0486 supertype mean Cyp19a1 = 1.15 is
-  the best Cyp19a1 signal available, and CLUS_1907 carries Cyp19a1 as a defining marker;
-  but a full DB scan confirmed **no ARH supertype expresses Cyp19a1 as a defining
-  marker**. The match is therefore the least-bad transcriptomic candidate rather than a
-  positive identification of the ARH aromatase population.
-- **MERFISH registration uncertainty.** The classical type is defined in MBA:223 but the
-  best transcriptomic match sits in periventricular preoptic territory. Possible
-  explanations include MERFISH registration artefacts at the ARH/periventricular boundary
-  or a pan-hypothalamic aromatase transcriptomic identity that is not segregated by
-  anatomical zone in WMBv1 — neither is established by current evidence.
-- **Single-source classical definition.** The ARH location assignment for
-  arc_aromatase_neuron rests entirely on Wartenberg et al. 2021 [1]. ARH-region
-  alternative supertypes SUPT_0427 and SUPT_0428 (ARH-PVi Six6 Dopa-Gaba) have not had
-  Cyp19a1 expression assessed and remain possible — though unconfirmed — candidates.
-
-**Marker evidence provenance**
-
-- **Cyp19a1** — classical evidence is transcript-level (Wartenberg 2021 reports an
-  aromatase neuronal network in hypothalamus and amygdala, sexually dimorphic in ARH
-  adjacent to kisspeptin neurons) [1]. Atlas signal is also transcript-level (10x
-  Chromium precomputed mean = 1.15 at SUPT_0486; CLUS_1907 carries Cyp19a1 as a defining
-  marker). The atlas captures Cyp19a1+ cells, but they are spatially located in the
-  preoptic / periventricular zone — not the arcuate nucleus. There is no atlas
-  annotation/expression discrepancy in the usual sense (the gene is detected and the
-  metadata flags it as defining for CLUS_1907) — the discrepancy is between the
-  classical type's ARH location and the atlas Cyp19a1+ cells' POA/periventricular
-  location.
-- **Single-citation marker provenance.** Cyp19a1 as a defining marker for
-  arc_aromatase_neuron rests on Wartenberg 2021 [1] alone. A targeted literature search
-  for additional primary studies of arcuate Cyp19a1+ neurons (e.g. Cyp19a1-Cre lineage
-  tracing, ISH co-localisation with kisspeptin) would strengthen the classical
-  definition independently of the atlas mapping problem.
-
-**What would upgrade — or definitively eliminate — confidence**
-
-- **Query Cyp19a1 expression in ARH-located supertypes** (SUPT_0427, SUPT_0428, and
-  neighbouring ARH supertypes) from the precomputed HDF5 stats. If any ARH supertype
-  carries non-zero Cyp19a1, it becomes a stronger candidate than SUPT_0486 despite a
-  weaker marker signal, because it would resolve the location DISCORDANT verdict. If all
-  ARH supertypes are confirmed Cyp19a1-negative, SUPT_0486 remains the only available
-  match and the UNCERTAIN classification is locked in by atlas-level absence of ARH
-  Cyp19a1+ cells.
-- **CLUS_1907 spatial localisation.** Confirm whether CLUS_1907 cells are exclusively
-  POA/periventricular or include any MBA:223 representation. If exclusively POA, this
-  strengthens the location DISCORDANT verdict.
-- **Targeted cite-traverse** for "arcuate aromatase Cyp19a1 mouse" beyond Wartenberg 2021
-  to confirm the ARH location of the classical type with independent primary evidence.
+</details>
 
 ---
 
@@ -156,17 +159,31 @@ recovered by any Cyp19a1-positive WMBv1 supertype.
 <details>
 <summary>Data sources, analyses, and reproducibility receipts</summary>
 
-**Classical type definition.** See classical type table in Introduction; defining_basis on the classical node and per-property literature support are listed there. The KB-side definition lives at the source graph file linked in the reproducibility footer.
+**Classical type definition.** The arcuate aromatase neuron is a CLASSICAL_NEUROCHEMICAL node defined by *Cyp19a1* (aromatase) expression in the arcuate hypothalamic nucleus [MBA:223], with male-biased sexual dimorphism. The single primary citation is Wartenberg et al. 2021 [1], which characterised the aromatase network across hypothalamus and amygdala using reporter mouse and immunohistochemistry, and identified the arcuate aromatase cluster as adjacent to kisspeptin neurons. No NT type, negative markers, or neuropeptides are asserted on the classical node.
 
-**Atlas mapping query.** Candidate atlas clusters were retrieved from CCN20230722 at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias). Full scoring rules: `workflows/map-cell-type.md`.
+**Atlas mapping query.** Candidate atlas clusters were retrieved from the WMBv1 taxonomy (CCN20230722) at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match within MBA:223, defining markers, sex bias when applicable). Full scoring rules: `workflows/map-cell-type.md`.
 
-**Property alignment.** Each defining property was compared to the corresponding atlas-side value via the `property_comparisons` schema; alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
+**Property alignment.** Each defining property of the classical type was compared to the corresponding atlas-side value via the `property_comparisons` schema, with alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
 
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote. Specific mapping limitations and caveats are documented per-candidate in the Discussion section.
 
+*Generated by evidencell `25c2b32` at 2026-06-08T18:14:09+00:00 from [kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml](kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
 
-**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote.
+**Evidence base table**
 
-*Generated by evidencell `0c97cfa` from [`kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`](../../kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+| Edge ID | Evidence types | Supports | Source |
+| --- | --- | --- | --- |
+| edge_arc_aromatase_neuron_to_CS20230722_SUPT_0427 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_arc_aromatase_neuron_to_CS20230722_SUPT_0495 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_arc_aromatase_neuron_to_CS20230722_CLUS_1569 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_arc_aromatase_neuron_to_CS20230722_CLUS_1570 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_arc_aromatase_neuron_to_CS20230722_CLUS_1571 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_arc_aromatase_neuron_to_CS20230722_CLUS_1683 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_arc_aromatase_neuron_to_CS20230722_CLUS_5303 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_arc_aromatase_neuron_to_CS20230722_SUPT_1190 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_arc_aromatase_neuron_to_CS20230722_SUPT_1173 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_arc_aromatase_neuron_to_CS20230722_SUPT_1174 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_arc_aromatase_neuron_to_cs20230722_supt_0486 | ATLAS_METADATA | WEAK | atlas-internal |
 
 </details>
 
@@ -174,60 +191,33 @@ recovered by any Cyp19a1-positive WMBv1 supertype.
 
 ## Discussion
 
-**Primary mapping:** → SUPT_0486 (preoptic — wrong region; null result) at UNCERTAIN confidence. Key support: no support — ATLAS_METADATA confirms Cyp19a1 = 0.0 across all ARH supertypes (SUPT_0427 Cyp19a1=0.0; child clusters CLUS_1569, 1570, 1571 all = 0.0). Key caveats: `MARKER_NOT_SPECIFIC` (Cyp19a1 absent from atlas at the expected location); the arcuate aromatase population is not resolvable from WMBv1 metadata.
+**Primary mapping:** Arcuate aromatase neuron → 0427 ARH-PVi Six6 Dopa-Gaba_1 [CS20230722_SUPT_0427] at UNCERTAIN confidence. Key support: arcuate region match in atlas metadata (region_fraction_100um=0.741). Key caveats: *Cyp19a1* is the defining marker for the classical type but is absent from the WMBv1 precomputed expression panel at supertype and cluster level for every ARH candidate in the current top-K, so the diagnostic marker cannot be checked. The Six6-Dopa-Gaba transcriptomic identity is canonical for the tubero-infundibular dopaminergic neurons of the ARH-PVi rather than for an aromatase population, so anatomy alone is not enough to commit to this mapping.
 
-No Cell Ontology term currently assigned for this classical type.
+No Cell Ontology term currently assigned. This type is a candidate for CL contribution: a sexually dimorphic, *Cyp19a1*-positive arcuate neuron with documented neurosteroidogenic function (testosterone → estrogen) and a male-biased cell count.
 
 ### Proposed experiments and follow-ups
 
-### 1. Targeted Cyp19a1 expression query in ARH-located WMBv1 supertypes
+- **What:** Query *Cyp19a1* expression in the WMBv1 precomputed expression HDF5 for all ARH-region (MBA:223) supertypes and their child clusters, including SUPT_0427, SUPT_0428, SUPT_0495 and any Kiss1-neighbouring ARH cluster.
+  **Target:** identify any ARH cluster with non-trivial *Cyp19a1* mean expression.
+  **Expected output:** atlas-internal expression record on candidate clusters; potential reassignment of primary candidate.
+  **Resolves:** open question 1; underpins all UNCERTAIN→stronger confidence transitions in this report.
 
-**What:** Query the precomputed HDF5 expression stats for Cyp19a1 across all WMBv1
-supertypes whose MERFISH soma distribution includes Arcuate hypothalamic nucleus
-[MBA:223] — including SUPT_0427 and SUPT_0428 (ARH-PVi Six6 Dopa-Gaba supertypes) and
-neighbouring ARH supertypes.
+- **What:** Re-assess the legacy edge to SUPT_0486 (PVpo-VMPO-MPN Hmx2 Gaba_5), whose child CLUS_1907 carries *Cyp19a1* as a defining marker. The supertype is in periventricular preoptic zones, not ARH, but the *Cyp19a1*-positive child is the only direct atlas marker signal for aromatase in this graph.
+  **Target:** decide whether CLUS_1907 represents (a) the same pan-hypothalamic aromatase network described in the source paper [1] but lying outside the strict ARH boundary, or (b) a distinct preoptic aromatase population.
+  **Expected output:** curator decision on whether SUPT_0486 belongs in a separate classical preoptic-aromatase node; refreshed property comparisons against the current Stage A top-K.
+  **Resolves:** open questions 2 and 3.
 
-**Target:** Identify any ARH supertype with Cyp19a1 mean expression ≥ 0.5 (consistent
-with detectable subset expression).
-
-**Expected output:** `MarkerAnalysisEvidence` for any ARH supertype with non-zero
-Cyp19a1; or, if all ARH supertypes return Cyp19a1 ≈ 0, a negative `MarkerAnalysisEvidence`
-that locks in the UNCERTAIN classification by establishing atlas-level absence of ARH
-Cyp19a1+ cells.
-
-**Resolves:** Open question 1.
-
-### 2. Spatial localisation of CLUS_1907
-
-**What:** Inspect the MERFISH spatial distribution of CLUS_1907 (the SUPT_0486 child
-cluster carrying Cyp19a1 as a defining marker) and determine whether any cells are
-located in MBA:223 (ARH) or whether the cluster is exclusively in POA/periventricular
-zones.
-
-**Target:** A definitive MBA-region breakdown of CLUS_1907 cells.
-
-**Expected output:** Updated location field on the SUPT_0486 / CLUS_1907 edge, supporting
-either retention of the DISCORDANT verdict (CLUS_1907 entirely outside MBA:223) or
-re-assessment if any MBA:223 cells are present.
-
-**Resolves:** Open question 2.
-
----
+- **What:** Targeted literature search for atlas-side transcriptomic studies of arcuate aromatase neurons (Wartenberg follow-ups, Mouse Whole Brain papers describing aromatase clusters, MERFISH-based ARH studies that quantify *Cyp19a1*).
+  **Target:** find any independent transcriptomic confirmation of an ARH *Cyp19a1*-positive cluster.
+  **Expected output:** additional LiteratureEvidence on the classical node and potentially new candidate edges.
+  **Resolves:** open question 4.
 
 ### Open questions
 
-1. Do SUPT_0427 or SUPT_0428 (ARH Dopa-Gaba supertypes), or any other ARH-located
-   supertype, show Cyp19a1 expression in the precomputed HDF5 stats?
-2. Is CLUS_1907 located exclusively in POA/periventricular zones in MERFISH data, or
-   are any cells assigned to MBA:223?
-
----
-
-### Evidence base
-
-| Edge ID | Evidence type | Supports |
-|---|---|---|
-| edge_arc_aromatase_neuron_to_cs20230722_supt_0486 | ATLAS_METADATA | WEAK — SUPT_0486 best available Cyp19a1 signal (mean=1.15; CLUS_1907 defining) but anatomically in PVpo-VMPO-MPN with 0 cells in MBA:223; full DB scan confirms no ARH supertype carries Cyp19a1 as a defining marker |
+1. Does *Cyp19a1* show detectable expression in any ARH supertype (SUPT_0427, SUPT_0428, SUPT_0495, or others) in the WMBv1 precomputed expression panel?
+2. Is CLUS_1907 (the *Cyp19a1*-positive child of SUPT_0486) located exclusively in periventricular preoptic zones in MERFISH spatial data, or does it have any arcuate-region representation?
+3. The legacy edge `edge_arc_aromatase_neuron_to_cs20230722_supt_0486` fell outside the current Stage A top-50 and warrants curator review — should this candidate be reinstated, retired, or migrated to a separate preoptic-aromatase classical node?
+4. Does any Kiss1-neighbouring ARH cluster carry *Cyp19a1*? Wartenberg et al. [1] specify that the arcuate aromatase neurons are adjacent to kisspeptin neurons; spatial co-localisation with a Kiss1+ cluster is a strong prior for the true target.
 
 ---
 
@@ -235,4 +225,300 @@ re-assessment if any MBA:223 cells are present.
 
 | # | Citation | PMID | Used for |
 |---|---|---|---|
-| [1] | Wartenberg et al. 2021 | [PMID:34561233](https://pubmed.ncbi.nlm.nih.gov/34561233/) | Soma location (ARH adjacent to kisspeptin neurons), Cyp19a1 / aromatase as defining marker, sexually dimorphic male-biased ARH aromatase cluster, testosterone-to-estrogen conversion |
+| [1] | Wartenberg et al. 2021 | [34561233](https://pubmed.ncbi.nlm.nih.gov/34561233) | soma location, defining marker, sexual dimorphism |
+
+---
+
+<!-- verdict-block-start: edge_arc_aromatase_neuron_to_CS20230722_SUPT_0427 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.30
+  rationale: >
+    [tier:STRONGEST] CS20230722_SUPT_0427 painted soma distribution centres on
+    MBA:223 (region_fraction_100um: 0.741; strict region_fraction: 0.427), the
+    strongest ARH-resident candidate among neuronal supertypes in the current
+    top-K. The defining marker Cyp19a1 is not represented in the atlas
+    precomputed expression panel for this supertype, so the diagnostic marker
+    cannot be cross-checked; mapping is left as evidencell:UncertainRelationship.
+  reconciliation_note: >
+    Cyp19a1 absent from atlas expression panel across all ARH candidates in
+    current top-K; predicate cannot be committed until atlas-side aromatase
+    expression is queried (see proposed_experiments).
+  caveats:
+    - caveat_type: NO_DISCRIMINATING_MARKER
+      description: >
+        Cyp19a1 defining marker has no atlas-side expression data on
+        CS20230722_SUPT_0427 or any of its child clusters in the current
+        property_comparisons. The mapping rests on anatomy alone.
+    - caveat_type: SINGLE_DATASET
+      description: >
+        Classical node arc_aromatase_neuron is supported by a single primary
+        source (Wartenberg 2021, PMID:34561233); marker, location, and sex-bias
+        assertions all depend on this paper.
+  proposed_experiments:
+    - >
+      Query Cyp19a1 expression in the precomputed expression HDF5 for
+      CS20230722_SUPT_0427 and its child clusters (CLUS_1569, CLUS_1570,
+      CLUS_1571).
+    - >
+      Extend the Cyp19a1 query to all ARH-region (MBA:223) supertypes
+      including the sister TIDA supertype and CS20230722_SUPT_0495 to identify any
+      ARH-resident cluster with non-trivial aromatase expression.
+  unresolved_questions:
+    - >
+      Does Cyp19a1 show detectable expression in any ARH supertype in the
+      WMBv1 precomputed expression panel?
+    - >
+      Is there a Kiss1-neighbouring ARH cluster carrying Cyp19a1, matching
+      the Wartenberg 2021 description of arcuate aromatase neurons adjacent
+      to kisspeptin neurons?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_arc_aromatase_neuron_to_CS20230722_SUPT_0495 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.25
+  rationale: >
+    [tier:NEXT] CS20230722_SUPT_0495 has the highest arcuate proximity in the
+    survival cohort (region_fraction_100um: 0.917; strict region_fraction:
+    0.665), but Cyp19a1 is absent from the atlas precomputed expression
+    panel for this supertype, so the defining marker is unassessed and the
+    relationship cannot be committed.
+  reconciliation_note: >
+    Strongest pure anatomical match for MBA:223 in the cohort; lineage
+    (Tbx3-defined posterior arcuate) does not by itself predict an
+    aromatase-positive identity.
+  caveats:
+    - caveat_type: NO_DISCRIMINATING_MARKER
+      description: >
+        Cyp19a1 has no atlas-side expression record on CS20230722_SUPT_0495;
+        candidate retained on anatomical proximity alone.
+    - caveat_type: OTHER
+      description: >
+        Tbx3-defined posterior arcuate populations are most often associated
+        with feeding-circuit neurons (POMC/AgRP neighbourhood) rather than
+        with neurosteroid biosynthesis; identity with Wartenberg 2021's
+        Cyp19a1-positive arcuate cluster is not implied by anatomy alone.
+  proposed_experiments:
+    - >
+      Query Cyp19a1 expression in the precomputed expression HDF5 for
+      CS20230722_SUPT_0495 and its child clusters.
+  unresolved_questions:
+    - >
+      Is the Tbx3-defined posterior arcuate population aromatase-expressing
+      at any of its child clusters?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_arc_aromatase_neuron_to_CS20230722_CLUS_1569 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.25
+  rationale: >
+    [tier:WEAKEST] CS20230722_CLUS_1569 is the leading ARH child of
+    CS20230722_SUPT_0427 by strict region_fraction (0.526;
+    region_fraction_100um: 0.789) with Dopa as the assigned transmitter.
+    Cyp19a1 is absent from the atlas expression panel at cluster level, and
+    the Six6-Dopa-Gaba identity is canonical for the tubero-infundibular
+    dopaminergic neurons rather than for an aromatase population;
+    relationship remains evidencell:UncertainRelationship.
+  reconciliation_note: >
+    Sibling clusters CLUS_1570 and CLUS_1571 share the same supertype with
+    weaker ARH fractions; CLUS_1569 is the best ARH representative of the
+    set. Identity with the classical aromatase node is not supported by
+    transcriptomic evidence currently available.
+  caveats:
+    - caveat_type: NO_DISCRIMINATING_MARKER
+      description: >
+        Cyp19a1 has no atlas-side cluster-level expression record on
+        CS20230722_CLUS_1569.
+    - caveat_type: OTHER
+      description: >
+        Six6-Dopa-Gaba is the canonical transcriptomic identity for the
+        ARH-PVi tubero-infundibular dopamine neurons; Wartenberg 2021's
+        arcuate aromatase neurons are described as a distinct,
+        Kiss1-adjacent population.
+  proposed_experiments:
+    - >
+      Query Cyp19a1 expression in the precomputed expression HDF5 for
+      CS20230722_CLUS_1569 and sibling clusters CS20230722_CLUS_1570 and
+      CS20230722_CLUS_1571.
+  unresolved_questions:
+    - >
+      Does CS20230722_CLUS_1569 (or any sibling in
+      CS20230722_SUPT_0427) carry Cyp19a1 at detectable levels?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_arc_aromatase_neuron_to_CS20230722_CLUS_1570 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1570 is a sibling of CS20230722_CLUS_1569 in
+    the same supertype with a lower strict region_fraction (0.545 with
+    region_fraction_100um: 0.779) and no Cyp19a1 atlas expression data;
+    superseded by CS20230722_CLUS_1569 as the best ARH-resident child.
+  caveats:
+    - caveat_type: NO_DISCRIMINATING_MARKER
+      description: >
+        Cyp19a1 not represented in atlas expression panel for
+        CS20230722_CLUS_1570.
+  proposed_experiments: []
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_arc_aromatase_neuron_to_CS20230722_CLUS_1571 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1571 is a sibling of CS20230722_CLUS_1569 in
+    the same supertype with a lower strict region_fraction (0.338) and no
+    Cyp19a1 atlas expression data; superseded by CS20230722_CLUS_1569 as
+    the best ARH-resident child.
+  caveats:
+    - caveat_type: NO_DISCRIMINATING_MARKER
+      description: >
+        Cyp19a1 not represented in atlas expression panel for
+        CS20230722_CLUS_1571.
+  proposed_experiments: []
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_arc_aromatase_neuron_to_CS20230722_CLUS_1683 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.10
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1683 (SBPV-PVa Six6 Satb2 Gaba_1) is centred
+    on the suprachiasmatic preoptic and periventricular anterior zones
+    rather than the arcuate (region_fraction_100um: 0.506; strict
+    region_fraction: 0.346, with substantial Medial preoptic nucleus
+    occupancy), and carries no Cyp19a1 atlas expression data.
+  caveats:
+    - caveat_type: DISCORDANT_ANATOMY
+      description: >
+        SBPV-PVa Six6 Satb2 Gaba_1 occupancy of MBA:223 is partial; primary
+        soma distribution is in preoptic/periventricular zones.
+  proposed_experiments: []
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_arc_aromatase_neuron_to_CS20230722_CLUS_5303 -->
+```yaml
+verdict:
+  confidence: REFUTED
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_5303 (5303 VLMC NN_4) is a vascular
+    leptomeningeal cluster, not a neuronal population; identity with a
+    Cyp19a1-positive neurochemical arcuate neuron is excluded by cell
+    class.
+  caveats:
+    - caveat_type: OTHER
+      description: >
+        VLMC NN_4 is a non-neuronal vascular leptomeningeal cluster.
+  proposed_experiments: []
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_arc_aromatase_neuron_to_CS20230722_SUPT_1190 -->
+```yaml
+verdict:
+  confidence: REFUTED
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_1190 (1190 VLMC NN_4) is a vascular
+    leptomeningeal supertype, not a neuronal population; excluded by cell
+    class.
+  caveats:
+    - caveat_type: OTHER
+      description: >
+        VLMC NN_4 supertype is non-neuronal.
+  proposed_experiments: []
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_arc_aromatase_neuron_to_CS20230722_SUPT_1173 -->
+```yaml
+verdict:
+  confidence: REFUTED
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_1173 (1173 Tanycyte NN_2) is a tanycyte
+    supertype, not a neuronal population; identity with the arcuate
+    aromatase neuron is excluded by cell class even though tanycytes
+    populate MBA:223 abundantly.
+  caveats:
+    - caveat_type: OTHER
+      description: >
+        Tanycyte NN_2 is non-neuronal.
+  proposed_experiments: []
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_arc_aromatase_neuron_to_CS20230722_SUPT_1174 -->
+```yaml
+verdict:
+  confidence: REFUTED
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_1174 (1174 Tanycyte NN_3) is a tanycyte
+    supertype, not a neuronal population; excluded by cell class.
+  caveats:
+    - caveat_type: OTHER
+      description: >
+        Tanycyte NN_3 is non-neuronal.
+  proposed_experiments: []
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_arc_aromatase_neuron_to_cs20230722_supt_0486 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.20
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0486 (PVpo-VMPO-MPN Hmx2 Gaba_5) was
+    previously proposed because its periventricular preoptic child cluster
+    carries Cyp19a1 as a defining marker, but the supertype's painted soma
+    distribution sits in PVpo/MPN/AVPV (no MBA:223 cells), and the legacy
+    edge fell outside the current Stage A top-50; flagged for curator
+    review.
+  reconciliation_note: >
+    Legacy edge from pre-emitter pass; property_comparisons not refreshed
+    in current run. The Cyp19a1-positive periventricular preoptic child cluster
+    may represent a separate preoptic-aromatase population rather than the
+    arcuate aromatase neuron of Wartenberg 2021; curator decision needed.
+  caveats:
+    - caveat_type: DISCORDANT_ANATOMY
+      description: >
+        CS20230722_SUPT_0486 is in PVpo-VMPO-MPN with no MBA:223 cells in
+        its painted distribution; classical type is in MBA:223.
+    - caveat_type: OTHER
+      description: >
+        Edge fell outside current Stage A top-50 at rank 1;
+        property_comparisons not refreshed in this run. Curator review
+        warranted (cf. evidencell #111).
+  proposed_experiments:
+    - >
+      Confirm whether the periventricular preoptic child cluster has any
+      MBA:223 representation in MERFISH spatial data, or is exclusively in
+      periventricular preoptic zones.
+  unresolved_questions:
+    - >
+      Should CS20230722_SUPT_0486 and its periventricular preoptic child
+      cluster be re-mapped to a separate preoptic-aromatase classical node
+      distinct from arc_aromatase_neuron?
+    - >
+      Curator review of legacy edge edge_arc_aromatase_neuron_to_cs20230722_supt_0486 — fell outside current Stage A top-50 (cf. #111).
+```
+<!-- verdict-block-end -->

--- a/reports/sexually_dimorphic/avpv_kiss1_neuron_summary.md
+++ b/reports/sexually_dimorphic/avpv_kiss1_neuron_summary.md
@@ -1,125 +1,443 @@
 # AVPV/PeN kisspeptin neuron — WMBv1 Mapping Report
-*2026-04-25 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
+*2026-04-25 · Source: `kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
 
 ---
 
-## Classical type
+## Introduction
+
+AVPV/PeN kisspeptin neurons are a sexually dimorphic, female-biased
+hypothalamic population that gates the preovulatory GnRH/LH surge through
+estrogen-positive feedback in female rodents [1][2][3]. In mice, the
+defining neurochemical signature combines the *Kiss1* neuropeptide with
+*Th* (most AVPV/PeN Kiss1 cells co-express tyrosine hydroxylase, the
+rate-limiting enzyme for dopamine) and *Esr1* (estrogen receptor α),
+distinguishing them from the arcuate KNDy population which is not
+sexually dimorphic and obligately co-expresses NKB and dynorphin.
+
+### Classical type
 
 | Property | Value | References |
 |---|---|---|
-| CL term | hypothalamus kisspeptin neuron (CL:4023123) | |
-| Soma location | anteroventral periventricular nucleus (AVPV) [MBA:272]; periventricular nucleus (PeN) [MBA:341] | [1] [2] [3] [1] [2] [3] |
-| NT | GABAergic / dopaminergic (TH co-expression) | [3] |
-| Markers | Kiss1+, Th+, Esr1+ | [1] [2] [3] [4] [5] |
-| Neuropeptides | Kiss1 | [6] |
+| Soma location | Anteroventral periventricular nucleus [MBA:272]; Periventricular hypothalamic nucleus, posterior part [MBA:126] | [1][2][3] |
+| Neurotransmitter | GABAergic / dopaminergic (Th co-expression) | [3] |
+| Defining markers | *Kiss1*, *Th*, *Esr1* | [1][2][3][4][5] |
+| Neuropeptides | *Kiss1* | [6] |
+| Sex bias | Female-biased (more Kiss1 cells in females than males) | [1][2][3] |
+| Cell Ontology | hypothalamus kisspeptin neuron [[CL:4023123](https://www.ebi.ac.uk/ols4/ontologies/cl/classes?obo_id=CL:4023123)] (BROAD) | — |
+
+<details>
+<summary>Details — source evidence for classical type properties</summary>
+
+- **Soma location (AVPV/PeN):** review, mouse · [1]
+  > The Kisspeptin system is apparently critical for brain gender differentiation, acting through the regulation of postnatal T secretion. Distribution of Kisspeptin neurons in the hypothalamus varies between species. In mammals there are 2 major regions of these neurons; a rostral one in the Pre-Optic Area (POA) and a caudal one in the arcuate nucleus, with proportionally more Kisspeptin neurons in the ARC than in the POA region (4,30). In rodents, the POA regions are concentrated in the Anteroventral Periventricular Nucleus (AVPV). Anatomical differences between genders have been reported in the hypothalamus of some species, e.g. the rat AVPV is sexually dimorphic, with a greater number of KISS1 neurons in females compared to males (30). Like most sex differences in the brain, this sexual dimorphism is likely caused during the perinatal critical period by exposure to testosterone (or its metabolites) (31)
+  > — Nejad et al. 2017, Functional Roles in Reproductive Neuroendocrine Control · [1] <!-- quote_key: 1227024_3fcab8ab -->
+
+- **Soma location + AVPV positive-feedback function:** anti-Kiss1 antibody POA infusion, rat · [2]
+  > Metastin/kisspeptin, the KiSS-1 gene product, has been identified as an endogenous ligand of GPR54 that reportedly regulates GnRH/LH surges and estrous cyclicity in female rats. The aim of the present study was to determine if metastin/kisspeptin neurons are a target of estrogen positive feedback to induce GnRH/LH surges. We demonstrated that preoptic area (POA) infusion of the anti-rat metastin/kisspeptin monoclonal antibody blocked the estrogen-induced LH surge, indicating that endogenous metastin/ kisspeptin released around the POA mediates the estrogen positive feedback effect on GnRH/LH release. Metastin/kisspeptin neurons in the anteroventral periventricular nucleus (AVPV) may be responsible for mediating the feedback effect because the percentage of c-Fos-expressing KiSS-1 mRNA-positive cells to total KiSS-1 mRNA-positive cells was significantly higher in the afternoon than in the morning in the anteroventral periventricular nucleus (AVPV) of high estradiol (E(2))-treated females. The percentage of c-Fos-expressing metastin/kisspeptin neurons was not different between the afternoon and morning in the arcuate nucleus (ARC). Most of the KiSS-1 mRNA expressing cells contain ERalpha immunoreactivity in the AVPV and ARC. In addition, AVPV KiSS-1 mRNA expressions were highest in the proestrous afternoon and lowest in the diestrus 1 in females and were increased by estrogen treatment in ovariectomized animals. On the other hand, the ARC KiSS-1 mRNA expressions were highest at diestrus 2 and lowest at proestrous afternoon and were increased by ovariectomy and decreased by high estrogen treatment. Males lacking the surge mode of GnRH/LH release showed no obvious cluster of metastin/kisspeptin-immunoreactive neurons in the AVPV when compared with high E(2)-treated females, which showed a much greater density of these neurons. Taken together, the present study demonstrates that the AVPV metastin/kisspeptin neurons are a target of estrogen positive feedback to induce GnRH/ LH surges in female rats.
+  > — Adachi et al. 2007, Functional Roles in Reproductive Neuroendocrine Control · [2] <!-- quote_key: 1357086_85e3d032 -->
+
+- **Th co-expression + sexually dimorphic AVPV/PeN distribution:** ISH + IHC, mouse · [3]
+  > Kiss1-syntheizing neurons reside primarily in the hypothalamic anteroventral periventricular (AVPV/PeN) and arcuate (ARC) nuclei. AVPV/PeN Kiss1 neurons are sexually dimorphic, with females expressing more Kiss1 than males, and participate in estradiol (E2)- induced positive feedback control of GnRH secretion. In mice, most AVPV/PeN Kiss1 cells coexpress tyrosine hydroxylase (TH), the rate-limiting enzyme in catecholamine synthesis (in this case, dopamine).
+  > — Stephens et al. 2017, Neuronal Markers and Molecular Characteristics · [3] <!-- quote_key: 4702847_ebd225e6 -->
+
+- **Th marker — GPR54 KO sex-reversal:** transgenic, mouse · [4]
+  > adult testosterone-treated GPR54 KO males displayed "female-like" numbers of tyrosine hydroxylase-immunoreactive and Kiss1 mRNA-containing neurons in the anteroventral periventricular nucleus and likewise possessed fewer motoneurons in the spino- bulbocavernosus nucleus than did WT males
+  > — Kauffman et al. 2007, Neuronal Markers and Molecular Characteristics · [4] <!-- quote_key: 17692566_78d7ff15 -->
+
+- **Esr1 co-expression:** review, mammal · [5]
+  > Sex steroid hormones act on hypothalamic kisspeptin neurons to regulate reproductive neural circuits in the brain. Kisspeptin neurons start to express estrogen receptors in utero
+  > — Wartenberg et al. 2021, Neuronal Markers and Molecular Characteristics · [5] <!-- quote_key: 237626479_9c737a0a -->
+
+- **Kiss1 neuropeptide identity + AVPV dimorphism:** review · [6]
+  > The AVPV is a sexually dimorphic site with a differential distribution pattern of several neurotransmitters and neuropeptides, including kisspeptin
+  > — Frazão et al. 2013, Functional Roles in Reproductive Neuroendocrine Control · [6] <!-- quote_key: 11330110_f135c1a8 -->
+
+- **Esr1 / steroid-receptor regulation:** review · [1]
+  > KISS1 neurons express sex steroid receptors and are regulated by gonadal sex steroids, mediating the effects of estrogen on GnRH neurons
+  > — Nejad et al. 2017, Functional Roles in Reproductive Neuroendocrine Control · [1] <!-- quote_key: 1227024_6801ab8e -->
+
+</details>
+
+### Cell Ontology mapping
+
+Cell Ontology mapping: hypothalamus kisspeptin neuron
+[[CL:4023123](https://www.ebi.ac.uk/ols4/ontologies/cl/classes?obo_id=CL:4023123)]
+(BROAD). The mapping interpretation is reprised in the Discussion.
 
 ---
 
-## Cell Ontology mapping
+## Results
 
-AVPV/PeN kisspeptin neuron is a **broad match** to **hypothalamus kisspeptin neuron (CL:4023123)** in the Cell Ontology — i.e. **hypothalamus kisspeptin neuron (CL:4023123)** is the closest existing CL term (an ancestor) but does not fully cover this type. A new child term is a candidate for submission to CL.
+Marker, region, and sex-bias alignment combined with a bulk-RNA-seq
+differential correlation against Stephens 2024 [7] picks out a single
+WMBv1 cluster — *1915 PVpo-VMPO-MPN Hmx2 Gaba_5* [CS20230722_CLUS_1915]
+— as the female-biased Kiss1+Th+Esr1+ atlas correlate of the AVPV/PeN
+kisspeptin population, with its parent supertype *0486 PVpo-VMPO-MPN
+Hmx2 Gaba_5* [CS20230722_SUPT_0486] providing the broader preoptic
+GABAergic context (see property comparison tables and bulk-correlation
+figure below). The cluster is very small (n≈3–5 cells in WMBv1), so the
+direction of the sex-ratio and expression signals is reliable but
+absolute statistical power is limited; annotation-transfer evidence from
+published AVPV Kiss1 scRNA-seq has not yet been generated.
 
-*Mapping notes:* CL:4023123 covers all hypothalamic kisspeptin neurons. The AVPV/PeN (RP3V) population is Kiss1-only (not obligately KNDy), so the more specific CL:4023128 (RP3V KNDy neuron) is inappropriate as it requires NKB and dynorphin co-expression. A dedicated CL term for the AVPV/RP3V Kiss1 non-KNDy subpopulation does not yet exist — potential CL contribution.
+### 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_CLUS_1915] · 🟡 MODERATE
+
+**Table 1 — Property comparison**
+
+| Property | Classical | Cluster [CS20230722_CLUS_1915] | Alignment |
+|---|---|---|---|
+| Soma location | AVPV [MBA:272]; PeN [MBA:126] | AVPV [MBA:272] n=1; PVpo [MBA:133] n=1; Hypothalamus [MBA:1097] n=3 | APPROXIMATE |
+| NT type | GABAergic / dopaminergic (Th co-expression) | Dopa (cluster.yaml `name_in_source` = "Dopa") | CONSISTENT |
+| *Kiss1* expression | defining marker | precomputed mean = 2.51; *Kiss1* is a cluster-level DEFINING marker | CONSISTENT |
+| *Th* expression | defining marker | precomputed mean = 6.6 (highest *Th* of any SUPT_0486 child) | CONSISTENT |
+| *Esr1* expression | defining marker | precomputed mean = 9.55 (highest *Esr1* in SUPT_0486) | CONSISTENT |
+| Sex ratio | female-biased | MFR = 0.02 (≈50:1 F:M) | CONSISTENT |
+| Annotation-transfer F1 | n/a | not assessed | NOT_ASSESSED |
+
+**Table 2 — Evidence support**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas precomputed expression + MFR | Atlas metadata | SUPPORT | Kiss1+Th+Esr1 co-expression; MFR=0.02 | atlas-internal |
+| Stephens 2024 bulk RP3V-vs-ARC Kiss1 sort | Bulk correlation | SUPPORT | δ=0.090, rank 1 / 5322 | [7] |
+
+**Supporting evidence**
+
+- *Kiss1*, *Th*, and *Esr1* — the three classical defining markers — are
+  all elevated on CS20230722_CLUS_1915 at the cluster level (mean
+  expression 2.51, 6.6, 9.55 respectively), and *Kiss1* is flagged
+  DEFINING on the atlas cluster record. The cluster also carries
+  `name_in_source: "Dopa"`, confirming the dopaminergic identity that
+  is concealed at the supertype label (which reads as Gaba_5).
+- Extreme female bias (male/female ratio = 0.02) matches the classical
+  female-biased dimorphism reported in mouse and rat AVPV [1][3][6].
+- Bulk Kiss1+ neurons FACS-sorted from RP3V vs ARC and correlated
+  against WMBv1 pseudobulk place CS20230722_CLUS_1915 at rank 1 of
+  5,322 clusters by differential δ (ρ\_RP3V − ρ\_ARC = 0.090,
+  ρ\_RP3V = 0.388 vs ρ\_ARC = 0.298) — independent quantitative
+  confirmation of the atlas-metadata-based call. All other top-20
+  bulk-correlation hits are also preoptic / periventricular
+  hypothalamic GABAergic clusters, so the differential signal is
+  anatomically clean [7].
+
+![Top 10 clusters by δ for RP3V_vs_ARC (CS20230722_CLUS_1915)](figures/avpv_kiss1_neuron_RP3V_vs_ARC_da0cac2d.png)
+
+*Top 10 clusters by δ for RP3V_vs_ARC (CS20230722_CLUS_1915) — δ ranks
+CS20230722_CLUS_1915 first of 5,322 atlas clusters; it is the only
+top-10 hit with strongly female-biased MFR. Bulk pools of 10–15 cells
+are noisy, so absolute ρ values run 0.3–0.5 even for true matches
+(see Methods); rank-1 status combined with the female-bias separation
+is the discriminating signal.*
+
+| Rank | Cluster | Supertype | δ | MFR | Top anatomy |
+|---:|---|---|---:|---:|---|
+| **1** | **CLUS_1915** | **SUPT_0486** | **0.0899** | **0.02** | **Hypothalamus** |
+| 2 | CLUS_1527 | SUPT_0418 | 0.0867 | 1.56 | Median preoptic nucleus |
+| 3 | CLUS_1904 | SUPT_0484 | 0.0849 | 1.50 | Hypothalamus |
+| 4 | CLUS_1939 | SUPT_0489 | 0.0848 | 4.56 | Dorsomedial nucleus of the hypothalamus |
+| 5 | CLUS_1912 | SUPT_0486 | 0.0839 | 1.22 | Hypothalamus |
+| 6 | CLUS_1914 | SUPT_0486 | 0.0835 | 10.11 | Periventricular hypothalamic nucleus, preoptic part |
+| 7 | CLUS_1944 | SUPT_0489 | 0.0831 | 2.23 | Dorsomedial nucleus of the hypothalamus |
+| 8 | CLUS_1530 | SUPT_0418 | 0.0831 | 0.75 | Median preoptic nucleus |
+| 9 | CLUS_1910 | SUPT_0485 | 0.0828 | 1.44 | Periventricular hypothalamic nucleus, preoptic part |
+| 10 | CLUS_1908 | SUPT_0484 | 0.0827 | 1.50 | Periventricular hypothalamic nucleus, preoptic part |
+
+**Marker evidence provenance**
+
+- ***Kiss1*** — transcript- and protein-level marker, anchored across
+  the citation set (ISH, IHC, anti-kisspeptin function-blocking
+  antibody) [1][2][3]. On the cluster, *Kiss1* is flagged DEFINING in
+  atlas metadata AND carries non-trivial precomputed expression
+  (2.51), so the atlas annotation and the expression measurement
+  agree.
+- ***Th*** — protein-level evidence in the source literature
+  (TH-immunoreactive AVPV cells co-expressing Kiss1 mRNA) [3][4]; the
+  cluster carries the highest *Th* mean in the supertype (6.6) and
+  the explicit "Dopa" identity tag, confirming the marker at
+  transcript level.
+- ***Esr1*** — protein (ERα immunoreactivity in Kiss1 cells) [2] and
+  transcript [5] evidence; the cluster carries the highest *Esr1*
+  mean in SUPT_0486 (9.55).
+
+**Concerns**
+
+- Soma location is APPROXIMATE rather than CONSISTENT: only n=1
+  cell is annotated to AVPV [MBA:272] in the cluster's MERFISH
+  registration, with the remainder split between PVpo [MBA:133] (n=1)
+  and the broad Hypothalamus catchall [MBA:1097] (n=3). MERFISH
+  spatial resolution is insufficient to discriminate AVPV from
+  adjacent PVpo/PeN at this cell count *(note: AVPV, PVpo and PeN are
+  all immediately adjacent periventricular preoptic structures; the
+  split is consistent with registration scatter across that
+  boundary)*.
+- Total cluster size in WMBv1 is very small (n=3–5 cells, supertype
+  n=933). The direction of MFR and expression rankings is reliable,
+  but absolute confidence is capped pending annotation transfer or
+  larger-dataset replication.
+- *avpv_th_neuron* (the AVPV dopaminergic population) also maps to
+  CS20230722_CLUS_1915. Most AVPV Kiss1 cells co-express *Th* in mouse
+  [3], so substantial overlap is expected biologically; whether
+  *avpv_kiss1_neuron* and *avpv_th_neuron* are separable populations
+  within CS20230722_CLUS_1915 is an open question.
+- The edge predicate was auto-migrated from the deprecated
+  `evidencell:PartialOverlapMatch` to `skos:closeMatch` on 2026-05-26
+  pending curator review; this report commits the predicate
+  explicitly.
+
+**What would upgrade confidence**
+
+- MapMyCells annotation transfer of published AVPV Kiss1-Cre or
+  Kiss1-Cre/Rosa-tdTom scRNA-seq onto WMBv1, with F1 ≥ 0.5 against
+  CS20230722_CLUS_1915 at cluster level → adds
+  `AnnotationTransferEvidence`.
+- Larger-N spatial transcriptomic dataset that better resolves AVPV
+  vs PVpo vs PeN boundaries → tightens the soma-location alignment.
+
+### 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] · 🟡 MODERATE
+
+This is the parent supertype of CS20230722_CLUS_1915. It collects
+preoptic GABAergic cells from the PVpo / VMPO / MPN zone (n=933
+across all child clusters) and provides the broader-resolution
+context for the cluster-level mapping above. At this resolution the
+AVPV-specific signal is diluted: the supertype's region distribution
+is dominated by PVpo [MBA:133] and MPN [MBA:515] rather than AVPV,
+and *Kiss1*/*Th*/*Esr1* expression averaged across all child
+clusters is much weaker than on CS20230722_CLUS_1915 specifically.
+
+**Table 1 — Property comparison**
+
+| Property | Classical | Supertype [CS20230722_SUPT_0486] | Alignment |
+|---|---|---|---|
+| Soma location | AVPV [MBA:272]; PeN [MBA:126] | Hypothalamus [MBA:1097] n=381; PVpo [MBA:133] n=354; MPN [MBA:515] n=276 | DISCORDANT (region_fraction_100um=0.061) |
+| NT type | GABAergic / dopaminergic | not asserted at supertype level | NOT_ASSESSED |
+| *Kiss1*, *Th*, *Esr1* | defining markers | no atlas expression data at supertype level | NOT_ASSESSED |
+| Sex ratio | female-biased | MFR not computed at supertype level | NOT_ASSESSED |
+
+**Table 2 — Evidence support**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas region + MFR rollup | Atlas metadata | PARTIAL | AVPV n=16 cells in supertype; CLUS_1915 child carries the signal | atlas-internal |
+
+*(1 of approximately 18 child clusters — CLUS_1915 — shows the
+female-biased Kiss1+Th+ profile; the remainder are sex-neutral or
+male-biased and lack Kiss1+Th+Esr1 co-expression at this strength.
+Best match: CS20230722_CLUS_1915.)*
+
+**Supporting evidence**
+
+- The supertype contains n=16 cells annotated to AVPV [MBA:272],
+  i.e. the AVPV cells in WMBv1 do live inside CS20230722_SUPT_0486;
+  they are concentrated in the single child cluster
+  CS20230722_CLUS_1915 rather than distributed across the supertype.
+- *Esr1* is on the atlas metadata marker list for CS20230722_SUPT_0486
+  (consistent with classical *Esr1* expression on AVPV/PeN Kiss1
+  cells [2][5]), even though precomputed averages are not reported
+  at supertype resolution.
+
+**Concerns**
+
+- Strict `region_fraction_100um = 0.061` and `region_fraction = 0.043`
+  — the AVPV/PeN classical regions are a minor component of the
+  supertype's total footprint. The supertype is broader than the
+  classical type by design at this resolution; the discordance is
+  expected and reflects the standard pattern where AVPV Kiss1 cells
+  live in a child cluster of a wider preoptic GABAergic supertype.
+- Multiple sexually dimorphic preoptic classical types
+  (*avpv_kiss1_neuron*, *avpv_th_neuron*, *mpoa_esr1_neuron*) map to
+  this same supertype. The supertype is a 1:n target.
+
+**What would upgrade confidence**
+
+- Same annotation-transfer experiment as for CS20230722_CLUS_1915:
+  high F1 at supertype level (≥ 0.7) would solidify the broader
+  mapping; concurrent high F1 at cluster level on
+  CS20230722_CLUS_1915 would solidify the parent–child pairing.
+
+<details>
+<summary>Candidates audited (full top-K)</summary>
+
+| WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key evidence | Verdict |
+|---|---|---:|---|---|---|
+| 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_CLUS_1915] | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 | 265 | 🟡 MODERATE | Kiss1+Th+Esr1+ co-expression; MFR=0.02; bulk δ rank 1/5322 | Primary |
+| — | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] | 933 | 🟡 MODERATE | AVPV cells n=16 in supertype; signal in CLUS_1915 child | Supports broader mapping |
+| 1876 PVpo-VMPO-MPN Hmx2 Gaba_1 [CS20230722_CLUS_1876] | 0482 PVpo-VMPO-MPN Hmx2 Gaba_1 | 63 | 🔴 LOW | GABA + AVPV n=39, no marker expression data | Eliminated (no defining-marker signal) |
+| 1507 PVR Six3 Sox3 Gaba_1 [CS20230722_CLUS_1507] | 0411 PVR Six3 Sox3 Gaba_1 | 263 | 🔴 LOW | GABA + AVPV n=202, no marker expression data | Eliminated (no defining-marker signal) |
+| — | 0411 PVR Six3 Sox3 Gaba_1 [CS20230722_SUPT_0411] | 740 | 🔴 LOW | AVPV n=225 at supertype; no marker expression | Eliminated (no defining-marker signal) |
+| — | 0494 ARH-PVp Tbx3 Gaba_2 [CS20230722_SUPT_0494] | 640 | 🔴 LOW | PeN [MBA:126] n=54, ARH-anchored, no marker expression | Eliminated (ARH-leaning; no marker signal) |
+| — | 0550 MPN-MPO-PVpo Hmx2 Glut_5 [CS20230722_SUPT_0550] | 583 | 🔴 LOW | AVPV n=107 but glutamatergic | Eliminated (wrong NT — Glut) |
+| 1301 MEA-BST Lhx6 Nfib Gaba_4 [CS20230722_CLUS_1301] | 0360 MEA-BST Lhx6 Nfib Gaba_4 | 149 | 🔴 LOW | GABA + small preoptic footprint (region_fraction_100um=0.051) | Eliminated (distant region — MEA-BST) |
+| 1891 PVpo-VMPO-MPN Hmx2 Gaba_2 [CS20230722_CLUS_1891] | 0483 PVpo-VMPO-MPN Hmx2 Gaba_2 | 159 | 🔴 LOW | GABA preoptic but region_fraction_100um=0.074 | Eliminated (low region fraction; no marker signal) |
+| 1895 PVpo-VMPO-MPN Hmx2 Gaba_2 [CS20230722_CLUS_1895] | 0483 PVpo-VMPO-MPN Hmx2 Gaba_2 | 163 | 🔴 LOW | region_fraction_100um=0.010 | Eliminated (distant — almost no AVPV/PeN cells) |
+| — | 0249 NDB-SI-MA-STRv Lhx8 Gaba_6 [CS20230722_SUPT_0249] | 423 | 🔴 LOW | Pallidum/striatum-dominated; region_fraction_100um=0.019 | Eliminated (wrong region — striatopallidal) |
+
+</details>
 
 ---
 
-## Mapping candidates
+### Methods
 
-| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
-|---|---|---|---|---|---|
-| — | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] |  | 178 |  |  |
-| — | 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_CLUS_1915] | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 | 5 |  |  |
+<details>
+<summary>Data sources, analyses, and reproducibility receipts</summary>
 
-All edges: `evidencell:PartialOverlapMatch`
+**Classical type definition.** *avpv_kiss1_neuron* is defined on the
+classical-neurochemical basis (`definition_basis:
+CLASSICAL_NEUROCHEMICAL`): a sexually dimorphic, female-biased
+hypothalamic kisspeptin population with soma in the anteroventral
+periventricular nucleus [MBA:272] and the posterior periventricular
+hypothalamic nucleus [MBA:126], expressing *Kiss1*, *Th*, and *Esr1*
+[1][2][3][4][5], with *Kiss1* serving as the defining neuropeptide
+[6]. Two electrophysiological subtypes (type I irregular, type II
+quiescent) have been described; the population is functionally
+distinct from the non-dimorphic arcuate KNDy population.
 
----
+**Atlas mapping query.** Candidate atlas clusters were retrieved from
+the WMBv1 taxonomy (CCN20230722) at ranks 0 (cluster) and 1
+(supertype) using metadata-based scoring (region match, NT type,
+defining markers, sex bias when applicable). Full scoring rules are
+in `workflows/map-cell-type.md`.
 
-## 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 · 
+**Property alignment.** Each defining property of the classical type
+was compared to the corresponding atlas-side value via the
+`property_comparisons` schema, with alignments graded
+CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side
+numerical values came from precomputed expression on the cluster
+(cluster.yaml in the taxonomy reference store) and from MERFISH
+spatial registration for soma location.
 
-*`CS20230722_SUPT_0486` · 178 cells (10x)*
+**Bulk transcriptomic correlation.**
 
-**Supporting evidence:**
+| Field | Value |
+|---|---|
+| Source publication | Stephens et al. 2024 [7] |
+| GEO accession | — |
+| Technique | bulk_RNAseq_FACS_sorted |
+| n pools | 2 |
+| Atlas | CCN20230722 (SHA-256: b21ca985) |
+| Statistic | spearman_rho |
+| Parameters | pseudobulk_transform=log1p(sum/n_cells); gene_id_space=ensembl_mouse; gene_intersection=bulk_pool_intersection∩atlas_col_names; replicate_pooling=n/a (bulk supp values are already pooled). |
+| Script | [correlate.py](https://github.com/Cellular-Semantics/evidencell/blob/d7c4445/correlate.py) |
+| Code version | d7c4445 |
+| Caveats | Bulk pools of 10–15 cells are noisy; absolute ρ values fall in 0.3–0.5 even for true matches. The differential δ statistic is the discriminative one; raw ρ rankings are dominated by housekeeping background. |
 
-- SUPT_0486 (PVpo-VMPO-MPN Hmx2 Gaba_5) is the highest-scoring supertype for AVPV-region preoptic GABAergic neurons. Precomputed expression confirms Esr1=7.72 (defining marker for both classical node and supertype), Th=2.72, and Kiss1=0.62. The supertype contains n=16 cells labeled AVPV (MBA:272). Child cluster CLUS_1915 (dopaminergic designation, male_female_ratio=0.02) is the strongest sub-resolution candidate for the female-biased AVPV Kiss1/TH population. PARTIAL_OVERLAP because SUPT_0486 spans a broader preoptic zone than the AVPV/PeN. [Atlas metadata]
+**Atlas data sources.** WMBv1 taxonomy CCN20230722; pseudobulk source
+`conf/mapmycells/CCN20230722/precomputed_stats.h5` (SHA-256:
+`b21ca985652fb25f9608f99005139a40757133a76fbe845ae5b175c5c26a447b`).
 
-**Concerns:**
+**Anti-hallucination.** All citations, atlas accessions, ontology
+CURIEs, and verbatim literature quotes in this report are validated
+against the evidencell knowledge base at write time. Authored-prose
+evidence narratives are validated against their source
+`evidence_items[*].explanation` fields. The pre-write hook rejects
+any unresolvable identifier or unattributed blockquote. Specific
+mapping limitations and caveats are documented per-candidate in the
+Discussion section.
 
-- **nt_type** (APPROXIMATE): A=GABAergic / dopaminergic (Th co-expression) / B=GABAergic (Gaba_5 label). GABAergic concordant; dopaminergic component present at supertype level (Th=2.72) but diluted. Resolved at cluster level by CLUS_1915 (nt_type=Dopa).
+*Generated by evidencell `25c2b32` at 2026-06-08T17:29:25+00:00 from
+[kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml](kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
 
-- **location_MBA272** (APPROXIMATE): A=MBA:272 (AVPV) / B=MBA:272 (AVPV) n=16; MBA:133 PVpo n=64; MBA:515 MPN n=37. Direct AVPV location match (n=16); supertype spans broader preoptic zone.
-- **marker_Kiss1** (APPROXIMATE): A=POSITIVE (transcript, defining marker) / B=precomputed mean_expression=0.62. Present but low-moderate at supertype level; consistent with subset expression.
-- **marker_Th** (APPROXIMATE): A=POSITIVE (protein, co-expressed with Kiss1) / B=precomputed mean_expression=2.72. 
-- SUPT_0486 spans PVpo-VMPO-MPN and contains multiple preoptic cell types. avpv_kiss1_neuron, avpv_th_neuron, and mpoa_esr1_neuron all map to SUPT_0486, reflecting the heterogeneity of this preoptic GABAergic supertype. AVPV Kiss1 neurons are a subset.
-- Supertype-level sex ratio not directly available. Female-biased sex ratio signal is concentrated in child cluster CLUS_1915 (male_female_ratio=0.02). A cluster-level edge to CLUS_1915 would provide more specific mapping.
+**Evidence base.**
 
-**What would upgrade confidence:**
+| Edge ID | Evidence types | Supports | Source |
+| --- | --- | --- | --- |
+| edge_avpv_kiss1_neuron_to_cs20230722_supt_0486 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_kiss1_neuron_to_cs20230722_clus_1915 | ATLAS_METADATA; BULK_CORRELATION | SUPPORT; SUPPORT | atlas-internal; [7] |
+| edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1301 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1876 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1891 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1895 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1507 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0411 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0494 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0550 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0249 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0486 | ATLAS_METADATA | PARTIAL | atlas-internal |
 
-- *Unresolved:* Which cluster(s) within SUPT_0486 carry peak Kiss1+Th+Esr1 co-expression consistent with AVPV Kiss1/TH identity?
-
-- *Unresolved:* Do PeN (MBA:341) Kiss1 neurons map to SUPT_0486 or a different supertype?
-
-- *Proposed:* Inspect child clusters of SUPT_0486 for Kiss1, Th, Esr1 co-expression at cluster level to identify the AVPV Kiss1/TH candidate cluster.
-
-- *Proposed:* MapMyCells annotation transfer of published AVPV Kiss1 scRNA-seq data to WMBv1.
-
-
----
-
-## 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 · 
-
-*`CS20230722_CLUS_1915` · 5 cells (10x) · supertype: 0486 PVpo-VMPO-MPN Hmx2 Gaba_5*
-
-**Supporting evidence:**
-
-- CLUS_1915 (1915 PVpo-VMPO-MPN Hmx2 Gaba_5) is the child cluster of SUPT_0486 with the highest co-expression of Kiss1 (2.51), Th (6.6), and Esr1 (9.55) — all three classical defining markers. It is the most strongly female-biased cluster in the supertype (male_female_ratio=0.02), directly concordant with the FEMALE_BIASED sex_bias of avpv_kiss1_neuron. Kiss1 and Slc18a2 are cluster-level DEFINING markers. nt_type=Dopa confirmed in cluster.yaml. MBA:272 (AVPV) cells explicitly present. CLUS_1915 was not ranked in the top-30 DB results because its Kiss1/Th/Esr1 profile appears only in precomputed_expression, not in the defining_markers metadata columns. It was identified through child_cluster_expression analysis of the SUPT_0486 parent. [Atlas metadata]
-- Stephens 2024 (PMID:37934722) bulk Kiss1+ neurons sorted from RP3V vs ARC. Differential δ = ρ_RP3V − ρ_ARC ranks CLUS_1915 first of 5,322 atlas clusters, with δ=0.090 (ρ_RP3V=0.388, ρ_ARC=0.298). All other top-20 hits are also preoptic/periventricular hypothalamic GABAergic clusters — the differential signal is strongly anatomically clean. Independent quantitative confirmation of the existing ATLAS_METADATA-based mapping; the Kiss1+ pool transcriptomic profile tracks CLUS_1915 specifically more than any other cluster in the atlas. [Bulk correlation] [7]
-
-**Concerns:**
-
-- **location_MBA272** (APPROXIMATE): A=MBA:272 (AVPV) / B=MBA:272 (AVPV) n=1; MBA:133 PVpo n=1; MBA:1097 Hypothalamus n=3. AVPV cells present but cluster is very small (n=5 total) and primary soma annotation resolves to the broad Hypothalamus catchall (MBA:1097). MERFISH spatial resolution insufficient to resolve AVPV vs adjacent PVpo/PeN at this cell count.
-
-- CLUS_1915 contains only n=3–5 total cells in the WMBv1 atlas. The sex ratio (MFR=0.02) and expression values are reliable in direction but have limited statistical power. Confidence is capped at MODERATE pending annotation transfer evidence or larger-dataset replication.
-- CLUS_1915 is a sub-resolution split of SUPT_0486. The cluster-level Kiss1+Th+Dopa phenotype is the most specific available match for avpv_kiss1_neuron; however, avpv_th_neuron maps to the same cluster (both types substantially overlap in the classical literature — most AVPV Kiss1 cells co-express Th).
-
-**What would upgrade confidence:**
-
-- *Unresolved:* Do avpv_kiss1_neuron and avpv_th_neuron represent separable populations within CLUS_1915, or is CLUS_1915 the atlas correlate of both?
-
-- *Proposed:* MapMyCells annotation transfer of published AVPV Kiss1-Cre or Kiss1-Cre/Rosa-tdTom scRNA-seq data to WMBv1; confirm F1 score against CLUS_1915.
-
-
----
-
-## Proposed experiments
-
-### 1 — Other
-
-- Inspect child clusters of SUPT_0486 for Kiss1, Th, Esr1 co-expression at cluster level to identify the AVPV Kiss1/TH candidate cluster.
-*Resolves: edge_avpv_kiss1_neuron_to_cs20230722_supt_0486*
-
-### 2 — MapMyCells / annotation transfer
-
-- MapMyCells annotation transfer of published AVPV Kiss1 scRNA-seq data to WMBv1.
-- MapMyCells annotation transfer of published AVPV Kiss1-Cre or Kiss1-Cre/Rosa-tdTom scRNA-seq data to WMBv1; confirm F1 score against CLUS_1915.
-*Resolves: edge_avpv_kiss1_neuron_to_cs20230722_supt_0486, edge_avpv_kiss1_neuron_to_cs20230722_clus_1915*
-
----
-
-## Open questions
-
-1. Which cluster(s) within SUPT_0486 carry peak Kiss1+Th+Esr1 co-expression consistent with AVPV Kiss1/TH identity?
-2. Do PeN (MBA:341) Kiss1 neurons map to SUPT_0486 or a different supertype?
-3. Do avpv_kiss1_neuron and avpv_th_neuron represent separable populations within CLUS_1915, or is CLUS_1915 the atlas correlate of both?
+</details>
 
 ---
 
-## Evidence base
+## Discussion
 
-| Edge | Evidence types | Supports |
-|---|---|---|
-| edge_avpv_kiss1_neuron_to_cs20230722_supt_0486 | Atlas metadata | PARTIAL |
-| edge_avpv_kiss1_neuron_to_cs20230722_clus_1915 | Atlas metadata | SUPPORT |
-| edge_avpv_kiss1_neuron_to_cs20230722_clus_1915 | Bulk correlation [7] | SUPPORT |
+**Primary mapping:** AVPV/PeN kisspeptin neuron →
+*1915 PVpo-VMPO-MPN Hmx2 Gaba_5* [CS20230722_CLUS_1915] at MODERATE
+confidence. Key support: atlas precomputed expression (*Kiss1*+*Th*+*Esr1*
+all elevated; MFR=0.02 ≈ 50:1 female bias) and the Stephens 2024 [7]
+RP3V-vs-ARC bulk-correlation rank 1 / 5322 (δ=0.090). Key caveats:
+LOW_CELL_COUNT (n=3–5 cells in CS20230722_CLUS_1915 limits absolute
+statistical power) and TAXONOMY_LEVEL_MISMATCH (the AVPV-dopaminergic
+population overlaps with *avpv_kiss1_neuron* at the cluster level —
+most AVPV Kiss1 cells co-express *Th* in mouse [3], so the two
+classical types share this atlas correlate). The Cell Ontology BROAD
+mapping to hypothalamus kisspeptin neuron
+[[CL:4023123](https://www.ebi.ac.uk/ols4/ontologies/cl/classes?obo_id=CL:4023123)]
+reflects that CL covers all hypothalamic Kiss1 populations and lacks a
+term specific to the AVPV/RP3V Kiss1-only (non-KNDy) subpopulation;
+CL:4023128 (RP3V KNDy neuron) would be too narrow because it requires
+NKB and dynorphin co-expression that AVPV/PeN Kiss1 cells do not
+exhibit. *(note: a new CL term targeting the AVPV/RP3V Kiss1, non-KNDy
+type is a candidate contribution.)*
+
+### Proposed experiments and follow-ups
+
+**Annotation transfer (MapMyCells) of published AVPV Kiss1 scRNA-seq
+to WMBv1.**
+
+- **What:** Run MapMyCells using Kiss1-Cre or Kiss1-Cre/Rosa-tdTom
+  AVPV scRNA-seq as source, WMBv1 as target.
+- **Target:** F1 ≥ 0.5 at cluster level on CS20230722_CLUS_1915 (the
+  population is very small, so a higher threshold is unlikely to be
+  achievable in a single-cohort run).
+- **Expected output:** `AnnotationTransferEvidence` on both
+  edge_avpv_kiss1_neuron_to_cs20230722_clus_1915 and
+  edge_avpv_kiss1_neuron_to_cs20230722_supt_0486.
+- **Resolves:** open question 1, the absolute confidence cap from the
+  small CS20230722_CLUS_1915 cell count, and (partially) the
+  *avpv_kiss1_neuron* vs *avpv_th_neuron* separability question.
+
+**Targeted spatial transcriptomic resolution of AVPV vs PeN soma.**
+
+- **What:** Re-analyse or supplement the WMBv1 MERFISH registration
+  with a higher-resolution probe panel covering Kiss1/Th/Esr1 in the
+  AVPV–PVpo–PeN periventricular column.
+- **Target:** Resolve cluster-level cell counts at MBA:272 vs MBA:133
+  vs MBA:126 with n ≥ 20 per region.
+- **Expected output:** Refined `anatomical_location[]` counts on
+  CS20230722_CLUS_1915.
+- **Resolves:** the APPROXIMATE soma-location alignment (open
+  question 2).
+
+**Legacy candidate review (CS20230722_CLUS_1915 edge curation).**
+
+- **What:** Curator review of the legacy lowercase-ID edge
+  `edge_avpv_kiss1_neuron_to_cs20230722_clus_1915`. The cluster fell
+  outside the current Stage A top-50 ranking (its Kiss1+Th+Esr1
+  profile is only visible in precomputed expression, not in the
+  defining-marker metadata columns Stage A scores on), and its
+  `property_comparisons` were not refreshed in the 2026-06-08 sweep.
+- **Target:** Confirm whether the edge should be retained as the
+  primary mapping despite Stage-A absence, or whether Stage A's
+  scoring rule should be tightened to surface precomputed-expression
+  signal for cluster-level candidates (issue
+  Cellular-Semantics/evidencell#111).
+- **Expected output:** Either retention with a curator-anchored
+  confidence claim, or a fresh-emit replacement edge with refreshed
+  property comparisons.
+
+### Open questions
+
+1. Do *avpv_kiss1_neuron* and *avpv_th_neuron* represent separable
+   populations within CS20230722_CLUS_1915, or is
+   CS20230722_CLUS_1915 the atlas correlate of both? (Most AVPV
+   Kiss1 cells co-express *Th* in mouse [3], so substantial overlap
+   is expected biologically.)
+2. Do PeN [MBA:126] *Kiss1* neurons map to CS20230722_SUPT_0486 in
+   the same way the AVPV-proper population does, or to a different
+   supertype? The MERFISH cell count in PeN proper within
+   CS20230722_CLUS_1915 is not separately resolved.
+3. Does CS20230722_CLUS_1915 falling outside the current Stage A
+   top-50 warrant tightening Stage A's marker-column scoring (issue
+   Cellular-Semantics/evidencell#111)?
 
 ---
 
@@ -127,10 +445,336 @@ All edges: `evidencell:PartialOverlapMatch`
 
 | # | Citation | PMID | Used for |
 |---|---|---|---|
-| [1] | Nejad et al. 2017 · PMID:29201072 | [29201072](https://pubmed.ncbi.nlm.nih.gov/29201072/) | soma location |
-| [2] | Adachi et al. 2007 · PMID:17213691 | [17213691](https://pubmed.ncbi.nlm.nih.gov/17213691/) | soma location |
-| [3] | Stephens et al. 2017 · PMID:28660243 | [28660243](https://pubmed.ncbi.nlm.nih.gov/28660243/) | soma location |
-| [4] | Kauffman et al. 2007 · PMID:17699664 | [17699664](https://pubmed.ncbi.nlm.nih.gov/17699664/) | Th marker |
-| [5] | Wartenberg et al. 2021 · PMID:34561233 | [34561233](https://pubmed.ncbi.nlm.nih.gov/34561233/) | Esr1 marker |
-| [6] | Frazão et al. 2013 · PMID:23407940 | [23407940](https://pubmed.ncbi.nlm.nih.gov/23407940/) | Kiss1 neuropeptide |
-| [7] | Stephens et al. 2024 · PMID:37934722 | [37934722](https://pubmed.ncbi.nlm.nih.gov/37934722/) | Stephens 2024 (PMID:37934722) bulk Kiss1+ neurons sorted from RP3V vs ARC. Diffe |
+| [1] | Nejad et al. 2017 | [29201072](https://pubmed.ncbi.nlm.nih.gov/29201072) | Soma location, sex steroid regulation |
+| [2] | Adachi et al. 2007 | [17213691](https://pubmed.ncbi.nlm.nih.gov/17213691) | Soma location, Esr1 co-expression, E2 positive feedback |
+| [3] | Stephens et al. 2017 | [28660243](https://pubmed.ncbi.nlm.nih.gov/28660243) | Soma location, Th co-expression, sex bias |
+| [4] | Kauffman et al. 2007 | [17699664](https://pubmed.ncbi.nlm.nih.gov/17699664) | *Th* marker |
+| [5] | Wartenberg et al. 2021 | [34561233](https://pubmed.ncbi.nlm.nih.gov/34561233) | *Esr1* marker |
+| [6] | Frazão et al. 2013 | [23407940](https://pubmed.ncbi.nlm.nih.gov/23407940) | *Kiss1* neuropeptide identity, AVPV dimorphism |
+| [7] | Stephens et al. 2024 | 37934722 (not yet ingested into references.json) | Bulk Kiss1+ RP3V vs ARC correlation |
+
+---
+
+<!-- verdict-block-start: edge_avpv_kiss1_neuron_to_cs20230722_clus_1915 -->
+```yaml
+verdict:
+  confidence: MODERATE
+  confidence_score: 0.65
+  relationship: skos:closeMatch
+  mapping_cardinality: "1:1"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:STRONGEST] CS20230722_CLUS_1915 shows Kiss1+Th+Esr1
+    co-expression (precomputed means 2.51, 6.6, 9.55) with extreme
+    female bias (MFR=0.02) and ranks 1 of 5322 atlas clusters by
+    bulk_correlation differential δ=0.090 in
+    corr_run_20260428_stephens_kiss1_wmbv1 (RP3V vs ARC,
+    Stephens 2024 [7]); 3 of 3 defining markers CONSISTENT; soma
+    APPROXIMATE (MBA:272 n=1 plus boundary scatter into
+    MBA:133/MBA:1097 — MERFISH resolution at very low cell count).
+  reconciliation_note: >
+    Paired with skos:broadMatch on CS20230722_SUPT_0486 (parent
+    supertype, 1:n; see
+    edge_avpv_kiss1_neuron_to_cs20230722_supt_0486); the AVPV
+    Kiss1+Th+ signal concentrates in this single child cluster
+    within the supertype. avpv_th_neuron also maps to
+    CS20230722_CLUS_1915 — overlap is expected biologically because
+    most mouse AVPV Kiss1 cells co-express Th [3]; the two
+    classical types share this atlas correlate at cluster level.
+  caveats:
+    - caveat_type: LOW_CELL_COUNT
+      description: >
+        CS20230722_CLUS_1915 contains only n=3–5 cells in WMBv1; MFR
+        and expression directions are reliable but absolute
+        statistical power is limited. Confidence is capped at
+        MODERATE pending annotation transfer or larger-dataset
+        replication.
+    - caveat_type: TAXONOMY_LEVEL_MISMATCH
+      description: >
+        CS20230722_CLUS_1915 is the most specific available match
+        but is shared with the avpv_th_neuron classical type — most
+        AVPV Kiss1 cells co-express Th [3], so the two types
+        substantially overlap and are not separated at WMBv1
+        cluster resolution.
+    - caveat_type: OTHER
+      description: >
+        Edge ID is legacy lowercase; CS20230722_CLUS_1915 fell
+        outside the current Stage A top-50 because its marker
+        signal is in precomputed_expression rather than the
+        defining-marker metadata columns Stage A scores on.
+        Surfaced for curator review
+        (Cellular-Semantics/evidencell#111).
+  proposed_experiments:
+    - >
+      Cluster annotation transfer of published AVPV Kiss1-Cre or
+      Kiss1-Cre/Rosa-tdTom transgene-marked transcriptomes onto
+      WMBv1; target F1 ≥ 0.5 at cluster level on
+      CS20230722_CLUS_1915. Adds AnnotationTransferEvidence.
+    - >
+      Higher-resolution spatial transcriptomic (MERFISH or
+      comparable) resolution of AVPV [MBA:272] vs PVpo [MBA:133] vs
+      PeN [MBA:126] soma counts on CS20230722_CLUS_1915.
+  unresolved_questions:
+    - >
+      Do avpv_kiss1_neuron and avpv_th_neuron represent separable
+      populations within CS20230722_CLUS_1915, or is
+      CS20230722_CLUS_1915 the atlas correlate of both?
+    - >
+      Do PeN [MBA:126] Kiss1 neurons map to CS20230722_SUPT_0486 in
+      the same way as the AVPV population, or to a different
+      supertype?
+    - >
+      CS20230722_CLUS_1915 fell outside current Stage A top-50 and
+      warrants curator review before being relied on
+      (Cellular-Semantics/evidencell#111).
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_kiss1_neuron_to_cs20230722_supt_0486 -->
+```yaml
+verdict:
+  confidence: MODERATE
+  confidence_score: 0.55
+  relationship: skos:broadMatch
+  mapping_cardinality: "1:n"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:NEXT] CS20230722_SUPT_0486 is the parent supertype that
+    contains the AVPV-Kiss1 correlate CS20230722_CLUS_1915; the
+    supertype carries n=16 AVPV [MBA:272] cells but spans a broader
+    preoptic GABAergic zone (region_fraction_100um: 0.061; strict
+    region_fraction: 0.043) and aggregates ~18 child clusters of
+    which only CS20230722_CLUS_1915 shows the female-biased
+    Kiss1+Th+Esr1 profile.
+  reconciliation_note: >
+    Paired with skos:closeMatch on CS20230722_CLUS_1915
+    (best-cluster, 1:1; see
+    edge_avpv_kiss1_neuron_to_cs20230722_clus_1915). Multiple
+    sexually dimorphic preoptic classical types
+    (avpv_kiss1_neuron, avpv_th_neuron, mpoa_esr1_neuron) all map
+    to this supertype — the 1:n call reflects the supertype's
+    heterogeneity, not an expanded interpretation of
+    avpv_kiss1_neuron itself.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        CS20230722_SUPT_0486 spans PVpo-VMPO-MPN preoptic
+        GABAergic cells; the AVPV/PeN signal lives in one child
+        cluster (CS20230722_CLUS_1915). Three classical types map
+        to the supertype, reflecting the heterogeneity of this
+        preoptic GABAergic group.
+    - caveat_type: TAXONOMY_LEVEL_MISMATCH
+      description: >
+        Female-biased sex ratio is not computed at supertype
+        level; the signal sits in child cluster
+        CS20230722_CLUS_1915 (MFR=0.02). A cluster-level mapping
+        is more specific.
+  proposed_experiments:
+    - >
+      Annotation transfer of published AVPV Kiss1 transcriptomes
+      onto WMBv1; supertype-level F1 ≥ 0.7 with
+      CS20230722_CLUS_1915 carrying the cluster-level F1 would
+      solidify the broadMatch + closeMatch pairing.
+  unresolved_questions:
+    - >
+      Do PeN [MBA:126] Kiss1 neurons map to CS20230722_SUPT_0486
+      or a different supertype?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1301 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1301 sits in MEA-BST (medial
+    amygdala / bed nucleus of stria terminalis) rather than the
+    AVPV/PeN periventricular column; region_fraction_100um: 0.051
+    and no Kiss1/Th/Esr1 expression data available — distant
+    region with no defining-marker signal.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Location DISCORDANT (region_fraction_100um: 0.051);
+        MEA-BST is anatomically distant from AVPV/PeN.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1876 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1876 carries n=39 cells in AVPV
+    [MBA:272] (region_fraction_100um: 0.629) and is GABAergic,
+    but Kiss1, Th, and Esr1 are absent from Stage A
+    expression_detail and from precomputed_expression for this
+    cluster — no defining-marker signal to discriminate it from a
+    generic preoptic GABA cluster.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Location consistent with AVPV but defining markers
+        Kiss1/Th/Esr1 have no atlas expression data at this
+        cluster; cannot anchor to the AVPV Kiss1 phenotype.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1891 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1891 has region_fraction_100um:
+    0.074 (DISCORDANT) — soma sit predominantly in MPN [MBA:515]
+    and PVpo [MBA:133] rather than AVPV/PeN — and no
+    Kiss1/Th/Esr1 expression data available.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Location DISCORDANT (region_fraction_100um: 0.074);
+        minimal AVPV/PeN footprint.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1895 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1895 has region_fraction_100um:
+    0.010 (DISCORDANT, near-zero AVPV/PeN cells) and no
+    Kiss1/Th/Esr1 expression data.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Location DISCORDANT (region_fraction_100um: 0.010);
+        cluster sits in MPN/PVpo with essentially no AVPV/PeN
+        footprint.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1507 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1507 carries n=202 cells in AVPV
+    [MBA:272] (region_fraction_100um: 0.669; location CONSISTENT)
+    and is GABAergic, but Kiss1, Th, and Esr1 are absent from
+    Stage A expression_detail and from precomputed_expression for
+    this cluster — no defining-marker signal.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Location consistent with AVPV but Kiss1/Th/Esr1 have no
+        atlas expression data at this cluster — cannot anchor to
+        the AVPV Kiss1 phenotype.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0411 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0411 contains n=225 cells in AVPV
+    [MBA:272] (region_fraction_100um: 0.550; location CONSISTENT)
+    but no Kiss1/Th/Esr1 expression data at supertype level and
+    no NT assertion — anatomically plausible but no
+    defining-marker signal.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Location consistent with AVPV but defining markers
+        Kiss1/Th/Esr1 have no atlas expression data at this
+        supertype level.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0494 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0494 (ARH-PVp Tbx3 Gaba_2) carries
+    n=54 PeN [MBA:126] cells (region_fraction_100um: 0.557) but
+    is ARH-anchored by name and lacks Kiss1/Th/Esr1 expression
+    data; NT not asserted at supertype level.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        ARH-PVp Tbx3 supertype is more consistent with the
+        arcuate KNDy lineage than the AVPV/PeN Kiss1 (non-KNDy)
+        type; no defining-marker confirmation.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0550 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0550 (MPN-MPO-PVpo Hmx2 Glut_5)
+    carries n=107 AVPV [MBA:272] cells (region_fraction_100um:
+    0.733) but the supertype is glutamatergic — wrong
+    neurotransmitter for AVPV/PeN Kiss1 (GABAergic /
+    dopaminergic).
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Wrong NT — supertype is Glut_5; AVPV/PeN Kiss1 is
+        GABAergic with dopaminergic co-expression.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0249 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0249 (NDB-SI-MA-STRv Lhx8 Gaba_6)
+    is dominated by pallidum/striatum cells
+    (region_fraction_100um: 0.019, DISCORDANT) with no
+    Kiss1/Th/Esr1 signal — wrong region.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Location DISCORDANT (region_fraction_100um: 0.019;
+        Pallidum/Striatum-dominated); no AVPV/PeN footprint.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0486 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.3
+  rationale: >
+    [tier:CUT] Duplicate fresh-emit edge to CS20230722_SUPT_0486
+    — the substantive supertype mapping is encoded on the legacy
+    edge edge_avpv_kiss1_neuron_to_cs20230722_supt_0486
+    (lowercase ID) which carries the populated
+    property_comparisons, caveats, AVPV n=16 finding, and
+    CLUS_1915 child-pointer. This uppercase-ID fresh-emit edge
+    carries only discovery_score and a stub property_comparison;
+    recommend curator removal to resolve the duplicate.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Duplicate edge — same taxonomy_type CS20230722_SUPT_0486
+        is targeted by both
+        edge_avpv_kiss1_neuron_to_cs20230722_supt_0486 (legacy,
+        substantive) and this fresh-emit edge (impoverished).
+        Curator removal of one is recommended.
+```
+<!-- verdict-block-end -->

--- a/reports/sexually_dimorphic/avpv_th_neuron_summary.md
+++ b/reports/sexually_dimorphic/avpv_th_neuron_summary.md
@@ -1,102 +1,200 @@
 # AVPV tyrosine hydroxylase (TH) neuron — WMBv1 Mapping Report
-*2026-04-25 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
+*2026-04-25 · Source: `/Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
 
 ---
 
-## Classical type
+## Introduction
+
+The anteroventral periventricular nucleus (AVPV) of the rostral hypothalamus contains a sexually dimorphic population of tyrosine hydroxylase (TH)-expressing neurons that is two- to four-fold more numerous in females than in males and is implicated in oestradiol-driven positive feedback control of GnRH secretion [4]. Most of these AVPV/PeN TH neurons co-express Kiss1, and the population sits at the heart of the dimorphic preoptic circuitry coordinating reproductive physiology with environmental cues [3]. Placing this classical, transgene- and immunohistochemistry-defined population onto the Whole Mouse Brain v1 (WMBv1) transcriptomic atlas is the goal of the present mapping.
+
+### Classical type table
 
 | Property | Value | References |
 |---|---|---|
-| CL term | — | |
-| Soma location | anteroventral periventricular nucleus (AVPV) [MBA:272] | [1] [2] [3] |
-| NT | dopaminergic | [3] |
-| Markers | Th+, Kiss1+ | [1] [4] [2] [3] [5] |
+| Soma location | Anteroventral periventricular nucleus [MBA:272] | [1], [2], [3] |
+| NT type | dopaminergic | [3] |
+| Defining markers | Th; Kiss1 | Th: [1], [4], [2]; Kiss1: [3], [5] |
+| Negative markers | — | — |
+| Neuropeptides | — | — |
+| Notes | Female-biased dimorphism (2–4× more TH+ neurons in females); substantial overlap with AVPV/PeN Kiss1 neurons; distinct from SDN-POA where TH-ir cell bodies are absent (only TH-ir axons/synapses present). | — |
+
+<details>
+<summary>Details — source evidence for classical type properties</summary>
+
+- **Th (defining marker):** classical immunohistochemistry / TH-ir cell counts in AVPV [[1]], [[4]], [[2]].
+  > the anteroventral periventricular nucleus of the hypothalamus (AVPV) consists mainly of TH-positive neurons
+  > — He et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 3481177_1dd3b718 -->
+
+  > A notable exception is the AVPV of the hypothalamus, which is larger in volume, contains more cells, and sends more projections to multiple reproduction-related brain regions in females compared to males [25,34,71,72,76e[79]. Importantly, it also expresses several sexually dimorphic molecularly defined neuronal populations, including the tyrosine hydroxylase (TH)-expressing population, which contains 3e4 times more neurons in females than in males [34,72]
+  > — Zilkha et al. 2021, Sexually Dimorphic Brain Regions and Structures · [4] <!-- quote_key: 233446934_e19240c2 -->
+
+- **Kiss1 (defining marker):** AVPV/PeN Kiss1 ↔ TH co-expression [[3]], [[5]].
+  > Kiss1-syntheizing neurons reside primarily in the hypothalamic anteroventral periventricular (AVPV/PeN) and arcuate (ARC) nuclei. AVPV/PeN Kiss1 neurons are sexually dimorphic, with females expressing more Kiss1 than males, and participate in estradiol (E2)- induced positive feedback control of GnRH secretion. In mice, most AVPV/PeN Kiss1 cells coexpress tyrosine hydroxylase (TH), the rate-limiting enzyme in catecholamine synthesis (in this case, dopamine).
+  > — Stephens et al. 2017, Neuronal Markers and Molecular Characteristics · [3] <!-- quote_key: 4702847_ebd225e6 -->
+
+  > adult testosterone-treated GPR54 KO males displayed "female-like" numbers of tyrosine hydroxylase-immunoreactive and Kiss1 mRNA-containing neurons in the anteroventral periventricular nucleus and likewise possessed fewer motoneurons in the spino- bulbocavernosus nucleus than did WT males
+  > — Kauffman et al. 2007, Neuronal Markers and Molecular Characteristics · [5] <!-- quote_key: 17692566_78d7ff15 -->
+
+- **Soma location (AVPV [MBA:272]):**
+  > The hypothalamus plays a critical role in coordinating expression of reproductive behaviors and physiological responses with environmental cues. Its close anatomical and physiological relationship with the pituitary gland provides an effective means for coordinating diverse homeostatic processes through neuroendocrine regulation of hormone secretion. The hypothalamus contains sexual dimorphic areas which are different in morphology, density, gene expression and neuronal projections. One of the sexually dimorphic neuronal populations in the hypothalamus is tyrosine hydroxylase expressing (TH-ir) neurons whose number is greater in female than in male mice. The role of the sexual dimorphism of these TH-ir neurons is still unknown
+  > — author of [1] et al. 2012, Introduction · [1] <!-- quote_key: 214694216_9c6ba0ce -->
+
+</details>
+
+No Cell Ontology term currently covers this type — candidate for a new CL term (sibling of CL:4072009 *A12 dopaminergic neuron*, for the AVPV/RP3V A14 dopaminergic population).
 
 ---
 
-## Mapping candidates
+## Results
 
-| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
-|---|---|---|---|---|---|
-| — | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] |  | 178 |  |  |
-| — | 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_CLUS_1915] | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 | 5 |  |  |
+Classical AVPV TH neurons map most plausibly onto the periventricular-preoptic Hmx2 GABAergic supertype 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] (see property comparison and evidence support tables below), with the rare dopaminergic child cluster 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_CLUS_1915] as the best-resolved cluster carrying the female-biased TH/Kiss1 signature. Cluster-level resolution is limited by small n (CLUS_1915 retains only ~3–5 cells in the curated cohort) and by ambiguous separation from the largely overlapping AVPV Kiss1 population; soma counts at MBA:272 (Anteroventral periventricular nucleus) for both targets are sparse, consistent with boundary scatter across the periventricular-preoptic corridor rather than a clean within-AVPV placement.
 
-All edges: `evidencell:PartialOverlapMatch`
+### Supertype-level survivor — 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] · 🟡 MODERATE
+
+**Property comparison (Table 1).**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Anteroventral periventricular nucleus [MBA:272] | hypothalamus / Periventricular hypothalamic nucleus, preoptic part [MBA:133] / Medial preoptic nucleus [MBA:515] (`region_fraction_100um: 0.061`) | hypothalamus / preoptic periventricular / Medial preoptic nucleus (CLUS_1915; `region_fraction_100um: 0.071`) | DISCORDANT |
+| NT type | dopaminergic | not asserted (supertype label is Gaba_5) | Dopa (CLUS_1915) | SUPT: NOT_ASSESSED; CLUS: CONSISTENT |
+| Th expression | defining marker | no precomputed value at supertype level | Th=6.6 (CLUS_1915; highest in SUPT_0486 lineage) | NOT_ASSESSED at supertype; supportive at cluster |
+| Kiss1 expression | defining marker | no precomputed value at supertype level | Kiss1=2.51 (CLUS_1915; only child cluster substantially above background) | NOT_ASSESSED at supertype; supportive at cluster |
+| Sex ratio | female-biased (2–4× more TH+ in females) | not available at supertype level | MFR=0.02 (CLUS_1915; extreme female bias) | CONSISTENT at cluster |
+
+*(1 of 5 child clusters in SUPT_0486 [CLUS_1915] carries the female-biased Th/Kiss1 dopaminergic profile; the remainder are sex-neutral or lack Th/Kiss1 signal. Best match: CLUS_1915.)*
+
+**Evidence support (Table 2).**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas precomputed expression / cohort scoring at supertype | Atlas metadata | SUPPORT | Th=2.72, Esr1=7.72, Kiss1=0.62; rank-1 cohort top; female-biased child CLUS_1915 inside | atlas-internal |
+
+The mapping at supertype level is supported by three converging atlas signals: a Th-expressing periventricular-preoptic GABAergic supertype, an unusually female-biased child cluster (CLUS_1915, male/female ratio 0.02) within it, and Esr1 expression consistent with the classical type's documented oestrogen responsiveness [3]. The supertype's GABAergic label is not a contradiction of the classical type's dopaminergic identity: dopaminergic identity in this corridor is resolved only at cluster level (CLUS_1915 is annotated Dopa) and the AVPV TH/Kiss1 population is widely reported to be GABAergic-dopaminergic dual-phenotype. The principal weakness is that direct atlas-side Th and Kiss1 expression values are not exposed at the supertype level in the available facts, so transcript-level marker concordance is established only via the child cluster (see CLUS_1915 below). Location is the main caveat: only ~6% of SUPT_0486 cells fall within or near (100 µm of) MBA:272, with the bulk of soma scattering across the periventricular preoptic nucleus [MBA:133] and the medial preoptic nucleus [MBA:515] — adjacent rostral preoptic structures consistent with boundary scatter rather than a wrong-region placement *(note: the AVPV abuts the periventricular preoptic and medial preoptic nuclei, and MERFISH-derived soma assignments in this corridor are known to drift across the AVPV/PeN/MPO border)*.
+
+**Concerns.**
+- Location DISCORDANT — `region_fraction_100um: 0.061` (distant from a clean within-AVPV placement; weak counter-evidence interpretable as registration scatter across the adjacent preoptic periventricular and medial preoptic compartments rather than off-target localisation).
+- Supertype label is Gaba_5, not Dopa; dopaminergic identity is rescued only at cluster level (CLUS_1915).
+- avpv_th_neuron and avpv_kiss1_neuron both land on SUPT_0486 — the two classical types substantially overlap at the literature level (most AVPV/PeN Kiss1 cells co-express Th) and atlas-side separation between them within SUPT_0486 is not yet established.
+
+**What would upgrade confidence.**
+- Cluster annotation transfer onto WMBv1 from Th-Cre or Kiss1-Cre AVPV transcriptomic data, targeting F1 ≥ 0.80 at supertype (SUPT_0486) and cluster (CLUS_1915) levels, written back as `AnnotationTransferEvidence`.
+- Atlas-side Th and Kiss1 precomputed-expression values exposed at the supertype level, to anchor marker concordance without relying solely on the single Dopa-annotated child cluster.
+
+### Cluster-level survivor — 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_CLUS_1915] · 🟡 MODERATE
+
+**Property comparison (Table 1).**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Anteroventral periventricular nucleus [MBA:272] | (see SUPT_0486 row above) | hypothalamus / Periventricular hypothalamic nucleus, preoptic part [MBA:133] / Medial preoptic nucleus [MBA:515] (`region_fraction_100um: 0.071`) | DISCORDANT |
+| NT type | dopaminergic | not asserted | Dopa | CONSISTENT |
+| Th expression | defining marker | not available | Th=6.6 (highest in the SUPT_0486 lineage) | CONSISTENT |
+| Kiss1 expression | defining marker | not available | Kiss1=2.51 (only cluster substantially above background) | CONSISTENT |
+| Slc18a2 (VMAT2) | not asserted by classical lit | not available | DEFINING cluster marker | supportive context |
+| Sex ratio | female-biased (2–4×) | not available | MFR=0.02 (extreme female bias) | CONSISTENT |
+
+**Evidence support (Table 2).**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas precomputed expression / cluster annotation | Atlas metadata | SUPPORT | Th=6.6; Kiss1=2.51; Dopa; MFR=0.02; Slc18a2 DEFINING; cohort top (rank 0, score 4/next-best 2) | atlas-internal |
+
+CLUS_1915 is the only WMBv1 cluster simultaneously carrying (i) high Th expression, (ii) detectable Kiss1, (iii) a dopaminergic neurotransmitter annotation, and (iv) the extreme female bias characteristic of the AVPV TH/Kiss1 population [3], [4]. Slc18a2 (VMAT2), the vesicular monoamine transporter required for dopaminergic vesicle loading, appears as a DEFINING cluster marker, providing an orthogonal monoaminergic identity signal beyond Th itself. Stage A scored CLUS_1915 as the dominant rank-0 candidate within a 10-member female-biased dopaminergic AVPV cohort (score 4 vs next-best 2). The principal weakness is statistical: the cluster retains only ~3–5 source-cohort cells after atlas filtering, so all metrics are directionally correct but underpowered, which caps reportable confidence at MODERATE despite the qualitative marker convergence. As with the parent supertype, soma counts at MBA:272 are sparse (`region_fraction_100um: 0.071`), with the bulk of the cluster falling into the adjacent periventricular preoptic [MBA:133] and medial preoptic nuclei [MBA:515] — interpretable as boundary scatter across the AVPV/PeN/MPO corridor rather than off-target placement.
+
+**Concerns.**
+- Low cell count (n ≈ 3–5 after filtering): all signals directional but underpowered.
+- Location DISCORDANT — `region_fraction_100um: 0.071` (boundary scatter across the periventricular and medial preoptic neighbours of MBA:272).
+- avpv_th_neuron and avpv_kiss1_neuron both map onto CLUS_1915 — these two classical types substantially overlap in the literature (most AVPV/PeN Kiss1 cells co-express Th) and may in fact be the same transcriptomic population entered from two marker-defined entry points.
+- Edge YAML duplication: a second edge against this same accession (`edge_avpv_th_neuron_to_CS20230722_CLUS_1915`, fresh-emit ID) carries only stub structured evidence and no curator caveats; it should be retired by the curator in favour of the substantive lowercase-ID edge.
+
+**What would upgrade confidence.**
+- Annotation transfer of Th-Cre AVPV transcriptomic data onto WMBv1 targeting F1 ≥ 0.80 at cluster level for CLUS_1915.
+- A larger AVPV/PeN-targeted transcriptomic cohort (Th-Cre and/or Kiss1-Cre) to lift n above the small-sample ceiling that currently caps cluster-level confidence.
+
+<details>
+<summary>Candidates audited (full top-K)</summary>
+
+| WMBv1 cluster / supertype | Cells (10x) | Confidence | Key evidence | Verdict |
+|---|---:|---|---|---|
+| 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] | 933 | 🟡 MODERATE | Th+/Esr1+ supertype harbours female-biased Dopa child CLUS_1915 | Primary (supertype) |
+| 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_CLUS_1915] | 265 | 🟡 MODERATE | Th=6.6, Kiss1=2.51, Dopa, MFR=0.02 | Primary (cluster) |
+| 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_CLUS_1915] (duplicate edge) | 265 | ⚪ UNCERTAIN | Stub fresh-emit edge against same accession | Eliminated (duplicate of substantive edge) |
+| 1469 MPO-ADP Lhx8 Gaba_3 [CS20230722_CLUS_1469] | 30 | 🔴 LOW | Dopa label but in MPO/ADP, not AVPV | Eliminated (wrong subregion) |
+| 5246 Tanycyte NN_2 [CS20230722_CLUS_5246] | 94 | 🔴 REFUTED | Tanycyte (non-neuronal), located at third ventricle | Eliminated (non-neuronal lineage) |
+| 1910 PVpo-VMPO-MPN Hmx2 Gaba_4 [CS20230722_CLUS_1910] | 135 | 🔴 LOW | Dopa-adjacent but no Th/Kiss1 / female-bias signal | Eliminated (no dimorphic Th/Kiss1 signal) |
+| 5211 Astro-NT NN_1 [CS20230722_CLUS_5211] | 89 | 🔴 REFUTED | Astrocyte (non-neuronal), striatal/olfactory soma | Eliminated (non-neuronal lineage) |
+| 0550 MPN-MPO-PVpo Hmx2 Glut_5 [CS20230722_SUPT_0550] | 583 | 🔴 LOW | Glutamatergic; high MBA:272 fraction but no Th/Dopa | Eliminated (glutamatergic, no dopaminergic child) |
+| 1172 Tanycyte NN_1 [CS20230722_SUPT_1172] | 135 | 🔴 REFUTED | Tanycyte (non-neuronal) | Eliminated (non-neuronal lineage) |
+| 0419 PVR Six3 Sox3 Gaba_9 [CS20230722_SUPT_0419] | 620 | 🔴 LOW | Preoptic GABAergic; no Th/Dopa annotation | Eliminated (no dopaminergic identity) |
+| 0485 PVpo-VMPO-MPN Hmx2 Gaba_4 [CS20230722_SUPT_0485] | 260 | 🔴 LOW | PVpo GABA neighbour of SUPT_0486; no Th/Dopa child | Eliminated (no Th/Dopa child) |
+| 0400 SI-MPO-LPO Lhx8 Gaba_5 [CS20230722_SUPT_0400] | 195 | 🔴 LOW | Substantia innominata / MPO/LPO GABA; far from AVPV | Eliminated (wrong subregion) |
+
+</details>
 
 ---
 
-## 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 · 
+### Methods
 
-*`CS20230722_SUPT_0486` · 178 cells (10x)*
+<details>
+<summary>Data sources, analyses, and reproducibility receipts</summary>
 
-**Supporting evidence:**
+**Classical type definition.** The classical AVPV TH neuron is defined (CLASSICAL_NEUROCHEMICAL `definition_basis`) by tyrosine hydroxylase (Th) immunoreactivity in AVPV cell bodies [1], [4], [2], with substantial co-expression of Kiss1 [3], [5], a dopaminergic neurotransmitter phenotype [3], soma in the anteroventral periventricular nucleus [MBA:272] [1], [2], [3], and a robust female-biased numerical dimorphism (2–4× more TH+ neurons in females [4]).
 
-- SUPT_0486 is the top-ranked rank-1 candidate for avpv_th_neuron. Child cluster CLUS_1915 (nt_type=Dopa, male_female_ratio=0.02) is the most extremely female-biased cluster in the candidate set, directly concordant with the female-biased AVPV TH population (2-4x more TH+ neurons in females). Th=2.72, Esr1=7.72, Kiss1=0.62 at supertype level. Three independent signals (Th expression, AVPV location, female sex ratio in child cluster) converge on SUPT_0486/CLUS_1915. [Atlas metadata]
+**Atlas mapping query.** Candidate atlas clusters were retrieved from the Whole Mouse Brain v1 (WMBv1) taxonomy (CCN20230722) at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match at MBA:272, dopaminergic NT type, defining markers Th/Kiss1, and female sex bias). Full scoring rules: `workflows/map-cell-type.md`.
 
-**Concerns:**
+**Property alignment.** Each defining property of the classical type was compared to the corresponding atlas-side value via the `property_comparisons` schema, with alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster and from MERFISH spatial registration for soma location. No MERFISH location data was used for the classical-side soma (`has_merfish_location: false`); the classical soma assignment is anchored on the literature record.
 
-- **nt_type** (APPROXIMATE): A=dopaminergic (A14 group) / B=GABAergic (Gaba_5 label); child CLUS_1915 nt_type=Dopa. Dopaminergic identity resolved at cluster level; supertype label reflects majority.
-- **location_MBA272** (APPROXIMATE): A=MBA:272 (AVPV) / B=MBA:272 (AVPV) n=16; MBA:133 PVpo n=64; MBA:515 MPN n=37. Direct AVPV cells present (n=16); supertype also spans broader preoptic zone.
-- **marker_Th** (APPROXIMATE): A=POSITIVE (protein, primary defining marker) / B=precomputed mean_expression=2.72. 
-- **marker_Kiss1** (APPROXIMATE): A=POSITIVE (transcript, co-expressed with Th in AVPV) / B=precomputed mean_expression=0.62. 
-- SUPT_0486 carries a Gaba_5 label at supertype level while the classical AVPV TH neuron is dopaminergic. Dopaminergic identity is resolved only at cluster level (CLUS_1915, Dopa designation).
-- avpv_th_neuron and avpv_kiss1_neuron both map to SUPT_0486 — these two classical types substantially overlap (most AVPV/PeN Kiss1 cells co-express Th). Cluster-level resolution needed to determine whether they are separable within SUPT_0486.
+**Annotation transfer.** No annotation-transfer runs are recorded against this node — this is the principal gap and the primary upgrade path (see Discussion).
 
-**What would upgrade confidence:**
+**Bulk transcriptomic correlation.** No bulk-correlation runs are recorded against this node.
 
-- *Unresolved:* Does CLUS_1915 specifically correspond to AVPV A14 TH neurons? Confirm by cluster-level Kiss1/Th/Esr1 co-expression profiling.
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote. Specific mapping limitations and caveats are documented per-candidate in the Discussion section.
 
-- *Proposed:* MapMyCells annotation transfer of AVPV TH-lineage (Th-Cre or Kiss1-Cre) scRNA-seq data to WMBv1 for F1-based confirmation.
+*Generated by evidencell `25c2b32` at 2026-06-08T18:14:03+00:00 from [kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml](kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
 
+**Evidence base table.**
 
----
+| Edge ID | Evidence types | Supports | Source |
+| --- | --- | --- | --- |
+| edge_avpv_th_neuron_to_cs20230722_supt_0486 | ATLAS_METADATA | SUPPORT | atlas-internal |
+| edge_avpv_th_neuron_to_cs20230722_clus_1915 | ATLAS_METADATA | SUPPORT | atlas-internal |
+| edge_avpv_th_neuron_to_CS20230722_CLUS_1915 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_th_neuron_to_CS20230722_CLUS_1469 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_th_neuron_to_CS20230722_CLUS_5246 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_th_neuron_to_CS20230722_CLUS_1910 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_th_neuron_to_CS20230722_CLUS_5211 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_th_neuron_to_CS20230722_SUPT_0550 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_th_neuron_to_CS20230722_SUPT_1172 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_th_neuron_to_CS20230722_SUPT_0419 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_th_neuron_to_CS20230722_SUPT_0485 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_avpv_th_neuron_to_CS20230722_SUPT_0400 | ATLAS_METADATA | PARTIAL | atlas-internal |
 
-## 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 · 
-
-*`CS20230722_CLUS_1915` · 5 cells (10x) · supertype: 0486 PVpo-VMPO-MPN Hmx2 Gaba_5*
-
-**Supporting evidence:**
-
-- CLUS_1915 is the top-ranked rank-0 candidate (DB score=6) for avpv_th_neuron. Th=6.6 (highest in the SUPT_0486 lineage), Kiss1=2.51 (only cluster with Kiss1 substantially above background), MFR=0.02 (extreme female bias), nt_type=Dopa confirmed, MBA:272 (AVPV) cells present. Slc18a2 (VMAT2, vesicular monoamine transporter) is a DEFINING cluster marker, providing independent dopaminergic identity support. Three convergent signals: Th expression, female sex ratio, and dopaminergic NT type. [Atlas metadata]
-
-**Concerns:**
-
-- **location_MBA272** (APPROXIMATE): A=MBA:272 (AVPV) / B=MBA:272 (AVPV) n=1; MBA:133 PVpo n=1; MBA:1097 Hypothalamus n=3. AVPV cells present; cluster too small to resolve sub-regional anatomy precisely.
-- CLUS_1915 has only n=3–5 total cells. All metrics are directionally correct but have limited statistical power. Confidence capped at MODERATE.
-- avpv_th_neuron and avpv_kiss1_neuron both map to CLUS_1915 — the two classical types are substantially overlapping (most AVPV Kiss1 cells co-express Th). These may be the same cell population described from different entry points in the classical literature.
-
-**What would upgrade confidence:**
-
-- *Unresolved:* Is CLUS_1915 specifically the A14 TH/Kiss1 cluster, or does it also include TH+ AVPV neurons that are Kiss1-negative?
-
-- *Proposed:* MapMyCells annotation transfer of Th-Cre AVPV scRNA-seq data for F1-based confirmation at cluster level.
-
+</details>
 
 ---
 
-## Proposed experiments
+## Discussion
 
-### 1 — MapMyCells / annotation transfer
+**Primary mapping:** AVPV tyrosine hydroxylase (TH) neuron → 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] at MODERATE confidence, with 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_CLUS_1915] as the best-resolved child cluster at MODERATE confidence. Key support: atlas-side convergence of dopaminergic identity, Th/Kiss1 expression, and extreme female sex bias on CLUS_1915 within an otherwise GABAergic periventricular-preoptic supertype. Key caveats: NT prediction uncertain at supertype level (Gaba_5 vs Dopa rescued only at cluster level); low cell count at CLUS_1915 capping cluster-level confidence; and an ambiguous mapping with the overlapping avpv_kiss1_neuron classical type, which targets the same supertype and cluster.
 
-- MapMyCells annotation transfer of AVPV TH-lineage (Th-Cre or Kiss1-Cre) scRNA-seq data to WMBv1 for F1-based confirmation.
-- MapMyCells annotation transfer of Th-Cre AVPV scRNA-seq data for F1-based confirmation at cluster level.
-*Resolves: edge_avpv_th_neuron_to_cs20230722_supt_0486, edge_avpv_th_neuron_to_cs20230722_clus_1915*
+No Cell Ontology term currently covers this type. The knowledge base notes this as a candidate for a new CL term, structured as a sibling of CL:4072009 (*A12 dopaminergic neuron*) covering the AVPV/RP3V A14 dopaminergic group — distinct from CL:4072009 on anatomical (A14 vs A12), developmental, and functional grounds (oestradiol-driven positive feedback on GnRH secretion is specific to the AVPV/PeN population). The mapping above should therefore be read as a transcriptomic anchor for a future CL contribution rather than as a placement onto an existing ontology class.
 
----
+### Proposed experiments and follow-ups
 
-## Open questions
+- **What:** Cluster-level annotation transfer of AVPV TH-lineage and Kiss1-lineage transcriptomic data (Th-Cre or Kiss1-Cre cohorts) onto WMBv1.
+  **Target:** F1 ≥ 0.80 at supertype CS20230722_SUPT_0486 and at cluster CS20230722_CLUS_1915; concurrent assessment of whether the avpv_th_neuron and avpv_kiss1_neuron source cohorts are separable within CLUS_1915.
+  **Expected output:** `AnnotationTransferEvidence` items on edges to SUPT_0486 and CLUS_1915; if the two source cohorts are indistinguishable on AT and on available property panels, a `lit_to_lit_edges` link between the two classical nodes.
+  **Resolves:** the supertype-level NT uncertainty (Gaba_5 vs Dopa), the cluster-level small-n cap, and open question (1) below.
 
-1. Does CLUS_1915 specifically correspond to AVPV A14 TH neurons? Confirm by cluster-level Kiss1/Th/Esr1 co-expression profiling.
-2. Is CLUS_1915 specifically the A14 TH/Kiss1 cluster, or does it also include TH+ AVPV neurons that are Kiss1-negative?
+- **What:** Atlas-side cluster-level Kiss1/Th/Esr1 co-expression profiling at single-cell resolution on CLUS_1915 and its sibling clusters within SUPT_0486.
+  **Target:** identify which child cluster(s), if any, beyond CLUS_1915 carry the female-biased Th/Kiss1 profile and quantify within-cluster heterogeneity.
+  **Expected output:** updated PropertyComparisons with cluster-resolved marker values; possible reassignment of confidence at CLUS_1915 from MODERATE to HIGH if the small-n picture holds at fuller depth.
+  **Resolves:** open question (1).
 
----
+### Open questions
 
-## Evidence base
-
-| Edge | Evidence types | Supports |
-|---|---|---|
-| edge_avpv_th_neuron_to_cs20230722_supt_0486 | Atlas metadata | SUPPORT |
-| edge_avpv_th_neuron_to_cs20230722_clus_1915 | Atlas metadata | SUPPORT |
+1. Does CLUS_1915 specifically correspond to AVPV A14 TH/Kiss1 neurons, or does it also include TH+ AVPV neurons that are Kiss1-negative? Cluster-level Kiss1/Th/Esr1 co-expression profiling is needed (raised on both the SUPT_0486 and CLUS_1915 edges).
+2. Curator removal of the duplicate stub edge `edge_avpv_th_neuron_to_CS20230722_CLUS_1915` (legacy / fresh-emit ID collision against the substantive lowercase-ID edge on the same `taxonomy_type` accession).
 
 ---
 
@@ -105,7 +203,308 @@ All edges: `evidencell:PartialOverlapMatch`
 | # | Citation | PMID | Used for |
 |---|---|---|---|
 | [1] | https://doi.org/10.1007/s12031-012-9923-1 | — | soma location |
-| [2] | He et al. 2013 · PMID:25206587 | [25206587](https://pubmed.ncbi.nlm.nih.gov/25206587/) | soma location |
-| [3] | Stephens et al. 2017 · PMID:28660243 | [28660243](https://pubmed.ncbi.nlm.nih.gov/28660243/) | soma location |
-| [4] | Zilkha et al. 2021 · PMID:33910083 | [33910083](https://pubmed.ncbi.nlm.nih.gov/33910083/) | Th marker |
-| [5] | Kauffman et al. 2007 · PMID:17699664 | [17699664](https://pubmed.ncbi.nlm.nih.gov/17699664/) | Kiss1 marker |
+| [2] | He et al. 2013 | [PMID:25206587](https://pubmed.ncbi.nlm.nih.gov/25206587/) | soma location |
+| [3] | Stephens et al. 2017 | [PMID:28660243](https://pubmed.ncbi.nlm.nih.gov/28660243/) | soma location |
+| [4] | Zilkha et al. 2021 | [PMID:33910083](https://pubmed.ncbi.nlm.nih.gov/33910083/) | Th marker |
+| [5] | Kauffman et al. 2007 | [PMID:17699664](https://pubmed.ncbi.nlm.nih.gov/17699664/) | Kiss1 marker |
+
+---
+
+<!-- verdict-block-start: edge_avpv_th_neuron_to_cs20230722_supt_0486 -->
+```yaml
+verdict:
+  confidence: MODERATE
+  confidence_score: 0.55
+  relationship: skos:broadMatch
+  mapping_cardinality: "1:n"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:STRONGEST] CS20230722_SUPT_0486 (rank 1, cohort rank 6 of 12 by composite
+    score; the supertype's broader female-biased Dopa signal is concentrated in
+    child CS20230722_CLUS_1915, MFR=0.02, Th=6.6, Kiss1=2.51) is the broadest
+    defensible anchor for the classical AVPV Th/Kiss1 dopaminergic population;
+    supertype-level NT label is Gaba_5 with Dopa identity rescued only at the
+    cluster level, and region_fraction_100um=0.061 reflects boundary scatter
+    across MBA:133 / MBA:515 adjacent to MBA:272. Marker concordance is supported
+    indirectly via child CS20230722_CLUS_1915 (Th, Kiss1, Slc18a2 DEFINING).
+  reconciliation_note: >
+    Paired with the cluster-level call on CS20230722_CLUS_1915 (skos:closeMatch +
+    1:1); the supertype carries the broader mapping while CS20230722_CLUS_1915 is
+    the best-resolved child carrying the female-biased Th/Kiss1 profile. Also
+    overlaps with avpv_kiss1_neuron, which targets the same supertype.
+  caveats:
+    - caveat_type: NT_PREDICTION_UNCERTAIN
+      description: >
+        SUPT_0486 carries a Gaba_5 label at supertype level while the classical
+        AVPV TH neuron is dopaminergic. Dopaminergic identity is resolved only at
+        cluster level (CS20230722_CLUS_1915, Dopa designation).
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        avpv_th_neuron and avpv_kiss1_neuron both map to SUPT_0486; the two
+        classical types substantially overlap (most AVPV/PeN Kiss1 cells co-express
+        Th). Cluster-level resolution needed to determine whether they are
+        separable within SUPT_0486.
+    - caveat_type: DISCORDANT_ANATOMY
+      description: >
+        region_fraction_100um=0.061 at MBA:272; bulk of supertype soma sit in
+        adjacent MBA:133 (preoptic periventricular) and MBA:515 (medial preoptic
+        nucleus) — interpretable as boundary scatter rather than off-target
+        placement.
+  proposed_experiments:
+    - >
+      Cluster annotation transfer of Th-Cre or Kiss1-Cre AVPV transgene-marked
+      transcriptomes onto WMBv1, targeting F1 >= 0.80 at supertype
+      CS20230722_SUPT_0486 and cluster CS20230722_CLUS_1915.
+    - >
+      Atlas-side cluster-resolved Th/Kiss1/Esr1 co-expression profiling across
+      SUPT_0486 children to localise the female-biased dopaminergic signal
+      beyond CS20230722_CLUS_1915.
+  unresolved_questions:
+    - >
+      Does CS20230722_CLUS_1915 specifically correspond to AVPV A14 TH neurons?
+      Confirm by cluster-level Kiss1/Th/Esr1 co-expression profiling.
+    - >
+      Curator removal of duplicate edge edge_avpv_th_neuron_to_CS20230722_CLUS_1915
+      — legacy/fresh-emit ID collision on taxonomy_type CS20230722_CLUS_1915.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_th_neuron_to_cs20230722_clus_1915 -->
+```yaml
+verdict:
+  confidence: MODERATE
+  confidence_score: 0.6
+  relationship: skos:closeMatch
+  mapping_cardinality: "1:1"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:STRONGEST] CS20230722_CLUS_1915 (rank 0, cohort rank 1 of 10 by composite
+    score 4 vs next-best 2) is the only WMBv1 cluster simultaneously carrying high
+    Th (precomputed=6.6), detectable Kiss1 (=2.51), a Dopa neurotransmitter
+    annotation, Slc18a2 as a DEFINING cluster marker, and an extreme female sex
+    bias (MFR=0.02) matching the classical AVPV Th/Kiss1 dopaminergic population.
+    Confidence is capped at MODERATE by small cohort retention (n approx 3-5
+    cells after filtering) and by region_fraction_100um=0.071 at MBA:272 — boundary
+    scatter across the adjacent MBA:133 / MBA:515 preoptic periventricular corridor
+    rather than a clean within-AVPV placement.
+  reconciliation_note: >
+    Paired with the supertype-level call on CS20230722_SUPT_0486
+    (skos:broadMatch + 1:n); the cluster is the best-resolved child carrying the
+    female-biased Th/Kiss1 profile within that supertype. Also overlaps with
+    avpv_kiss1_neuron, which targets the same cluster — the two classical types
+    may correspond to the same transcriptomic population entered from two
+    marker-defined entry points.
+  caveats:
+    - caveat_type: LOW_CELL_COUNT
+      description: >
+        CS20230722_CLUS_1915 retains only n approx 3-5 cells after filtering. All
+        signals are directionally correct but statistical power is limited;
+        confidence is capped at MODERATE.
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        avpv_th_neuron and avpv_kiss1_neuron both map to CS20230722_CLUS_1915;
+        most AVPV/PeN Kiss1 cells co-express Th, and the two classical types may
+        in fact be the same population described from different marker entry
+        points.
+    - caveat_type: DISCORDANT_ANATOMY
+      description: >
+        region_fraction_100um=0.071 at MBA:272; bulk of cluster soma sit in
+        adjacent MBA:133 (preoptic periventricular) and MBA:515 (medial preoptic
+        nucleus) — interpretable as boundary scatter across the AVPV/PeN/MPO
+        corridor rather than off-target placement.
+  proposed_experiments:
+    - >
+      Annotation transfer of Th-Cre AVPV transgene-marked transcriptomes onto
+      WMBv1 targeting F1 >= 0.80 at cluster CS20230722_CLUS_1915.
+    - >
+      Larger AVPV/PeN-targeted transcriptomic cohort (Th-Cre and/or Kiss1-Cre) to
+      lift n above the small-sample ceiling currently capping cluster-level
+      confidence.
+  unresolved_questions:
+    - >
+      Is CS20230722_CLUS_1915 specifically the A14 TH/Kiss1 cluster, or does it
+      also include TH+ AVPV neurons that are Kiss1-negative?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_th_neuron_to_CS20230722_CLUS_1915 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.1
+  rationale: >
+    [tier:CUT] Duplicate fresh-emit edge against the same taxonomy_type
+    CS20230722_CLUS_1915 as the substantive lowercase-ID edge; this stub carries
+    only PARTIAL ATLAS_METADATA with region_fraction_100um=0.071 and no curator
+    caveats. Surfaced for curator removal.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Duplicate of substantive edge on CS20230722_CLUS_1915; retain the
+        lowercase-ID edge which carries the full caveat and evidence set.
+  unresolved_questions:
+    - >
+      Curator removal of duplicate edge edge_avpv_th_neuron_to_CS20230722_CLUS_1915
+      — legacy/fresh-emit ID collision on taxonomy_type CS20230722_CLUS_1915.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_th_neuron_to_CS20230722_CLUS_1469 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1469 carries a Dopa annotation but its soma sit in
+    the MPO/ADP (MBA:133 / third ventricle) with region_fraction_100um=0.053 at
+    MBA:272 — too distant from the AVPV to plausibly host the classical Th/Kiss1
+    population, and no Th/Kiss1 expression signal stands out at the cluster level.
+  caveats:
+    - caveat_type: DISCORDANT_ANATOMY
+      description: >
+        region_fraction_100um=0.053 at MBA:272; soma distribution centred on MPO
+        and the third ventricle, not AVPV.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_th_neuron_to_CS20230722_CLUS_5246 -->
+```yaml
+verdict:
+  confidence: REFUTED
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_5246 is a Tanycyte NN_2 cluster (non-neuronal,
+    ependymal lineage) with soma centred on the third ventricle and intermediate
+    periventricular hypothalamus; incompatible with a neuronal Th/Kiss1
+    dopaminergic identity regardless of any partial proximity to MBA:272.
+  caveats:
+    - caveat_type: OTHER
+      description: >
+        Non-neuronal lineage (tanycyte); cannot host the classical AVPV TH neuron
+        regardless of region overlap.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_th_neuron_to_CS20230722_CLUS_1910 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1910 (PVpo-VMPO-MPN Hmx2 Gaba_4, sibling of the
+    primary SUPT_0486 lineage) is Dopa-annotated and has region_fraction_100um=0.260
+    at MBA:272 but shows no standout Th, Kiss1, or female-bias signal at the
+    cluster level; the dimorphic AVPV Th/Kiss1 profile that anchors the mapping
+    sits in CS20230722_CLUS_1915, not here.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Adjacent Hmx2-lineage cluster lacking the defining female-biased Th/Kiss1
+        signature on which the mapping rests.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_th_neuron_to_CS20230722_CLUS_5211 -->
+```yaml
+verdict:
+  confidence: REFUTED
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_5211 is an Astro-NT NN_1 cluster (non-neuronal,
+    astrocytic lineage) with soma centred on striatum, cranial nerves, and
+    olfactory areas; incompatible with a neuronal AVPV Th/Kiss1 identity.
+  caveats:
+    - caveat_type: OTHER
+      description: >
+        Non-neuronal lineage (astrocyte) and soma in striatal/olfactory regions
+        far from MBA:272.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_th_neuron_to_CS20230722_SUPT_0550 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0550 (MPN-MPO-PVpo Hmx2 Glut_5) is glutamatergic
+    and lacks any Dopa-annotated child cluster, despite a very high
+    region_fraction_100um=0.733 at MBA:272. Without dopaminergic identity or a
+    Th/Kiss1-carrying child cluster, region overlap alone does not place the
+    classical AVPV TH neuron here.
+  caveats:
+    - caveat_type: NT_PREDICTION_UNCERTAIN
+      description: >
+        Glutamatergic supertype with no dopaminergic child cluster — incompatible
+        with the classical type's dopaminergic identity.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_th_neuron_to_CS20230722_SUPT_1172 -->
+```yaml
+verdict:
+  confidence: REFUTED
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_1172 (Tanycyte NN_1) is non-neuronal (ependymal
+    tanycyte lineage); incompatible with a neuronal Th/Kiss1 dopaminergic identity
+    regardless of partial periventricular overlap.
+  caveats:
+    - caveat_type: OTHER
+      description: >
+        Non-neuronal lineage (tanycyte); cannot host the classical AVPV TH neuron.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_th_neuron_to_CS20230722_SUPT_0419 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0419 (PVR Six3 Sox3 Gaba_9) is a periventricular
+    GABAergic supertype without dopaminergic identity or a Th/Kiss1-defining
+    child cluster, and region_fraction_100um=0.348 at MBA:272 reflects preoptic
+    overlap rather than AVPV-specific placement.
+  caveats:
+    - caveat_type: NT_PREDICTION_UNCERTAIN
+      description: >
+        GABAergic supertype with no dopaminergic child cluster; lacks the
+        defining classical-type Th/Kiss1 dopaminergic identity.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_th_neuron_to_CS20230722_SUPT_0485 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0485 (PVpo-VMPO-MPN Hmx2 Gaba_4) is the immediate
+    Hmx2-lineage sibling of the primary SUPT_0486 anchor but lacks a Dopa-annotated
+    Th/Kiss1-carrying child cluster equivalent to CS20230722_CLUS_1915; the AVPV
+    Th/Kiss1 dimorphic signal is concentrated in the SUPT_0486 lineage, not here.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Sibling Hmx2-lineage supertype without the defining female-biased Th/Kiss1
+        dopaminergic child cluster.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_avpv_th_neuron_to_CS20230722_SUPT_0400 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0400 (SI-MPO-LPO Lhx8 Gaba_5) is centred on
+    substantia innominata / MPO / LPO with region_fraction_100um=0.022 at MBA:272
+    — too distant from the AVPV — and lacks any dopaminergic or Th/Kiss1 signal.
+  caveats:
+    - caveat_type: DISCORDANT_ANATOMY
+      description: >
+        region_fraction_100um=0.022 at MBA:272; soma centred on substantia
+        innominata and lateral preoptic area, far from AVPV.
+```
+<!-- verdict-block-end -->

--- a/reports/sexually_dimorphic/bnst_crf_neuron_summary.md
+++ b/reports/sexually_dimorphic/bnst_crf_neuron_summary.md
@@ -1,207 +1,131 @@
 # BNST (anterolateral) corticotropin-releasing factor (CRF) neuron — WMBv1 Mapping Report
-*draft · 2026-04-25 · Source: `kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
-
-**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+*2026-04-25 · Source: `kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
 
 ---
 
 ## Introduction
 
-### Classical type
+The bed nucleus of the stria terminalis (BNST) contains the brain's highest density of corticotropin-releasing factor (CRF / Crh) neurons. Within the dorsolateral BNST these CRF neurons are female-biased — both more numerous and larger in females — and concentrated in the oval (ovBNST), anterolateral (alBNST), and dorsolateral (dlBNST) subdivisions, where they release CRF onto type II projection neurons and contribute to the affective component of pain [1][2]. They are distinguished from the calbindin-positive principal nucleus of the BNST (a male-biased Kiss1+ population), making Calb1 a diagnostic negative marker for the dlBNST CRF population.
 
-**BNST (anterolateral) corticotropin-releasing factor (CRF) neuron** is defined by
-neurochemical criteria: Crh expression as both a defining marker and the released
-neuropeptide; Calb1 absence (distinguishing dlBNST CRF neurons from the Calb1+
-principal nucleus of BNST); and a female-biased sexual dimorphism — anterolateral
-BST CRF+ neurons are larger and more numerous in females. Somas concentrate in
-three sub-nuclei of the bed nucleus of the stria terminalis: dlBNST, ovBNST, and
-alBNST. Functional electrophysiology classifies these as Type II dlBNST neurons.
-
-CL term: **corticotropin-releasing neuron (CL:4072021)** — mapping is BROAD; a
-BNST-specific child term is a candidate for new CL contribution.
+### Classical type table
 
 | Property | Value | References |
 |---|---|---|
-| Soma location | Bed nuclei of the stria terminalis [MBA:174] (dorsolateral / oval / anterolateral subnuclei) | [1], [2] |
+| Soma location | Bed nuclei of the stria terminalis [MBA:351] — dorsolateral (dlBNST), oval (ovBNST), and anterolateral (alBNST) subdivisions | [1][2] |
 | Defining markers | Crh | — |
-| Negative markers | Calb1 | — |
-| Neuropeptides | Crh (corticotropin-releasing factor) | [1], [2] |
-| CL term | CL:4072021 (corticotropin-releasing neuron) — BROAD | |
+| Negative markers | Calb1 (distinguishes from Calb1+ principal nucleus) | — |
+| Neuropeptides | Crh (corticotropin-releasing factor) | [1][2] |
+| Electrophysiology | Type II dlBNST neurons (CRF-excited) | [2] |
+| Sex bias | Female-biased — larger and more numerous CRF neurons in alBNST/ovBNST of females | [1] |
 
 <details>
-<summary>Literature support — expand for verbatim quotes</summary>
+<summary>Details — source evidence for classical type properties</summary>
 
-**[1] Frontiers in Neural Circuits 2025 — Sexually Dimorphic Brain Regions and Structures**
+- **Soma location & sex bias:** Kanaya et al. 2025 review citing Uchida et al. 2019 · [1]
 
-> The BNST modulates pain sensitivity by releasing corticotropin-releasing factor (CRF) from neurons in the anterolateral subdivision (Ide et al., 2013). Female mice have larger CRF neurons in the anterolateral BNST than male mice (Uchida et al., 2019). Dopaminergic projection from the periaqueductal gray (PAG) to the BNST, which preferentially targets the dorsal part, including the anterolateral subdivision (Gungor et al., 2016), drives pain-related behaviors differently between male and female mice (Yu et al., 2021b).
-> — Frontiers in Neural Circuits 2025, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 279874350_b2b4adba -->
+  > The BNST modulates pain sensitivity by releasing corticotropin-releasing factor (CRF) from neurons in the anterolateral subdivision (Ide et al., 2013). Female mice have larger CRF neurons in the anterolateral BNST than male mice (Uchida et al., 2019). Dopaminergic projection from the periaqueductal gray (PAG) to the BNST, which preferentially targets the dorsal part, including the anterolateral subdivision (Gungor et al., 2016), drives pain-related behaviors differently between male and female mice (Yu et al., 2021b).
+  > — Kanaya et al. 2025, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 279874350_b2b4adba -->
 
-**[2] Ide et al. 2013 · PMID:23554470 — Sexually Dimorphic Brain Regions and Structures**
+- **Type II electrophysiology and CRF action in dlBNST:** Ide et al. 2013 · [2]
 
-> Pain is a complex experience composed of sensory and affective components. Although the neural systems of the sensory component of pain have been studied extensively, those of its affective component remain to be determined. In the present study, we examined the effects of corticotropin-releasing factor (CRF) and neuropeptide Y (NPY) injected into the dorsolateral bed nucleus of the stria terminalis (dlBNST) on pain-induced aversion and nociceptive behaviors in rats to examine the roles of these peptides in affective and sensory components of pain, respectively. In vivo microdialysis showed that formalin-evoked pain enhanced the release of CRF in this brain region. Using a conditioned place aversion (CPA) test, we found that intra-dlBNST injection of a CRF1 or CRF2 receptor antagonist suppressed pain-induced aversion. Intra-dlBNST CRF injection induced CPA even in the absence of pain stimulation. On the other hand, intra-dlBNST NPY injection suppressed pain-induced aversion. Coadministration of NPY inhibited CRF-induced CPA. This inhibitory effect of NPY was blocked by coadministration of a Y1 or Y5 receptor antagonist. Furthermore, whole-cell patch-clamp electrophysiology in dlBNST slices revealed that CRF increased neuronal excitability specifically in type II dlBNST neurons, whereas NPY decreased it in these neurons. Excitatory effects of CRF on type II dlBNST neurons were suppressed by NPY. These results have uncovered some of the neuronal mechanisms underlying the affective component of pain by showing opposing roles of intra-dlBNST CRF and NPY in pain-induced aversion and opposing actions of these peptides on neuronal excitability converging on the same target, type II neurons, within the dlBNST.
-> — Ide et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 14550592_292dccea -->
+  > In the present study, we examined the effects of corticotropin-releasing factor (CRF) and neuropeptide Y (NPY) injected into the dorsolateral bed nucleus of the stria terminalis (dlBNST) on pain-induced aversion and nociceptive behaviors in rats to examine the roles of these peptides in affective and sensory components of pain, respectively.
+  > — Ide et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 14550592_292dccea -->
+
+  > Furthermore, whole-cell patch-clamp electrophysiology in dlBNST slices revealed that CRF increased neuronal excitability specifically in type II dlBNST neurons, whereas NPY decreased it in these neurons.
+  > — Ide et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 14550592_292dccea -->
 
 </details>
+
+Cell Ontology mapping: corticotropin-releasing neuron [[CL:4072021](https://www.ebi.ac.uk/ols4/ontologies/cl/classes?obo_id=CL:4072021)] (BROAD).
 
 ---
 
 ## Results
 
-### Mapping candidates
+Among the candidate WMBv1 supertypes located in MBA:351, only 0393 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_SUPT_0393] carries Crh as part of its taxonomy label and is the primary mapping for the dlBNST CRF population, with its child cluster 1409 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_CLUS_1409] as the best-child within the supertype (see property comparison table). A parallel pooled-bulk transcriptomic signal from Knoedler 2022 Esr1+ TRAP-seq nominates 0358 MEA-BST Lhx6 Nfib Gaba_2 [CS20230722_SUPT_0358] as a co-primary BST-localised candidate, but that nomination rests on an Esr1+ proxy rather than direct Crh expression and is held at LOW pending Crh confirmation.
 
-Two mapping edges are recorded for bnst_crf_neuron: an alternative supertype-level
-edge to SUPT_0358 supported by Knoedler 2022 Esr1+ TRAP-seq bulk-correlation
-evidence (LOW confidence — Esr1+ is a proxy, not a direct Crh signal), and the
-existing supertype-level edge to SUPT_0393 (the sole rank-1 candidate carrying
-Crh as a DEFINING_SCOPED atlas marker, eliminated at supertype resolution by
-Calb1 discordance). Both are speculative or eliminated at supertype resolution
-and require child-cluster analysis.
+### 0393 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_SUPT_0393] · 🟡 MODERATE
 
-| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
-|---|---|---|---|---|---|---|
-| 1 | 0358 MEA-BST Lhx6 Nfib Gaba_2 [CS20230722_SUPT_0358] | (self) | 666 | 🔴 LOW | NT CONSISTENT; Crh NOT_ASSESSED (Esr1+ proxy); location APPROXIMATE | Speculative |
-| — | 0393 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_SUPT_0393] | (self) | 231 | ⚪ UNCERTAIN | Crh CONSISTENT; Calb1 DISCORDANT | Eliminated (negative_Calb1) |
-2 edges total. Relationship type: PARTIAL_OVERLAP (both edges).
+**Property alignment (Table 1).**
 
-### Property alignment — primary candidate (SUPT_0358)
-
-**Table 1 — Property comparison.**
-
-| Property | Classical | Supertype | Best cluster | Alignment |
+| Property | Classical | Supertype 0393 | Best cluster 1409 | Alignment |
 |---|---|---|---|---|
-| Soma location | Bed nuclei of the stria terminalis [MBA:174] (dlBNST / ovBNST / alBNST) | Multiple child clusters; spans BST and MEA | CLUS_1290 primary soma = BST proper | APPROXIMATE |
-| NT type | GABAergic (CRF+ BST neurons predominantly GABAergic) | GABAergic (Lhx6 Nfib Gaba_2) | not assessed | CONSISTENT |
-| Crh expression | POSITIVE (defining marker) | NOT_ASSESSED — Knoedler sorted on Esr1, not Crh | not assessed | NOT_ASSESSED |
-| Sex ratio | sexually dimorphic (anterolateral BST CRF+ neurons larger in females) | not available | child cluster MFRs span 0.82 to 99.0; CLUS_1293 MFR=99 (male-biased) | APPROXIMATE |
+| Soma location | Bed nuclei of the stria terminalis [MBA:351] | BST count_100um=215 (region_fraction_100um=0.846) | BST count_100um=123 (region_fraction_100um=0.794) | CONSISTENT |
+| NT type | not asserted (CRF+ BST neurons predominantly GABAergic, classical) | not asserted at supertype | GABA | NOT_ASSESSED at supertype; CONSISTENT at cluster |
+| Crh expression (defining marker) | defining marker | no atlas expression data; Crh appears in supertype label | no atlas expression data | NOT_ASSESSED |
+| Calb1 expression (negative marker) | ABSENT | Calb1 mean = 5.57 (cohort pct 0.737) | Calb1 mean = 3.57 (cohort pct 0.517) | DISCORDANT |
+| Sex ratio | female-biased (alBNST/ovBNST CRF neurons larger in females) | not available at supertype | MFR not available in current facts | NOT_ASSESSED |
 
-**Table 2 — Evidence support.**
+*(2 of 9 child clusters of SUPT_0393 surface in the candidate set: CLUS_1409 and CLUS_1410. CLUS_1409 shows lower Calb1 (3.57, cohort pct 0.517) than the supertype mean and is the best-child for the classical type; CLUS_1410 shows higher Calb1 (7.57, cohort pct 0.855) and is therefore less concordant. The remaining children were not surfaced in the rank-0 top-50 and have not been individually assessed.)*
+
+**Evidence support (Table 2).**
 
 | Evidence | Type | Supports | Headline | Source |
 |---|---|---|---|---|
-| Knoedler 2022 Esr1+ TRAP-seq BNST-FR vs VMH-FR | Bulk transcriptomic correlation | PARTIAL | best_child_cluster=CLUS_1295 (rank 4, δ=0.0161); 4 SUPT_0358 child clusters in top 10 | [3] |
+| Atlas metadata: BST-located Crh-labelled Gaba supertype | Atlas metadata | PARTIAL | region_fraction_100um=0.846; supertype label encodes Crh | atlas-internal |
 
-*(Of the 4 SUPT_0358 child clusters in the Knoedler top-10 BNST-specific signal,
-CLUS_1290 maps to BST proper while CLUS_1293 carries an extreme male-biased
-MFR=99 — divergent from the female-biased classical type. Best match by BNST
-specificity: CLUS_1295. Direct Crh expression at child-cluster level has not
-been assessed.)*
+The placement of Crh in the supertype's taxonomy label (`0393 CEA-BST Rai14 Pdyn Crh Gaba_2`) reflects the atlas team's marker-based identification of this cluster as Crh-expressing, and the supertype's soma distribution (region_fraction_100um=0.846 onto MBA:351) places it directly in the dlBNST/alBNST territory where Uchida et al. 2019 and Ide et al. 2013 [1][2] localise the CRF population. The principal discordance is the negative-marker test: classical dlBNST CRF neurons are Calb1-negative, distinguishing them from the Calb1+ principal nucleus of the BNST, yet SUPT_0393 shows Calb1 mean expression 5.57 at the 73.7th cohort percentile. The most plausible reading is that SUPT_0393 aggregates several BNST GABAergic subtypes and that a Calb1-low, Crh-high child cluster within it is the true target — child cluster CLUS_1409 shows lower Calb1 (3.57, cohort pct 0.517) than the supertype mean and is the best-cluster candidate. Confidence is held at MODERATE: the supertype-level mapping is structurally supportable (BST location + Crh in the label) but the Calb1 discordance and the absence of direct Crh expression numbers at this resolution prevent a higher call.
 
----
+*(MERFISH registration caveat: WMBv1 places SUPT_0393 cells at the parent BNST term [MBA:351] without sub-nucleus assignment, so concordance with the dlBNST/ovBNST/alBNST resolution at which the female bias is documented [1] cannot be confirmed from atlas metadata alone.)*
 
+### 1409 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_CLUS_1409] · 🟡 MODERATE
 
+**Property alignment (Table 1).** See the table under SUPT_0393 above; the best-cluster column already shows CLUS_1409's values. The cluster-level NT annotation is explicit (GABA), and Calb1 at CLUS_1409 (3.57; cohort pct 0.517) is lower than at the sibling CLUS_1410 (7.57; cohort pct 0.855), making CLUS_1409 the more parsimonious candidate for a Calb1-low Crh-high dlBNST CRF subpopulation. CLUS_1409 carries 191 cells in the 10x dataset with region_fraction_100um=0.794 (in-BST proximity).
+
+**Evidence support (Table 2).**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas metadata: BST-located, GABA, Crh in supertype label | Atlas metadata | PARTIAL | region_fraction_100um=0.794; Crh on parent supertype | atlas-internal |
+
+The cluster-level evidence is the cleanest available structural match: CLUS_1409 sits in the Crh-labelled BST GABAergic supertype, has GABA NT annotation, has soma proximity to MBA:351 at 0.794, and shows Calb1 below the cohort median (pct 0.517). The Calb1 discordance remains — atlas expression at CLUS_1409 (3.57) is still well above the "absent" classical expectation, and direct Crh expression is not available at this cluster in the facts file — so confidence is MODERATE, paired with SUPT_0393 at supertype level. A targeted measurement of Crh at CLUS_1409 versus CLUS_1410, plus stratification of CLUS_1409 cells by sex, would be the most direct route to upgrading both edges.
 
 ### 0358 MEA-BST Lhx6 Nfib Gaba_2 [CS20230722_SUPT_0358] · 🔴 LOW
 
-### Supporting evidence
+**Property alignment (Table 1).**
 
-- **GABAergic identity is concordant.** Supertype label Lhx6 Nfib Gaba_2 directly
-  aligns with the GABAergic phenotype expected for BST CRF+ neurons (CONSISTENT).
-- **BST anatomical signal is captured at child-cluster level.** Property
-  comparison records CLUS_1290 with primary soma in BST proper, providing direct
-  anatomical anchoring within an otherwise mixed BST/MEA supertype (APPROXIMATE
-  at supertype level due to MEA contribution).
-- **Knoedler 2022 Esr1+ TRAP-seq bulk-correlation signal [3].**
-  > Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq pooled BNST female-receptive vs VMH female-receptive identifies SUPT_0358 (MEA-BST Lhx6 Nfib Gaba_2) as a top BNST-specific signal. Multiple child clusters appear in top 10 by δ(BNST_FR − VMH_FR): CLUS_1295 (rank 4), CLUS_1291 (rank 5), CLUS_1290 (rank 9, primary soma BST proper), CLUS_1293 (rank 10, MFR=99 — extreme male bias). CRITICAL CAVEAT: Knoedler sorted on Esr1+, not Crh+. This evidence supports SUPT_0358 as the BST-localised Esr1+ supertype; CRF+/Crh+ co-localisation within this supertype must be confirmed by direct evidence (ISH, scRNA-seq for Crh) before accepting SUPT_0358 as a bnst_crf_neuron mapping target. Confidence held at LOW pending that confirmation.
-  > — Knoedler et al. 2022 · [3]
+| Property | Classical | Supertype 0358 | Best cluster (Knoedler δ-ranked) | Alignment |
+|---|---|---|---|---|
+| Soma location | Bed nuclei of the stria terminalis [MBA:351] | spans MEA and BST; CLUS_1290 primary soma=BST | CLUS_1290 top anat = BST | APPROXIMATE |
+| NT type | GABAergic (CRF+ BST neurons predominantly GABAergic, classical) | GABAergic (Lhx6 Nfib Gaba_2) | GABAergic | CONSISTENT |
+| Crh expression (defining marker) | defining marker | NOT_ASSESSED — Knoedler sorted on Esr1, not Crh | NOT_ASSESSED | NOT_ASSESSED |
+| Sex ratio | female-biased | child cluster MFRs span 0.82–99.0 | CLUS_1293 MFR=99 (extreme male bias) | APPROXIMATE |
 
-### Marker evidence provenance
+**Evidence support (Table 2).**
 
-- **Crh** — classical node carries Crh as a defining marker without a primary
-  citation on the marker entry itself; literature support comes via the
-  neuropeptide field [1], [2], both of which establish Crh release and peptide
-  function in dlBNST. At target side, SUPT_0358 has no DEFINING marker for Crh
-  in atlas metadata, and the Knoedler sort was on Esr1+ rather than Crh+. The
-  mapping therefore relies on an Esr1+ proxy with no direct Crh quantification
-  at supertype or child-cluster level — a substantial provenance gap. *(note:
-  targeted ISH or scRNA-seq for Crh+/Esr1+ overlap in BST would resolve whether
-  the BNST-Esr1+ transcriptomic signature is a valid proxy for the CRF+
-  population.)*
-- **Calb1 (negative marker)** — classical node lists Calb1 as a negative marker
-  without a primary citation on the marker entry. Calb1 expression at SUPT_0358
-  has not been quantified in this edge's property_comparisons; this remains an
-  assessment gap that should be checked against precomputed expression to rule
-  out a Calb1+ contamination similar to that seen in SUPT_0393.
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Knoedler 2022 Esr1+ TRAP-seq BNST FR vs VMH FR | Bulk-correlation differential | PARTIAL | best child CLUS_1295 rank 4 (δ=0.0161); 4 of top-10 children belong to SUPT_0358 | [3] |
 
-### Concerns
+> Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq pooled BNST female-receptive vs VMH female-receptive identifies SUPT_0358 (MEA-BST Lhx6 Nfib Gaba_2) as a top BNST-specific signal. Multiple child clusters appear in top 10 by δ(BNST_FR − VMH_FR): CLUS_1295 (rank 4), CLUS_1291 (rank 5), CLUS_1290 (rank 9, primary soma BST proper), CLUS_1293 (rank 10, MFR=99 — extreme male bias). CRITICAL CAVEAT: Knoedler sorted on Esr1+, not Crh+. This evidence supports SUPT_0358 as the BST-localised Esr1+ supertype; CRF+/Crh+ co-localisation within this supertype must be confirmed by direct evidence (ISH, scRNA-seq for Crh) before accepting SUPT_0358 as a bnst_crf_neuron mapping target. Confidence held at LOW pending that confirmation.
+> — Knoedler et al. 2022 · [3]
 
-- **Crh expression is NOT_ASSESSED at supertype/cluster level.** The Knoedler
-  evidence is pooled Esr1+ TRAP-seq — Crh+/Esr1+ co-localisation in BST is not
-  established by this run. Without direct Crh quantification, SUPT_0358 cannot
-  be confirmed as the CRF+ correlate.
-- **Location APPROXIMATE — supertype spans BST and MEA.** SUPT_0358 includes
-  medial amygdala (MEA) cells alongside BST. *(adjacent region — MEA and BST
-  are part of the extended amygdala continuum, so this is weak counter-evidence
-  at supertype resolution; cluster-level resolution shows CLUS_1290 is in BST
-  proper.)*
-- **Sex ratio APPROXIMATE with conflicting child-cluster signal.** Child cluster
-  MFRs span 0.82 to 99.0; CLUS_1293 (rank 10 in the Knoedler signal) carries
-  MFR = 99 — extreme male bias, opposite the female-biased dimorphism that
-  defines bnst_crf_neuron. This indicates SUPT_0358 aggregates sex-divergent
-  subpopulations and the CRF+ female-biased subset is unlikely to encompass
-  the entire supertype.
-- **No DEFINING Crh marker in atlas metadata (NO_DISCRIMINATING_MARKER caveat).**
-  The mapping rests entirely on bulk-correlation co-localisation evidence
-  (Esr1+ proxy). Direct Crh expression measurement at cluster level is the
-  prerequisite for any confidence upgrade.
-- **Ambiguous mapping vs SUPT_0393 (AMBIGUOUS_MAPPING caveat).** SUPT_0358 and
-  SUPT_0393 may both capture parts of the heterogeneous BNST-CRF population —
-  SUPT_0393 via direct Crh expression (Calb1-confounded), SUPT_0358 via Esr1+
-  proxy (Crh-unverified). Curator review is required to determine which (or
-  both) should be retained.
+![δ ranked bar plot, BNST_FR vs VMH_FR, target SUPT_0358](figures/bnst_crf_neuron_BNST_FR_vs_VMH_FR_b7a35400.png)
 
-### What would upgrade confidence
+*Top 10 clusters by δ (Spearman ρ difference, BNST_FR pool − VMH_FR pool) from Knoedler 2022 Esr1+ TRAP-seq. Four of the top 10 are children of SUPT_0358 (highlighted), confirming the supertype as the dominant BST-localised Esr1+ transcriptomic signature; ranks above SUPT_0358 are cortical/septal Lamp5/Vip clusters whose appearance is an Esr1+ TRAP background, not a competing BST signal.*
 
-- **ISH or MERFISH co-staining for Crh, Esr1, Calb1 in BST** to identify the
-  cluster boundary between SUPT_0358 (Esr1+) and SUPT_0393 (Crh+). Expected
-  output: `MarkerAnalysisEvidence` resolving the Crh+/Esr1+/Calb1− triple-
-  overlap fraction within SUPT_0358 child clusters.
-- **MapMyCells annotation transfer of published BNST scRNA-seq with Crh+ subset
-  annotations** to WMBv1 at cluster resolution. Target: F1 ≥ 0.50 for Crh+
-  subset cells against either SUPT_0358 or SUPT_0393 (split expected).
-  Expected output: `AnnotationTransferEvidence` on both edges.
-- **Targeted child-cluster query for Crh and Calb1 precomputed expression**
-  across SUPT_0358 child clusters (CLUS_1290, CLUS_1291, CLUS_1293, CLUS_1295)
-  to identify any Crh-high, Calb1-low, female-biased child cluster as a more
-  specific candidate.
-- **Targeted literature search** for primary citations supporting Calb1
-  negativity in dlBNST CRF neurons (currently unsourced on the classical node)
-  would strengthen the negative-marker assertion that is currently driving the
-  SUPT_0393 elimination.
+The Knoedler signal is the only non-atlas-metadata evidence on any candidate for this node, and it strongly localises SUPT_0358 to the BST under an Esr1+ pulldown. The interpretive question is whether the Esr1+ pool overlaps the Crh+ pool in the BST: the literature in the facts file does not establish that overlap directly, and the mixed-direction MFRs across child clusters (notably CLUS_1293 at MFR=99, extreme male bias) are inconsistent with the classical female-biased CRF population. SUPT_0358 may therefore capture a different (or partially overlapping) BST sexually dimorphic population — Esr1+ rather than Crh+. Confidence is LOW; direct Crh measurement in BST at single-cell resolution is the test that would either upgrade SUPT_0358 to a co-primary mapping or refute it.
 
----
+**Stale-edge note.** SUPT_0358 fell outside the current Stage A top-50 at rank 1, and its `property_comparisons` were not refreshed in the 2026-06-08 sweep. The edge remains in the graph from prior curation work and is the only carrier of the Knoedler BULK_CORRELATION evidence — but it warrants curator review for stale-edge cleanup before being relied on (cf. Cellular-Semantics/evidencell#111).
 
-### Eliminated candidates
+<details>
+<summary>Candidates audited (full top-K)</summary>
 
-### 0393 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_SUPT_0393] · ⚪ UNCERTAIN
+| WMBv1 cluster / supertype | Supertype parent | Cells (10x) | Confidence | Key evidence | Verdict |
+|---|---|---:|---|---|---|
+| 0393 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_SUPT_0393] | — | 278 | 🟡 MODERATE | BST proximity 0.846; Crh in supertype label | Primary (supertype) |
+| 1409 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_CLUS_1409] | 0393 CEA-BST Rai14 Pdyn Crh Gaba_2 | 191 | 🟡 MODERATE | best-child within SUPT_0393; Calb1 below cohort median | Primary (best child) |
+| 0358 MEA-BST Lhx6 Nfib Gaba_2 [CS20230722_SUPT_0358] | — | 1734 | 🔴 LOW | Knoedler Esr1+ BST_FR vs VMH_FR top signal | Secondary (Esr1+ proxy) |
+| 1410 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_CLUS_1410] | 0393 CEA-BST Rai14 Pdyn Crh Gaba_2 | 87 | ⚪ UNCERTAIN | sibling of CLUS_1409; Calb1 high (7.57; pct 0.855) | Eliminated (Calb1 high, sibling outperformed) |
+| 0410 BST Tac2 Gaba_2 [CS20230722_SUPT_0410] | — | 483 | ⚪ UNCERTAIN | BST-located Tac2+ Gaba supertype | Eliminated (Tac2 supertype, not Crh) |
+| 1499 BST Tac2 Gaba_2 [CS20230722_CLUS_1499] | 0410 BST Tac2 Gaba_2 | 62 | ⚪ UNCERTAIN | child of SUPT_0410 | Eliminated (Tac2 lineage) |
+| 1475 MPO-ADP Lhx8 Gaba_4 [CS20230722_CLUS_1475] | 0405 MPO-ADP Lhx8 Gaba_4 | 100 | ⚪ UNCERTAIN | BST+MPO/Hypothalamus distribution | Eliminated (MPO-ADP lineage) |
+| 1476 MPO-ADP Lhx8 Gaba_4 [CS20230722_CLUS_1476] | 0405 MPO-ADP Lhx8 Gaba_4 | 67 | ⚪ UNCERTAIN | BST+MPO/Hypothalamus distribution | Eliminated (MPO-ADP lineage) |
+| 0343 MEA-BST Sox6 Gaba_7 [CS20230722_SUPT_0343] | — | 2071 | ⚪ UNCERTAIN | MEA-BST Sox6 lineage; Calb1=7.28, pct 0.894 | Eliminated (Calb1 high, MEA-dominant) |
+| 0379 CEA-AAA-BST Six3 Sp9 Gaba_7 [CS20230722_SUPT_0379] | — | 195 | ⚪ UNCERTAIN | CEA-AAA-BST Six3/Sp9 lineage | Eliminated (CEA/AAA-dominant, not Crh) |
+| 0383 ACB-BST-FS D1 Gaba_3 [CS20230722_SUPT_0383] | — | 722 | ⚪ UNCERTAIN | ACB-BST D1 medium spiny lineage | Eliminated (striatal D1, wrong subclass) |
 
-The single shared disqualifying signal is **Calb1 DISCORDANT** at supertype
-level (precomputed mean = 5.57 despite Calb1 being a NEGATIVE marker for the
-classical type).
-
-**Disqualifying evidence:**
-
-- **Calb1 = 5.57 at supertype level (DISCORDANT, primary driver of UNCERTAIN
-  confidence).** Calb1 is explicitly absent in dlBNST CRF neurons but shows
-  substantial supertype-level expression. SUPT_0393 likely aggregates both
-  Calb1− CRF neurons and Calb1+ BNST neurons. *(strong counter-evidence in a
-  marker sense — the negative-marker discordance disqualifies the supertype
-  as a whole; a child cluster with low Calb1 and high Crh would be a more
-  specific mapping candidate and may support upgrade to LOW or MODERATE.)*
-- **Sub-nucleus identity unresolvable (MERFISH_REGISTRATION_UNCERTAINTY
-  caveat).** The classical type is defined at sub-nucleus resolution (dlBNST,
-  ovBNST, alBNST). WMBv1 MERFISH annotation uses the parent BNST term
-  [MBA:351] without sub-nucleus assignment. This caveat applies to any BST
-  candidate, not only SUPT_0393.
-
-**Otherwise-supportive properties (PARTIAL atlas-metadata evidence, all
-overruled by the Calb1 discordance):**
-
-- Crh = 7.96 (DEFINING_SCOPED, CONSISTENT) — SUPT_0393 is the only rank-1
-  candidate with BST location, Crh marker, and GABAergic NT.
-- Location = BNST [MBA:351] n = 140 (CONSISTENT).
-- NT = GABAergic, Gad2 DEFINING (CONSISTENT).
-
-A Calb1-low child cluster of SUPT_0393 may rescue this candidate.
+</details>
 
 ---
 
@@ -210,17 +134,49 @@ A Calb1-low child cluster of SUPT_0393 may rescue this candidate.
 <details>
 <summary>Data sources, analyses, and reproducibility receipts</summary>
 
-**Classical type definition.** See classical type table in Introduction; defining_basis on the classical node and per-property literature support are listed there. The KB-side definition lives at the source graph file linked in the reproducibility footer.
+**Classical type definition.** The classical type is a CLASSICAL_NEUROCHEMICAL definition: BNST CRF (Crh+) neurons concentrated in the dorsolateral, oval, and anterolateral subdivisions of the BNST (MBA:351) [1][2], with Calb1 as a diagnostic negative marker (distinguishing them from the Calb1+ principal nucleus of the BNST) and type II electrophysiology in dlBNST slices [2]. Female-biased dimorphism (larger and more numerous CRF neurons in alBNST/ovBNST of females) defines the sexually dimorphic phenotype [1]. CL mapping is BROAD to corticotropin-releasing neuron [CL:4072021], pending a BNST-specific child term.
 
-**Atlas mapping query.** Candidate atlas clusters were retrieved from CCN20230722 at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias). Full scoring rules: `workflows/map-cell-type.md`.
+**Atlas mapping query.** Candidate atlas clusters were retrieved from the WMBv1 taxonomy (CS20230722) at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias when applicable). Full scoring rules: `workflows/map-cell-type.md`.
 
-**Property alignment.** Each defining property was compared to the corresponding atlas-side value via the `property_comparisons` schema; alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
+**Property alignment.** Each defining property of the classical type was compared to the corresponding atlas-side value via the `property_comparisons` schema, with alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
 
-**Bulk transcriptomic correlation.** Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq BNST female-receptive vs VMH female-receptive. SUPT_0358 child clusters at top of δ ranking. Run record: [`kb/correlation_runs/20260428_knoedler_esr1_wmbv1/manifest.yaml`](../../kb/correlation_runs/20260428_knoedler_esr1_wmbv1/manifest.yaml). Script: [`correlate.py`](https://github.com/Cellular-Semantics/evidencell/blob/4e67d6b/kb/correlation_runs/20260428_knoedler_esr1_wmbv1/correlate.py)
+**Bulk transcriptomic correlation.**
 
-**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote.
+| Field | Value |
+|---|---|
+| Source publication | Knoedler et al. 2022 · [3] |
+| GEO accession | GSE183092 |
+| Technique | TRAP-seq |
+| n pools | 12 (4 data files) |
+| Atlas | CCN20230722 (SHA-256: b21ca985) |
+| Statistic | spearman_rho (δ across paired pools) |
+| Parameters | pseudobulk_transform=log1p(sum/n_cells); pool_transform=log1p(replicate_mean(DESeq2_normalised_counts)); gene_id_space=ensembl_mouse_via_symbol_lookup; gene intersection across 4 regions ∩ atlas col names; n_replicates_per_pool=3 |
+| Script | `correlate.py` (commit 4e67d6b) |
+| Code version | 4e67d6b |
+| Caveats | Cross-sex within-region δ contrasts (Male vs FR or Male vs FNR) are artefactual: across all three regions tested (POA, VMH, BNST) the top hits are hindbrain Calcb cholinergic motor neurons — a global male-vs-female expression bias that swamps region-specific signals. METHODOLOGICAL RULE: paired-bulk δ requires the two pools to differ in cell population (region/marker/state) holding sex constant. TRAP-seq vs scRNA pseudobulk: polysome-bound mRNA shifts absolute ρ lower than for FACS-bulk inputs (Stephens-style), but Spearman rank-based statistics handle the magnitude offset. |
 
-*Generated by evidencell `0c97cfa` from [`kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`](../../kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+**Atlas data sources.** WMBv1 / CS20230722 — pseudobulk source `conf/mapmycells/CCN20230722/precomputed_stats.h5` (SHA-256: `b21ca985652fb25f9608f99005139a40757133a76fbe845ae5b175c5c26a447b`).
+
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote. Specific mapping limitations and caveats are documented per-candidate in the Discussion section.
+
+*Generated by evidencell `25c2b32` at 2026-06-08T18:14:08+00:00 from [kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml](kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+
+**Evidence base table.**
+
+| Edge ID | Evidence types | Supports | Source |
+|---|---|---|---|
+| edge_bnst_crf_neuron_to_cs20230722_supt_0393 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_bnst_crf_neuron_to_CS20230722_SUPT_0393 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_bnst_crf_neuron_to_CS20230722_CLUS_1409 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_bnst_crf_neuron_to_CS20230722_CLUS_1410 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_bnst_crf_neuron_to_cs20230722_supt_0358 | BULK_CORRELATION | PARTIAL | [3] |
+| edge_bnst_crf_neuron_to_CS20230722_SUPT_0410 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_bnst_crf_neuron_to_CS20230722_CLUS_1499 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_bnst_crf_neuron_to_CS20230722_CLUS_1475 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_bnst_crf_neuron_to_CS20230722_CLUS_1476 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_bnst_crf_neuron_to_CS20230722_SUPT_0343 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_bnst_crf_neuron_to_CS20230722_SUPT_0379 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_bnst_crf_neuron_to_CS20230722_SUPT_0383 | ATLAS_METADATA | PARTIAL | atlas-internal |
 
 </details>
 
@@ -228,85 +184,25 @@ A Calb1-low child cluster of SUPT_0393 may rescue this candidate.
 
 ## Discussion
 
-**Primary mapping:** → 0358 MEA-BST Lhx6 Nfib Gaba_2 [CS20230722_SUPT_0358] at LOW confidence. Key support: BULK_CORRELATION (Knoedler 2022 [3]) — Esr1+ proxy for the CRF+ subpopulation. Key caveats: Knoedler is Esr1-only; co-localisation with Crh requires direct evidence. Alternative existing edge to SUPT_0393 at UNCERTAIN..
+**Primary mapping:** BNST (anterolateral) corticotropin-releasing factor (CRF) neuron → 0393 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_SUPT_0393] at MODERATE confidence, with 1409 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_CLUS_1409] as the best-child within that supertype (also MODERATE). Key support: BST-localised Crh-labelled GABAergic supertype with proximity region_fraction_100um=0.846, and CLUS_1409 showing the lowest Calb1 (3.57, cohort pct 0.517) among the supertype's surfaced children. Key caveats: MARKER_NOT_SPECIFIC (Calb1 discordance at supertype level) and MERFISH_REGISTRATION_UNCERTAINTY (parent BNST term, no sub-nucleus resolution).
 
-No Cell Ontology term currently assigned for this classical type.
+The Cell Ontology has no specific term for this population; corticotropin-releasing neuron [[CL:4072021](https://www.ebi.ac.uk/ols4/ontologies/cl/classes?obo_id=CL:4072021)] is the closest ancestor. CL:4072021 covers all CRH-secreting neurons across brain regions (PVN, hippocampus, BNST, etc.). BNST CRF neurons do secrete CRH, making this a valid BROAD match. A BNST-specific child term does not yet exist — the female-biased dlBNST CRF population is a candidate for CL contribution.
+
+A parallel pooled-bulk transcriptomic signal from Knoedler 2022 Esr1+ TRAP-seq nominates 0358 MEA-BST Lhx6 Nfib Gaba_2 [CS20230722_SUPT_0358] as a co-primary candidate at LOW confidence, but the underlying pulldown sorted on Esr1+, not Crh+, and the supertype contains both female-biased and extreme-male-biased child clusters (CLUS_1293 MFR=99). SUPT_0358 most likely captures a partially overlapping Esr1+ BST sexually dimorphic population rather than the Crh+ population per se — resolution turns on whether Esr1+ and Crh+ cells co-localise within this supertype.
 
 ### Proposed experiments and follow-ups
 
-### 1. ISH or MERFISH co-staining for Crh, Esr1, Calb1 in BST
-
-**What:** Triple-stain ISH or MERFISH of BST in male and female mice for Crh,
-Esr1, and Calb1 to define the cluster boundary between SUPT_0358 (Esr1+) and
-SUPT_0393 (Crh+ with Calb1+ admixture) and to identify the Crh+ Calb1−
-anterolateral BST subset.
-
-**Target:** Quantify Crh+/Esr1+ overlap fraction in BST; identify a Crh+
-Calb1− Esr1+ female-biased subset.
-
-**Expected output:** `MarkerAnalysisEvidence` on both edges.
-
-**Resolves:** Open questions 1 and 2 (which supertype is the better mapping
-target).
-
-### 2. Annotation transfer of BNST scRNA-seq with Crh+ subset annotations
-
-**What:** MapMyCells annotation transfer of published BNST scRNA-seq with Crh+
-subset annotations against WMBv1 at cluster resolution.
-
-**Target:** F1 split between SUPT_0358 and SUPT_0393 — diagnostic for which
-supertype carries the Crh+ female-biased dimorphic population.
-
-**Expected output:** `AnnotationTransferEvidence` on both edges. Atlas: WMBv1.
-Tool: MapMyCells. Output format: per-cluster F1 matrix, fed back as
-`AnnotationTransferEvidence` YAML.
-
-**Resolves:** Open questions 1 and 2; addresses the Crh NOT_ASSESSED gap on
-SUPT_0358.
-
-### 3. Child-cluster precomputed expression query for SUPT_0393 and SUPT_0358
-
-**What:** Query precomputed Calb1 and Crh expression across child clusters of
-SUPT_0393 to identify any Calb1-low, Crh-high cluster as a more specific
-mapping candidate. Apply the same query to SUPT_0358 child clusters
-(CLUS_1290, CLUS_1291, CLUS_1293, CLUS_1295) for direct Crh assessment.
-
-**Target:** Identify a Crh-high, Calb1-low child cluster (in either supertype)
-that could be promoted to a primary cluster-level mapping.
-
-**Expected output:** Per-child-cluster Crh and Calb1 means recorded on the
-edges; potentially a new cluster-level `MappingEdge` if a clean child cluster
-is identified.
-
-**Resolves:** SUPT_0393 Calb1 DISCORDANT rescue path; SUPT_0358 Crh
-NOT_ASSESSED gap; refinement of female-biased vs male-biased child-cluster
-heterogeneity within SUPT_0358.
-
----
+- **What:** Direct Crh expression measurement at cluster level within SUPT_0393 and SUPT_0358 (e.g. ISH or MERFISH co-staining for Crh, Esr1, Calb1 in BST). **Target:** Confirm that CLUS_1409 (and ideally a Calb1-low subset) carries detectable Crh expression above background, and quantify Crh+/Esr1+ overlap within SUPT_0358 vs SUPT_0393. **Expected output:** Property-comparison evidence with direct Crh quantification at cluster level (replacing the current "no atlas expression data" NOT_ASSESSED). **Resolves:** primary edges (SUPT_0393, CLUS_1409) Calb1 discordance reading; LOW-confidence SUPT_0358 vs SUPT_0393 ambiguity.
+- **What:** Cluster annotation transfer from a published BNST transcriptomic dataset with Crh+ subset annotations to WMBv1. **Target:** F1 ≥ 0.50 at supertype level localising the dlBNST CRF subset. **Expected output:** AnnotationTransferEvidence on bnst_crf_neuron candidate edges. **Resolves:** discriminates whether the Crh+ subset within BST GABAergic populations lands cleanly on SUPT_0393 (the Crh-named supertype) or splits between SUPT_0393 and SUPT_0358.
+- **What:** Sex-stratified analysis of CLUS_1409 (and sibling CLUS_1410) and of all SUPT_0358 child clusters. **Target:** Test for female-bias signature matching the classical type's known dimorphism. **Expected output:** Sex-ratio metric (MFR equivalent) per cluster. **Resolves:** open question 2 below.
+- **What:** Curator review of the legacy SUPT_0358 edge for stale-edge cleanup (cf. Cellular-Semantics/evidencell#111). **Target:** Confirm or remove the legacy lowercase edge that carries Knoedler evidence but fell out of the current Stage A top-50 at rank 1.
 
 ### Open questions
 
-1. What fraction of SUPT_0358 cells co-express Esr1 and Crh? ISH or scRNA-seq
-   for Crh+/Esr1+ overlap in BST would resolve this. *(Appears on the SUPT_0358
-   edge.)*
-2. Is SUPT_0393 (high Crh, Calb1-confounded) or SUPT_0358 (Esr1+ proxy,
-   Crh-unverified) the better mapping for the sexually dimorphic anterolateral
-   BST CRF+ population — or do they capture distinct subsets? *(Appears on the
-   SUPT_0358 edge as the AMBIGUOUS_MAPPING caveat.)*
-3. Do individual clusters under SUPT_0393 segregate into Calb1-high and
-   Calb1-low populations? A Calb1-low, Crh-high child cluster would support
-   confidence upgrade. *(Appears on the SUPT_0393 edge.)*
-4. Does SUPT_0393 show a female-biased sex ratio consistent with
-   bnst_crf_neuron? *(Appears on the SUPT_0393 edge.)*
-
----
-
-### Evidence base
-
-| Edge ID | Evidence type | Supports |
-|---|---|---|
-| edge_bnst_crf_neuron_to_cs20230722_supt_0358 | BULK_CORRELATION ([3] Knoedler 2022) | PARTIAL — best_child_cluster=CLUS_1295 (rank 4, δ=0.0161); 4 SUPT_0358 child clusters in top 10 of BNST-FR vs VMH-FR; Esr1+ proxy, Crh unverified |
-| edge_bnst_crf_neuron_to_cs20230722_supt_0393 | ATLAS_METADATA | PARTIAL — Crh=7.96 (DEFINING_SCOPED), BST [MBA:351] n=140, Gad2 DEFINING; Calb1=5.57 DISCORDANT vs negative-marker requirement |
+1. Do individual clusters under SUPT_0393 (particularly CLUS_1409) segregate into Calb1-high and Calb1-low subpopulations consistent with the classical Calb1-negative dlBNST CRF type?
+2. Does SUPT_0393 (or specifically CLUS_1409) show the female-biased sex ratio consistent with bnst_crf_neuron, and what fraction of CLUS_1290/CLUS_1295 (SUPT_0358) cells co-express Crh+ with Esr1+?
+3. Is SUPT_0393 (high Crh-labelled atlas annotation) or SUPT_0358 (Esr1+ proxy with female-receptive BST signal) the better mapping for the sexually dimorphic anterolateral BST CRF+ population — or do they capture distinct, partially overlapping populations?
+4. Resolution of the WMBv1 MERFISH registration to BNST sub-nuclei (ovBNST, alBNST, dlBNST) would allow direct testing of the sub-nucleus identity claimed for the classical type; currently atlas cells are placed only at the parent BNST term (MBA:351).
 
 ---
 
@@ -314,6 +210,307 @@ heterogeneity within SUPT_0358.
 
 | # | Citation | PMID | Used for |
 |---|---|---|---|
-| [1] | Frontiers in Neural Circuits 2025 | [DOI:10.3389/fncir.2025.1593443](https://doi.org/10.3389/fncir.2025.1593443) | Soma location; CRF neuropeptide; female-biased dimorphism in anterolateral BNST |
-| [2] | Ide et al. 2013 | [PMID:23554470](https://pubmed.ncbi.nlm.nih.gov/23554470/) | Soma location (dlBNST); CRF neuropeptide; Type II ephys classification within dlBNST |
-| [3] | Knoedler et al. 2022 | [PMID:35143761](https://pubmed.ncbi.nlm.nih.gov/35143761/) | Knoedler 2022 Esr1+ TRAP-seq pooled BNST female-receptive vs VMH female-receptive — bulk-correlation BNST-specific signal identifying SUPT_0358 |
+| [1] | Kanaya et al. 2025. *Neonatal testosterone exposure alleviates female-specific severity of formalin-induced inflammatory pain in mice.* Front. Neural Circuits. [DOI:10.3389/fncir.2025.1593443](https://doi.org/10.3389/fncir.2025.1593443) | — | soma location, female-biased CRF neurons in alBNST |
+| [2] | Ide et al. 2013. *Opposing roles of CRF and NPY within the dorsolateral BNST in the negative affective component of pain in rats.* J. Neurosci. | [PMID:23554470](https://pubmed.ncbi.nlm.nih.gov/23554470) | dlBNST CRF action, type II electrophysiology |
+| [3] | Knoedler et al. 2022. *A functional cellular framework for sex and estrous cycle-dependent gene expression and behavior.* | [PMID:35143761](https://pubmed.ncbi.nlm.nih.gov/35143761) | Esr1+ TRAP-seq pooled BNST FR vs VMH FR (GSE183092) |
+
+---
+
+<!-- verdict-block-start: edge_bnst_crf_neuron_to_CS20230722_SUPT_0393 -->
+```yaml
+verdict:
+  confidence: MODERATE
+  confidence_score: 0.55
+  relationship: skos:broadMatch
+  mapping_cardinality: "1:n"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:STRONGEST] CS20230722_SUPT_0393 is the BST-localised Crh-labelled GABAergic
+    supertype (region_fraction_100um=0.846 onto MBA:351; Crh appears in the supertype
+    taxonomy label). Calb1 cohort percentile 0.737 at supertype level is DISCORDANT
+    with the classical Calb1-negative dlBNST CRF type; the best-child CS20230722_CLUS_1409
+    shows lower Calb1 (cohort percentile 0.517) and pairs with this edge as a
+    1:1 closeMatch at cluster level.
+  reconciliation_note: >
+    Paired with CS20230722_CLUS_1409 as the best-child within this supertype; both
+    surfaced as primary candidates. CS20230722_SUPT_0358 (Knoedler Esr1+ BST signal)
+    is a co-primary alternative at LOW confidence pending direct Crh measurement.
+  caveats:
+    - caveat_type: MARKER_NOT_SPECIFIC
+      description: >
+        CS20230722_SUPT_0393 shows Calb1 cohort percentile 0.737 despite bnst_crf_neuron
+        having Calb1 as a NEGATIVE marker. This supertype likely aggregates multiple BST
+        GABAergic subtypes; child cluster CS20230722_CLUS_1409 shows lower Calb1
+        (cohort percentile 0.517) and is the more specific mapping candidate.
+    - caveat_type: MERFISH_REGISTRATION_UNCERTAINTY
+      description: >
+        The classical type is defined at sub-nucleus resolution (dlBNST, ovBNST, alBNST).
+        WMBv1 transcriptomic annotation uses the parent BNST term (MBA:351) without
+        sub-nucleus assignment. Sub-nucleus identity of the matching cells cannot be
+        confirmed from atlas metadata.
+  proposed_experiments:
+    - >
+      Direct Crh expression measurement at cluster level within CS20230722_SUPT_0393
+      (CS20230722_CLUS_1409 and CS20230722_CLUS_1410); target detectable Crh above
+      background and a Calb1-low subset within CS20230722_CLUS_1409. Expected output:
+      property-comparison evidence with direct Crh quantification replacing current
+      NOT_ASSESSED.
+    - >
+      Cluster annotation transfer from a published BNST transcriptomic dataset with
+      Crh+ subset annotations to WMBv1; target F1 >= 0.50 at supertype level
+      localising the dlBNST CRF subset onto CS20230722_SUPT_0393.
+  unresolved_questions:
+    - Do individual clusters under CS20230722_SUPT_0393 segregate into Calb1-high and Calb1-low populations? A Calb1-low, Crh-high child cluster would support confidence upgrade.
+    - Does CS20230722_SUPT_0393 (or specifically CS20230722_CLUS_1409) show female-biased sex ratio consistent with bnst_crf_neuron?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_bnst_crf_neuron_to_cs20230722_supt_0393 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.25
+  rationale: >
+    [tier:CUT] Legacy/fresh-emit duplicate of CS20230722_SUPT_0393 (lowercase
+    edge id alongside fresh-emit uppercase edge); the fresh-emit edge
+    edge_bnst_crf_neuron_to_CS20230722_SUPT_0393 carries the canonical
+    structured evidence. Curator removal of this duplicate is the recommended
+    follow-up.
+  caveats:
+    - caveat_type: OTHER
+      description: >
+        Duplicate of the fresh-emit edge edge_bnst_crf_neuron_to_CS20230722_SUPT_0393
+        on the same taxonomy_type. Carried curator-authored caveats prior to the
+        2026-06-08 sweep; surfaced here as a stale-duplicate cleanup follow-up
+        rather than as an independent candidate.
+  unresolved_questions:
+    - Curator removal of duplicate edge edge_bnst_crf_neuron_to_cs20230722_supt_0393 — legacy/fresh-emit ID collision on taxonomy_type CS20230722_SUPT_0393.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_bnst_crf_neuron_to_CS20230722_CLUS_1409 -->
+```yaml
+verdict:
+  confidence: MODERATE
+  confidence_score: 0.55
+  relationship: skos:closeMatch
+  mapping_cardinality: "1:1"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:NEXT] CS20230722_CLUS_1409 (191 cells, region_fraction_100um=0.794 onto
+    MBA:351, GABA NT) is the best-child within CS20230722_SUPT_0393. Calb1 cohort
+    percentile 0.517 is below median (lower than sibling CS20230722_CLUS_1410 at
+    cohort percentile 0.855), making CS20230722_CLUS_1409 the more parsimonious
+    candidate for the classical Calb1-low Crh-high dlBNST CRF type. Direct Crh
+    expression at this cluster is NOT_ASSESSED in current facts.
+  reconciliation_note: >
+    Paired with CS20230722_SUPT_0393 (best-child within supertype). Supertype carries
+    1:n broadMatch; this cluster edge carries 1:1 closeMatch.
+  caveats:
+    - caveat_type: MARKER_NOT_SPECIFIC
+      description: >
+        Calb1 cohort percentile 0.517 at CS20230722_CLUS_1409 remains DISCORDANT with
+        the classical Calb1-absent expectation, though lower than at the parent
+        supertype. Direct Crh quantification is required to confirm CS20230722_CLUS_1409
+        as the Calb1-low, Crh-high subpopulation.
+    - caveat_type: MERFISH_REGISTRATION_UNCERTAINTY
+      description: >
+        Sub-nucleus identity (dlBNST, ovBNST, alBNST) of CS20230722_CLUS_1409 cells
+        cannot be confirmed from WMBv1 spatial registration, which uses the parent
+        BNST term (MBA:351).
+  proposed_experiments:
+    - >
+      Sex-stratified analysis of CS20230722_CLUS_1409 versus sibling CS20230722_CLUS_1410;
+      target detection of female-bias signature matching the classical type's dimorphism.
+    - >
+      Direct Crh measurement at CS20230722_CLUS_1409 (e.g. ISH or MERFISH co-staining
+      for Crh, Esr1, Calb1) to confirm cluster-level Crh expression and parsimoniously
+      identify the Calb1-low subset.
+  unresolved_questions:
+    - What fraction of CS20230722_CLUS_1409 cells co-express Crh+ and are Calb1-low? A subset analysis is needed to confirm parsimony with the classical type.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_bnst_crf_neuron_to_cs20230722_supt_0358 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.30
+  relationship: skos:closeMatch
+  mapping_cardinality: "1:1"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:WEAKEST] CS20230722_SUPT_0358 is the top BST-localised signal from Knoedler 2022
+    Esr1+ TRAP-seq BNST_FR vs VMH_FR (PMID:35143761); 4 of the top 10 clusters by
+    delta belong to CS20230722_SUPT_0358 (best child cluster rank 4 by Knoedler 2022
+    BST-FR vs VMH-FR bulk-correlation delta). CRITICAL:
+    Knoedler sorted on Esr1+, not Crh+; co-localisation of Esr1+ and Crh+ within this
+    supertype is not established by current evidence. Mixed-direction MFRs across child
+    clusters (one child cluster MFR=99, extreme male bias) are inconsistent with the
+    classical female-biased CRF population, suggesting the supertype captures a partially
+    overlapping Esr1+ BST sexually dimorphic population rather than the Crh+ population
+    per se.
+  reconciliation_note: >
+    Co-primary alternative to CS20230722_SUPT_0393 (the Crh-labelled supertype). Held at
+    LOW pending direct Crh measurement; would either upgrade to a parallel mapping or
+    be refuted. Stale-edge follow-up: this edge fell outside the current Stage A top-50
+    at rank 1 and its property_comparisons were not refreshed in the 2026-06-08 sweep
+    (cf. Cellular-Semantics/evidencell#111).
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Alternative or co-primary candidate to CS20230722_SUPT_0393. Both may capture
+        parts of the heterogeneous BNST dimorphic population; curator review needed to
+        decide whether CS20230722_SUPT_0358 is a parallel mapping or a separate Esr1+ type.
+    - caveat_type: NO_DISCRIMINATING_MARKER
+      description: >
+        CS20230722_SUPT_0358 has no DEFINING marker for Crh in atlas metadata. The mapping
+        rests on bulk-correlation co-localisation evidence (Esr1+ proxy) only. Direct
+        Crh expression measurement at cluster level is required for confidence upgrade.
+    - caveat_type: OTHER
+      description: >
+        Stale-edge follow-up — CS20230722_SUPT_0358 fell outside the current Stage A
+        top-50 at rank 1 and property_comparisons were not refreshed in the 2026-06-08
+        sweep; warrants curator review before being relied on
+        (cf. Cellular-Semantics/evidencell#111).
+  proposed_experiments:
+    - >
+      ISH or MERFISH co-staining for Crh, Esr1, Calb1 in BST to identify the cluster
+      boundary between CS20230722_SUPT_0358 (Esr1+) and CS20230722_SUPT_0393 (Crh+) and
+      quantify their overlap.
+    - >
+      Cluster annotation transfer of published BNST transcriptomic data with Crh+ subset
+      annotations to WMBv1; expect the Crh+ signal to split between CS20230722_SUPT_0358
+      and CS20230722_SUPT_0393 if both contain Crh+ subpopulations.
+  unresolved_questions:
+    - What fraction of CS20230722_SUPT_0358 cells co-express Esr1+ and Crh+? Direct co-staining in BST would resolve this.
+    - Is CS20230722_SUPT_0393 (Crh-labelled) or CS20230722_SUPT_0358 (Esr1+ proxy) the better mapping for the sexually dimorphic anterolateral BST CRF+ population?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_bnst_crf_neuron_to_CS20230722_CLUS_1410 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] Sibling of CS20230722_CLUS_1409 within CS20230722_SUPT_0393, but Calb1
+    cohort percentile 0.855 is well above the classical Calb1-absent expectation and
+    above sibling CS20230722_CLUS_1409 (cohort percentile 0.517). CS20230722_CLUS_1409
+    is the more parsimonious best-child; CS20230722_CLUS_1410 is eliminated on
+    cohort-relative Calb1 grounds.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        DISCORDANT negative_marker_Calb1 at cohort percentile 0.855; sibling
+        CS20230722_CLUS_1409 carries the candidate role at lower Calb1.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_bnst_crf_neuron_to_CS20230722_SUPT_0410 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0410 is the BST-located 0410 BST Tac2 Gaba_2 supertype,
+    not a Crh-labelled supertype. region_fraction_100um=0.569 onto MBA:351 is positive
+    but the supertype identity (Tac2+ Gaba) does not match the classical Crh+ defining
+    marker and Calb1 cohort percentile 0.492 is mid-range. Eliminated as a
+    wrong-supertype-lineage candidate.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: Tac2-defined supertype, not Crh-defined; eliminated on marker lineage.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_bnst_crf_neuron_to_CS20230722_CLUS_1499 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] Child of CS20230722_SUPT_0410 (BST Tac2 Gaba_2 lineage). Same wrong-lineage
+    elimination as the parent supertype; Calb1 cohort percentile 0.504 is mid-range.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: Tac2 lineage, not Crh lineage.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_bnst_crf_neuron_to_CS20230722_CLUS_1475 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1475 is a child of 0405 MPO-ADP Lhx8 Gaba_4. While
+    region_fraction_100um=0.864 onto MBA:351 is high, the supertype is an MPO-ADP
+    Lhx8 lineage spanning Hypothalamus and BST; the supertype identity does not match
+    the classical Crh+ defining marker.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: MPO-ADP Lhx8 lineage straddling Hypothalamus and BST; not Crh lineage.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_bnst_crf_neuron_to_CS20230722_CLUS_1476 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] Sibling of CS20230722_CLUS_1475 within 0405 MPO-ADP Lhx8 Gaba_4.
+    Same MPO-ADP Lhx8 lineage elimination.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: MPO-ADP Lhx8 lineage, not Crh lineage.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_bnst_crf_neuron_to_CS20230722_SUPT_0343 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.10
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0343 (0343 MEA-BST Sox6 Gaba_7) is an MEA-BST Sox6
+    lineage with Calb1 cohort percentile 0.894 — strongly DISCORDANT with the
+    classical Calb1-negative expectation. MEA-dominant distribution and the Sox6
+    lineage do not match Crh+ defining marker.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: Calb1 cohort percentile 0.894 is among the highest in the cohort; MEA-Sox6 lineage, not Crh lineage.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_bnst_crf_neuron_to_CS20230722_SUPT_0379 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.10
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0379 (0379 CEA-AAA-BST Six3 Sp9 Gaba_7) is a
+    CEA-AAA-BST Six3/Sp9 lineage; the supertype identity does not match Crh+ defining
+    marker and the soma distribution is CEA/AAA-dominant rather than BST-dominant
+    (region_fraction_100um=0.519).
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: CEA-AAA-BST Six3/Sp9 lineage, not Crh lineage.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_bnst_crf_neuron_to_CS20230722_SUPT_0383 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.10
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0383 (0383 ACB-BST-FS D1 Gaba_3) is an ACB-BST-FS D1
+    medium spiny lineage; the supertype identity (D1 Gaba) does not match Crh+
+    defining marker. Eliminated as wrong subclass (striatal D1 lineage).
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: Striatal D1 medium spiny lineage, not BNST CRF lineage.
+```
+<!-- verdict-block-end -->

--- a/reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
+++ b/reports/sexually_dimorphic/mpoa_esr1_neuron_summary.md
@@ -1,166 +1,164 @@
 # MPOA estrogen receptor 1 (Esr1) neuron — WMBv1 Mapping Report
-*draft · 2026-04-25 · Source: `/Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
-
-**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+*2026-04-25 · Source: `/Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
 
 ---
 
 ## Introduction
 
-### Classical type
+The medial preoptic area (MPOA) is a sexually dimorphic hypothalamic structure that houses molecularly heterogeneous neuronal populations, including a steroid-receptor-expressing class defined by Esr1 (estrogen receptor 1), Ar (androgen receptor), and Pgr (progesterone receptor) [1][2]. MPOA Esr1+ neurons are required, alongside galanin neurons, for pup-directed/parental behavior; Esr1 governs male-type mating behaviour while overlapping Nts+ neurons govern female socio-sexual behaviours [1]. Because the MPOA contains both GABAergic and glutamatergic Esr1+ subpopulations, the classical type as written here spans more than one transcriptomic supertype and may need to be split.
 
-**MPOA estrogen receptor 1 (Esr1) neuron** is defined by neurochemical criteria —
-Esr1, Ar, and Pgr expression — in the medial preoptic area (MPOA). The
-population is functionally heterogeneous: MPOA Esr1 neurons (alongside galanin
-neurons) are required for pup-directed/parental behavior, Esr1 governs male-type
-mating behavior, and an overlapping Nts (neurotensin)+ subtype governs female
-socio-sexual behaviors. The MPOA contains both GABAergic and glutamatergic
-neurons, and the Esr1+ population spans both NT subtypes — the classical node
-may be better represented as multiple cell-type terms. No CL term has been
-assigned and one is a candidate for new term(s).
+### Classical type table
 
 | Property | Value | References |
 |---|---|---|
-| Soma location | Medial preoptic nucleus [MBA:464] | [1] |
-| Defining markers | Esr1 (transcript), Ar (transcript), Pgr (transcript) | [1], [2] |
+| Soma location | Medial preoptic area [MBA:523] | [1] |
+| Defining markers | Esr1, Ar, Pgr | [1], [2] |
+| NT type | Mixed (GABAergic and glutamatergic both documented in MPOA) | [1] |
 
 <details>
 <summary>Details — source evidence for classical type properties</summary>
 
-- **Soma location (MPOA):** review · mouse · [1]
+- **Soma location:** classical review · mouse · [1]
   > A large hypothalamic structure, the MPOA sends projections to multiple downstream brain regions and is both larger and contains more neurons in males than in females [35]. Notably, the MPOA is home to various heterogeneous, molecularly defined, neuronal clusters, including many sexually dimorphic populations, such as androgen receptor (AR)-expressing population and estrogen receptor alpha (ESR1)expressing population [80]
   > — Zilkha et al. 2021, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 233446934_5d0fb07e -->
 
-- **Esr1 / parental behavior context:** review · mouse · [1]
+- **Esr1 marker (parental-behaviour subpopulation):**
   > At least two different subpopulations within the MPOA were shown to be required for the regulation of pupdirected behavior. The first is the ESR1 þ population, which is highly sexually dimorphic in its distribution and projection patterns [85]
   > — Zilkha et al. 2021, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 233446934_9f0f55ea -->
 
+- **Esr1 / Ar / Pgr co-expression in MPOA:**
+  > Since the MPOA is enriched in the expression of steroid hormone receptors genes (e.g., Esr1, androgen receptor (Ar), progesterone receptor (Pgr))
+  > — Hashikawa et al. 2021, Neuronal Markers and Molecular Characteristics · [2] <!-- quote_key: 237425192_b8087ed0 -->
+
+- **Functional partition (Esr1 vs Gal vs Nts subpopulations):**
+  > Molecularly defined subpopulations of neurons expressing a variety of neuropeptides and/or hormonal receptors in the MPOA are tightly associated with reproductive behaviors. MPOA neurons expressing Gal (galanin) or Esr1 (estrogen receptor 1) are essential for parental behaviors, while MPOA neurons expressing Esr1 or Nts (neurotensin) govern male-type mating behaviors and female socio-sexual behaviors, respectively
+  > — Hashikawa et al. 2021, Neuronal Markers and Molecular Characteristics · [2] <!-- quote_key: 237425192_c17e0213 -->
+
 </details>
+
+No Cell Ontology term currently covers this type — candidate for a new CL term.
 
 ---
 
 ## Results
 
-### Mapping candidates
-
-Two co-primary mapping edges are recorded for mpoa_esr1_neuron, reflecting that
-the classical population is heterogeneous in NT type. SUPT_0486 (GABAergic,
-PVpo-VMPO-MPN) captures the GABAergic Esr1+ fraction with direct atlas-marker
-support; SUPT_0521 (glutamatergic, AVPV-MEPO-SFO Tbr1 Glut_3) is independently
-identified as the dominant POA-Esr1+ supertype by Knoedler 2022 bulk
-correlation [3]. Both are CROSS_CUTTING relationships and the classical node
-likely requires a glut/GABA split.
-
-| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
-|---|---|---|---|---|---|---|
-| 1 | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] | (self) | 178 | 🟡 MODERATE | Esr1/Ar/Pgr CONSISTENT; NT APPROXIMATE (GABA only) | Best candidate (GABAergic fraction) |
-| 2 | 0521 AVPV-MEPO-SFO Tbr1 Glut_3 [CS20230722_SUPT_0521] | (self) | 391 | 🟡 MODERATE | Esr1 CONSISTENT; NT APPROXIMATE (Glut only); location APPROXIMATE | Best candidate (glutamatergic fraction) |
-2 edges total. Relationship type: CROSS_CUTTING (both edges).
-
-### Property alignment — primary candidate (SUPT_0486)
-
-**Table 1 — Property comparison.**
-
-| Property | Classical | Supertype | Best cluster | Alignment |
-|---|---|---|---|---|
-| Soma location | Medial preoptic nucleus [MBA:464] | MBA:515 (MPN) n=37; MBA:133 (PVpo) n=64; MBA:272 (AVPV) n=16 | not assessed | CONSISTENT |
-| NT type | mixed (GABAergic and glutamatergic, both documented in MPOA) | GABAergic (PVpo-VMPO-MPN Hmx2 Gaba subclass) | not assessed | APPROXIMATE |
-| Esr1 expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=7.72 (DEFINING atlas marker) | not assessed | CONSISTENT |
-| Ar expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=8.15 | not assessed | CONSISTENT |
-| Pgr expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=6.80 | not assessed | CONSISTENT |
-| Sex ratio | not documented on classical node | not available | not assessed | NOT_ASSESSED |
-
-**Table 2 — Evidence support.**
-
-| Evidence | Type | Supports | Headline | Source |
-|---|---|---|---|---|
-| SUPT_0486 atlas metadata (Esr1/Ar/Pgr, MPN n=37) | Atlas metadata | SUPPORT | Esr1=7.72 (DEFINING), Ar=8.15, Pgr=6.80; MBA:515 MPN n=37 | atlas-internal |
-
-*(Child-cluster breakdown not assessed — see proposed experiments.)*
-
-### Property alignment — co-primary candidate (SUPT_0521)
-
-**Table 1 — Property comparison.**
-
-| Property | Classical | Supertype | Best cluster | Alignment |
-|---|---|---|---|---|
-| Soma location | Medial preoptic nucleus [MBA:464] | Anteroventral periventricular nucleus, Median preoptic nucleus | CLUS_2085 primary soma in Anteroventral periventricular nucleus | APPROXIMATE |
-| NT type | mixed (GABAergic and glutamatergic, both documented in MPOA) | Glutamatergic (Tbr1 Glut_3 label) | not assessed | APPROXIMATE |
-| Esr1 expression | POSITIVE (transcript, primary defining marker) | Esr1+ by experimental design (TRAP-Cre line) | not assessed | CONSISTENT |
-| Sex ratio | not documented on classical node | not available | not assessed | NOT_ASSESSED |
-
-**Table 2 — Evidence support.**
-
-| Evidence | Type | Supports | Headline | Source |
-|---|---|---|---|---|
-| Knoedler 2022 TRAP-seq POA_FR vs VMH_FR | Bulk transcriptomic correlation | SUPPORT | best child CLUS_2085 (rank 1 of 5322, δ=0.0151); 4 SUPT_0521 children in top 10 | [3] |
-
-*(4 of SUPT_0521's child clusters — CLUS_2085, CLUS_2087, CLUS_2082, CLUS_2079 — appear in the top 10 atlas clusters by POA_FR vs VMH_FR Esr1+ TRAP differential; CLUS_2085 ranks first overall. Best match: CLUS_2085.)*
-
----
-
-
+The current evidence supports a **two-component mapping**: a GABAergic preoptic Esr1+ supertype, 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486], where atlas precomputed expression confirms all three defining steroid-receptor markers (Esr1 mean=7.72 defining, Ar=8.15, Pgr=6.80) and MPN-encoded anatomical labelling matches the classical soma location; and a glutamatergic preoptic Esr1+ supertype, 0521 AVPV-MEPO-SFO Tbr1 Glut_3 [CS20230722_SUPT_0521], identified by Knoedler 2022 TRAP-seq of Esr1+ POA female-receptive vs VMH female-receptive cells, whose top-ranked atlas cluster (CLUS_2085, δ=0.0151, rank 1 of 5,322) and three further top-10 hits are AVPV-MEPO-SFO Tbr1 Glut_3 child clusters [3] (see figure and property comparison tables). The remaining ten preoptic-region candidates from Stage A carry only anatomical location signal — no atlas-side expression for Esr1/Ar/Pgr — and do not differentiate.
 
 ### 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] · 🟡 MODERATE
 
-### Supporting evidence
+**Table 1 — Property comparison**
 
-- **All three classical defining markers reach CONSISTENT alignment at supertype level.** Precomputed mean expression Esr1 = 7.72 (DEFINING atlas marker), Ar = 8.15, and Pgr = 6.80 — directly matching the steroid hormone receptor profile that defines mpoa_esr1_neuron [1], [2].
-- **Direct anatomical anchor in MPN.** SUPT_0486 carries n = 37 cells in Medial preoptic nucleus [MBA:515], which is the same structure as the classical node's soma assignment Medial preoptic nucleus [MBA:464] *(note: MBA:515 and MBA:464 both label MPN — the location is concordant)*.
-- **GABAergic component matches.** The supertype label PVpo-VMPO-MPN Hmx2 Gaba_5 is concordant with the GABAergic fraction of the mixed-NT classical population.
-- **Adjacent preoptic territory captured.** Additional cells in Periventricular preoptic nucleus [MBA:133] (n=64) and Anteroventral periventricular nucleus [MBA:272] (n=16) are within the broader medial preoptic zone.
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Medial preoptic area [MBA:523] | MBA:515 (MPN) n=37; MBA:133 (PVpo) n=64; MBA:272 (AVPV) n=16 | not assessed | CONSISTENT |
+| NT type | Mixed (GABAergic + glutamatergic) | GABAergic (PVpo-VMPO-MPN Hmx2 Gaba subclass) | not assessed | APPROXIMATE |
+| Esr1 | Defining marker (POSITIVE, transcript) | precomputed mean_expression = 7.72 (DEFINING atlas marker) | not assessed | CONSISTENT |
+| Ar | Defining marker (POSITIVE, transcript) | precomputed mean_expression = 8.15 | not assessed | CONSISTENT |
+| Pgr | Defining marker (POSITIVE, transcript) | precomputed mean_expression = 6.80 | not assessed | CONSISTENT |
+| Sex ratio | Not documented at supertype level | not available | not assessed | NOT_ASSESSED |
 
-### Marker evidence provenance
+*(Child-cluster breakdown not assessed — see proposed experiments. Supertype-level Esr1/Ar/Pgr are concordant; whether all child clusters share this profile or whether a specific MPN-resident child dominates remains to be resolved.)*
 
-- **Esr1** — classical evidence is transcript-based (review citations) [1], [2]. Atlas precomputed Esr1 = 7.72 is transcript-based (10x Chromium) and Esr1 is a DEFINING atlas marker for SUPT_0486. Strong cross-platform agreement.
-- **Ar** — classical evidence is transcript-based [1], [2]. Atlas precomputed Ar = 8.15 (transcript). Highest of the three steroid receptors at supertype level. Consistent.
-- **Pgr** — classical evidence is from a single preprint citation [2]. Atlas precomputed Pgr = 6.80 (transcript). Supports the classical assertion; *(note: a single primary citation underlies the classical Pgr claim and a targeted cite-traverse for "MPOA progesterone receptor Esr1 co-expression" could strengthen this provenance)*.
+**Table 2 — Evidence support**
 
-### Concerns
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas precomputed expression (defining markers) | Atlas metadata | SUPPORT | Esr1=7.72 (DEFINING), Ar=8.15, Pgr=6.80; MPN n=37 | atlas-internal |
 
-- **NT-type alignment is APPROXIMATE — supertype captures only the GABAergic fraction.** SUPT_0486 is GABAergic; the classical mpoa_esr1_neuron population includes glutamatergic Esr1+ neurons that map elsewhere (specifically to SUPT_0521 — see co-primary candidate below). The supertype assignment alone does not represent the full classical population.
-- **Functional heterogeneity is unresolved.** The classical node spans multiple functional subtypes — parental (alongside galanin), male-type mating, and Nts+ female socio-sexual — that likely distribute across multiple clusters within SUPT_0486 *(distributed across clusters caveat from edge YAML)*.
-- **Child-cluster breakdown not assessed.** No specific child cluster of SUPT_0486 has been identified as carrying peak Esr1/Ar/Pgr or strongest MPN anatomical signal.
-- **Sex ratio not assessed.** Sex dimorphism is documented for MPOA generally [1] but is not in the classical node's properties or the supertype atlas metadata; child-cluster MFR data have not been collected for this edge.
+**Supporting evidence**
 
-### What would upgrade confidence
+- Atlas precomputed expression on SUPT_0486 confirms all three defining steroid-receptor markers at high mean expression; Esr1 carries the DEFINING atlas marker tag. The supertype's label directly encodes MPN, and 37 cells from MBA:515 (MPN, the same anatomical structure as the classical MBA:523 medial preoptic area) sit in this supertype, alongside PVpo and AVPV-resident cells.
 
-- **Child-cluster expression analysis** within SUPT_0486 to identify the cluster(s) with peak Esr1/Ar/Pgr and strongest MPN signal (resolves open question 1). Expected output: cluster-level edge with `ATLAS_METADATA` evidence and potential CONSISTENT location alignment at MPN.
-- **MapMyCells annotation transfer** of a published MPOA Esr1+ scRNA-seq dataset (e.g. Moffitt 2018) against WMBv1 at cluster resolution; F1 ≥ 0.50 at SUPT_0486 would support the supertype assignment, with the F1 split between SUPT_0486 and SUPT_0521 directly testing the NT heterogeneity. Expected output: `AnnotationTransferEvidence`.
-- **Targeted literature search** for the Nts+ MPOA Esr1+ subpopulation to determine whether it co-maps to SUPT_0486 (resolves open question 2).
+**Concerns**
 
----
+- AMBIGUOUS_MAPPING: SUPT_0486 captures only the GABAergic fraction of the classical Esr1+ MPOA population. The glutamatergic fraction has its own preoptic transcriptomic identity (see SUPT_0521 below), so this edge alone cannot represent the full classical type.
+- DISTRIBUTED_ACROSS_CLUSTERS: the functional partition of MPOA Esr1+ cells (parental, male mating, female socio-sexual via Nts+) likely distributes across multiple SUPT_0486 child clusters, none of which has been pinned down here.
+- *(note: this edge was not refreshed in the 2026-06-08 property_comparisons sweep — it currently sits outside the Stage A top-50 at rank 1 and warrants curator review before it is relied on; cf. Cellular-Semantics/evidencell#111.)*
+
+**What would upgrade confidence**
+
+- Cluster-level resolution within SUPT_0486 quantifying which child has the strongest joint Esr1/Ar/Pgr profile and the densest MPN soma assignment.
+- ISH/MERFISH co-staining of Esr1 with Slc32a1 (vGAT) and Slc17a6 (vGlut2) in MPOA to quantify the GABA vs Glut split of the classical population.
+- Annotation transfer of published MPOA Esr1+ transcriptomic data (e.g. Moffitt 2018) to SUPT_0486; F1 ≥ 0.5 at supertype level with a clear best-child would lift confidence.
 
 ### 0521 AVPV-MEPO-SFO Tbr1 Glut_3 [CS20230722_SUPT_0521] · 🟡 MODERATE
 
-### Supporting evidence
+**Table 1 — Property comparison**
 
-- **Independent quantitative bulk-correlation evidence ranks SUPT_0521 first across the atlas [3].**
-  > Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq pooled POA female-receptive vs VMH female-receptive. SUPT_0521 (AVPV-MEPO-SFO Tbr1 Glut_3, glutamatergic) child cluster CLUS_2085 ranks #1 of 5,322 atlas clusters by δ = ρ(POA_FR) − ρ(VMH_FR), with δ=0.0151 and primary soma in the Anteroventral periventricular nucleus. Three additional SUPT_0521 child clusters (2087, 2082, 2079) appear in the top 10. This is the dominant POA-Esr1+ supertype by bulk correlation — but is glutamatergic, not GABAergic like the existing SUPT_0486 mapping. Suggests the classical mpoa_esr1_neuron node may be heterogeneous and need a glut/GABA split, or that SUPT_0486 captures only a subset of the classical population.
-  > — Knoedler et al. 2022 · [3]
-- **Esr1 identity is CONSISTENT by experimental design.** SUPT_0521 cells were captured in a Esr1+ TRAP-Cre line — Esr1 expression is established by the input contrast itself, independent of atlas precomputed values [3].
-- **Glutamatergic NT identity is captured.** The Tbr1 Glut_3 label resolves the glutamatergic fraction of the classical mixed-NT MPOA Esr1+ population that SUPT_0486 (GABAergic) does not represent.
-- **Multiple SUPT_0521 child clusters cluster together at the top of the differential.** Four child clusters in the top 10 of 5,322 indicates the differential signal is supertype-coherent rather than driven by a single cluster.
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Medial preoptic area [MBA:523] | MBA:1097 Hypothalamus count_100um=311; MBA:129 third ventricle count_100um=254; MBA:452 Median preoptic nucleus count_100um=183 | CLUS_2085 top_anat = Anteroventral periventricular nucleus, n=29 | APPROXIMATE |
+| NT type | Mixed (GABAergic + glutamatergic) | Glutamatergic (Tbr1 Glut_3 subclass) | Glutamatergic | APPROXIMATE |
+| Esr1 | Defining marker (POSITIVE, transcript) | no atlas expression data | no atlas expression data | NOT_ASSESSED |
+| Ar | Defining marker (POSITIVE, transcript) | no atlas expression data | no atlas expression data | NOT_ASSESSED |
+| Pgr | Defining marker (POSITIVE, transcript) | no atlas expression data | no atlas expression data | NOT_ASSESSED |
+| Sex ratio | Not documented | not available | MFR=1.5 (CLUS_2085) | NOT_ASSESSED |
 
-### Marker evidence provenance
+*(Child-cluster breakdown: four of the top ten atlas clusters ranked by δ on the POA_FR vs VMH_FR contrast are SUPT_0521 children — CLUS_2085, 2087, 2086, plus rank-4/rank-10 children of the sister Glut_2 supertype SUPT_0520. The best child CLUS_2085 sits primarily in the Anteroventral periventricular nucleus, which is a known POA-Esr1+ female-biased subregion, while the classical node's soma annotation is the broader Medial preoptic area — `region_fraction_100um: 0.138` is in the boundary band, reflecting that Knoedler's POA dissection captures a broader preoptic zone than MPN proper.)*
 
-- **Esr1** — classical evidence is transcript-based (ISH and review citations) [1], [2]. SUPT_0521 Esr1 status is inferred from TRAP-Cre transgenic capture rather than from atlas precomputed expression alone — this is a stronger experimental confirmation of Esr1 expression than precomputed mean values *(note: precomputed Esr1 expression for SUPT_0521 is not surfaced in this facts file and would strengthen the cross-platform comparison)*.
-- **Ar / Pgr** — not assessed for SUPT_0521 in this edge. The classical node's defining marker set (Esr1, Ar, Pgr) is only partially evaluated against SUPT_0521; Ar and Pgr expression at this supertype/its child clusters has not yet been compared.
+**Table 2 — Evidence support**
 
-### Concerns
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Knoedler 2022 TRAP-seq | Bulk transcriptomic correlation | SUPPORT | best_child=CLUS_2085 (rank 1 of 5322, δ=0.0151) | [3] |
+| Stage A anatomical metadata | Atlas metadata | PARTIAL | region_fraction_100um=0.138 (boundary) | atlas-internal |
 
-- **Location is APPROXIMATE — SUPT_0521 spans AVPV/MePO, not MPN proper.** The classical mpoa_esr1_neuron is anchored at Medial preoptic nucleus [MBA:464]; SUPT_0521's primary somas are in Anteroventral periventricular nucleus and Median preoptic nucleus. AVPV/MePO is part of the broader medial preoptic area but is anatomically distinct from MPN proper *(adjacent region — could reflect the classical node's "MPOA" being broader than MPN, or could indicate the classical node should be narrowed to MPN-specific Esr1+ neurons; weak counter-evidence)*.
-- **Atlas dissection overlap caveat.** Knoedler's "POA" dissection captures a broader preoptic zone than MPN proper; AVPV and MePO Esr1+ neurons (anatomically anterior to MPN) are likely included in the bulk pool and contribute to the SUPT_0521 signal. The bulk-correlation evidence cannot distinguish MPN-Esr1+ from AVPV/MePO-Esr1+ contributions [3].
-- **NT-type alignment is APPROXIMATE — supertype captures only the glutamatergic fraction.** Mirror-image of the SUPT_0486 concern: SUPT_0521 represents the glutamatergic Esr1+ POA cells while SUPT_0486 represents the GABAergic fraction. Neither alone covers the full classical population.
-- **Co-primary mapping ambiguity.** This edge is co-primary alongside SUPT_0486; the two supertypes capture different NT-typed Esr1+ preoptic populations. The classical node likely needs to be split (mpoa_esr1_neuron_GABAergic vs mpoa_esr1_neuron_glutamatergic) or narrowed to MPN proper.
-- **Ar / Pgr not assessed at this supertype.** Two of the three classical defining markers have not been quantified for SUPT_0521.
+Knoedler 2022 [3] performed Esr1+ TRAP-seq on pooled POA female-receptive vs VMH female-receptive cells, and pseudobulk-correlation against WMBv1 cluster pseudobulks places SUPT_0521 (AVPV-MEPO-SFO Tbr1 Glut_3, glutamatergic) child cluster CLUS_2085 at rank #1 of 5,322 atlas clusters by δ = ρ(POA_FR) − ρ(VMH_FR), with δ=0.0151 and primary soma in the Anteroventral periventricular nucleus. Three additional SUPT_0521 child clusters (2087, 2082, 2079) appear in the top 10. This is the dominant POA-Esr1+ supertype by bulk correlation but is glutamatergic, not GABAergic like the existing SUPT_0486 mapping — suggesting that the classical mpoa_esr1_neuron node may be heterogeneous and need a glut/GABA split, or that SUPT_0486 captures only a subset of the classical population.
 
-### What would upgrade confidence
+![Top 10 clusters by δ for POA_FR_vs_VMH_FR (CS20230722_SUPT_0521)](figures/mpoa_esr1_neuron_POA_FR_vs_VMH_FR_838adb5f.png)
 
-- **ISH or MERFISH co-staining for Esr1, Slc17a6 (vGlut2), Slc32a1 (vGAT) in MPOA** to quantify the GABAergic vs glutamatergic fractions of Esr1+ cells (proposed experiment 1). Expected output: `MarkerAnalysisEvidence` documenting the empirical NT split.
-- **MapMyCells annotation transfer of published MPOA Esr1+ scRNA-seq data (e.g. Moffitt 2018) to SUPT_0521 vs SUPT_0486** (proposed experiment 2); expect F1 to split between the two supertypes, directly testing the glut/GABA hypothesis. Expected output: `AnnotationTransferEvidence` on both edges. Target: F1 ≥ 0.50 at supertype level for the matched NT fraction in each case.
-- **Quantification of Ar and Pgr precomputed expression for SUPT_0521 and its top-ranked child clusters** to complete the defining-marker comparison.
-- **Anatomical / functional literature search** to determine whether the AVPV/MePO Esr1+ population (SUPT_0521) is functionally distinct from MPN Esr1+ (SUPT_0486) in the parental/mating circuit literature (resolves open question 4).
+| Rank | Cluster | Supertype | δ | MFR | Top anatomy |
+|---:|---|---|---:|---:|---|
+| **1** | **CLUS_2085** | **SUPT_0521** | **0.0151** | **1.5** | **Anteroventral periventricular nucleus** |
+| 2 | CLUS_1528 | SUPT_0418 | 0.0149 | 1.04 | choroid plexus |
+| **3** | **CLUS_2087** | **SUPT_0521** | **0.0141** | **1.33** | **Anteroventral periventricular nucleus** |
+| 4 | CLUS_2082 | SUPT_0520 | 0.0140 | 1.86 | Median preoptic nucleus |
+| 5 | CLUS_1877 | SUPT_0482 | 0.0140 | 2.57 | optic chiasm |
+| 6 | CLUS_1507 | SUPT_0411 | 0.0137 | 1.04 | Anteroventral periventricular nucleus |
+| 7 | CLUS_1509 | SUPT_0412 | 0.0136 | 1.7 | Retrochiasmatic area |
+| 8 | CLUS_1527 | SUPT_0418 | 0.0132 | 1.56 | Median preoptic nucleus |
+| **9** | **CLUS_2086** | **SUPT_0521** | **0.0131** | **1.08** | Median preoptic nucleus |
+| 10 | CLUS_2079 | SUPT_0520 | 0.0131 | 0.96 | Anteroventral periventricular nucleus |
+
+(Bold rows are SUPT_0521 children.)
+
+**Supporting evidence**
+
+- Knoedler 2022 Esr1+ TRAP-seq on dissected POA tissue from female-receptive mice, pseudobulk-correlated against WMBv1 cluster-level pseudobulks under a paired δ contrast (POA_FR vs VMH_FR), ranks CLUS_2085 first of 5,322 atlas clusters and places four SUPT_0521 / sister-Glut supertype children in the top 10 [3]. This concentrates the bulk Esr1+ POA signal on a single glutamatergic preoptic supertype.
+- Anatomical scatter on SUPT_0521 is consistent with AVPV/MePO Esr1+ cells being captured by Knoedler's preoptic dissection rather than restricted to MPN proper — see boundary fraction noted below.
+
+**Concerns**
+
+- Atlas-side Esr1/Ar/Pgr expression are NOT_ASSESSED on this supertype (the genes are absent from the Stage A `expression_detail` and from the precomputed expression matrix queried), so direct confirmation that SUPT_0521 cells are themselves Esr1+ comes from Knoedler's TRAP-seq pulldown, not from the atlas-side. *(note: a targeted query of the atlas precomputed-stats HDF5 for Esr1/Ar/Pgr at SUPT_0521 and its child clusters would close this gap; see proposed experiments.)*
+- Location is APPROXIMATE: `region_fraction_100um: 0.138` (boundary scatter — could reflect that the classical node's MBA:523 soma label is narrower than Knoedler's preoptic dissection footprint; the atlas anatomical assignment for SUPT_0521 is dominated by Hypothalamus, third ventricle, and Median preoptic nucleus rather than MPOA strictly). The classical type as currently written may need to be either broadened to "preoptic Esr1+" or split between MPN-resident GABAergic and AVPV/MePO-resident glutamatergic subnodes.
+- AMBIGUOUS_MAPPING: co-primary alongside SUPT_0486. The two supertypes capture different NT-typed Esr1+ preoptic populations; the classical node may need to be split or narrowed.
+- ATLAS_DISSECTION_OVERLAP: Knoedler's "POA" dissection extends beyond MPN proper into AVPV and MePO; the SUPT_0521 signal partly reflects that capture.
+
+**What would upgrade confidence**
+
+- Targeted query of the WMBv1 precomputed expression HDF5 for Esr1, Ar, Pgr at SUPT_0521 and its top child clusters — direct atlas-side confirmation that these are Esr1+ glutamatergic cells.
+- ISH or MERFISH co-staining for Esr1, Slc17a6 (vGlut2), Slc32a1 (vGAT) in MPOA to quantify the GABAergic vs glutamatergic fractions of Esr1+ cells in MPN proper vs AVPV/MePO.
+- Cluster annotation transfer of published MPOA Esr1+ transcriptomic data (e.g. Moffitt 2018) split between SUPT_0521 and SUPT_0486; the predicted split would substantiate the GABA/Glut subdivision.
+
+<details>
+<summary>### Candidates audited (full top-K)</summary>
+
+| WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key evidence | Verdict |
+|---|---|---:|---|---|---|
+| 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] | — | 933 | 🟡 MODERATE | Atlas Esr1/Ar/Pgr all high; DEFINING atlas marker | Primary (GABAergic component) |
+| 0521 AVPV-MEPO-SFO Tbr1 Glut_3 [CS20230722_SUPT_0521] | — | 690 | 🟡 MODERATE | Knoedler δ rank 1 of 5322; 4/10 top hits SUPT_0521 children | Primary (glutamatergic component) |
+| 1466 MPO-ADP Lhx8 Gaba_3 [CS20230722_CLUS_1466] | 0404 MPO-ADP Lhx8 Gaba_3 | 157 | 🔴 LOW | region_fraction_100um=0.529; no atlas Esr1/Ar/Pgr | Eliminated (no marker evidence) |
+| 1536 PVR Six3 Sox3 Gaba_9 [CS20230722_CLUS_1536] | 0419 PVR Six3 Sox3 Gaba_9 | 145 | 🔴 LOW | region_fraction_100um=0.694; no atlas Esr1/Ar/Pgr | Eliminated (no marker evidence) |
+| 1885 PVpo-VMPO-MPN Hmx2 Gaba_1 [CS20230722_CLUS_1885] | 0482 PVpo-VMPO-MPN Hmx2 Gaba_1 | 36 | 🔴 LOW | region_fraction_100um=0.750; no atlas Esr1/Ar/Pgr | Eliminated (no marker evidence) |
+| 1887 PVpo-VMPO-MPN Hmx2 Gaba_1 [CS20230722_CLUS_1887] | 0482 PVpo-VMPO-MPN Hmx2 Gaba_1 | 140 | 🔴 LOW | region_fraction_100um=0.612; no atlas Esr1/Ar/Pgr | Eliminated (no marker evidence) |
+| 2118 ADP-MPO Trp73 Glut_1 [CS20230722_CLUS_2118] | 0527 ADP-MPO Trp73 Glut_1 | 81 | 🔴 LOW | region_fraction_100um=0.818; no atlas Esr1/Ar/Pgr | Eliminated (no marker evidence) |
+| 0419 PVR Six3 Sox3 Gaba_9 [CS20230722_SUPT_0419] | — | 620 | 🔴 LOW | region_fraction_100um=0.560; no atlas Esr1/Ar/Pgr | Eliminated (no marker evidence) |
+| 0403 MPO-ADP Lhx8 Gaba_2 [CS20230722_SUPT_0403] | — | 627 | 🔴 LOW | region_fraction_100um=0.641; no atlas Esr1/Ar/Pgr | Eliminated (no marker evidence) |
+| 0401 SI-MPO-LPO Lhx8 Gaba_6 [CS20230722_SUPT_0401] | — | 48 | 🔴 LOW | region_fraction_100um=0.812; no atlas Esr1/Ar/Pgr | Eliminated (no marker evidence) |
+| 0348 MEA-BST Lhx6 Sp9 Gaba_2 [CS20230722_SUPT_0348] | — | 675 | 🔴 LOW | region_fraction_100um=0.203; medial amygdala / BNST resident | Eliminated (off-target region) |
+| 0398 SI-MPO-LPO Lhx8 Gaba_3 [CS20230722_SUPT_0398] | — | 686 | 🔴 LOW | region_fraction_100um=0.568; no atlas Esr1/Ar/Pgr | Eliminated (no marker evidence) |
+
+</details>
 
 ---
 
@@ -169,17 +167,52 @@ likely requires a glut/GABA split.
 <details>
 <summary>Data sources, analyses, and reproducibility receipts</summary>
 
-**Classical type definition.** See classical type table in Introduction; defining_basis on the classical node and per-property literature support are listed there. The KB-side definition lives at the source graph file linked in the reproducibility footer.
+**Classical type definition.** The classical type `mpoa_esr1_neuron` is defined under `definition_basis: CLASSICAL_NEUROCHEMICAL` with defining markers Esr1, Ar, Pgr; soma in the Medial preoptic area [MBA:523]; NT type heterogeneous (GABAergic + glutamatergic both documented). Sources: Zilkha et al. 2021 [1] for soma location and Esr1+ MPOA dimorphism; Hashikawa et al. 2021 [2] for Esr1 / Ar / Pgr co-expression and the parental / mating / socio-sexual functional partition.
 
-**Atlas mapping query.** Candidate atlas clusters were retrieved from CCN20230722 at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias). Full scoring rules: `workflows/map-cell-type.md`.
+**Atlas mapping query.** Candidate atlas clusters were retrieved from the WMBv1 taxonomy (CCN20230722) at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias when applicable). Full scoring rules: `workflows/map-cell-type.md`.
 
-**Property alignment.** Each defining property was compared to the corresponding atlas-side value via the `property_comparisons` schema; alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
+**Property alignment.** Each defining property of the classical type was compared to the corresponding atlas-side value via the `property_comparisons` schema, with alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
 
-**Bulk transcriptomic correlation.** Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq pooled POA female-receptive vs VMH female-receptive. SUPT_0521 child cluster CLUS_2085 ranks #1 of 5,322 atlas clusters by δ. Run record: [`kb/correlation_runs/20260428_knoedler_esr1_wmbv1/manifest.yaml`](../../kb/correlation_runs/20260428_knoedler_esr1_wmbv1/manifest.yaml). Script: [`correlate.py`](https://github.com/Cellular-Semantics/evidencell/blob/4e67d6b/kb/correlation_runs/20260428_knoedler_esr1_wmbv1/correlate.py)
+**Bulk transcriptomic correlation.**
 
-**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote.
+| Field | Value |
+|---|---|
+| Source publication | Knoedler et al. 2022, *A functional cellular framework for sex and estrous cycle-dependent gene expression and behavior* · [3] |
+| GEO accession | GSE183092 |
+| Technique | TRAP-seq |
+| n pools | 12 |
+| Atlas | CCN20230722 (SHA-256: b21ca985) |
+| Statistic | spearman_rho |
+| Parameters | pseudobulk_transform=log1p(sum/n_cells); pool_transform=log1p(replicate_mean(DESeq2_normalised_counts)); gene_id_space=ensembl_mouse_via_symbol_lookup; gene_intersection=intersection_across_4_regions∩atlas_col_names; n_replicates_per_pool=3. |
+| Script | [correlate.py](https://github.com/Cellular-Semantics/evidencell/blob/4e67d6b/kb/correlation_runs/corr_run_20260428_knoedler_esr1_wmbv1/correlate.py) |
+| Code version | 4e67d6b |
+| Caveats | Cross-sex within-region δ contrasts (Male vs FR or Male vs FNR) are artefactual: top hits are hindbrain Calcb cholinergic motor neurons reflecting a global male-vs-female expression bias. METHODOLOGICAL RULE: paired-bulk δ requires the two pools to differ in cell population holding sex constant. TRAP-seq vs scRNA pseudobulk: polysome-bound mRNA shifts absolute ρ values lower, but Spearman rank-based δ rankings are comparable across run types. |
 
-*Generated by evidencell `0c97cfa` from [`kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`](../../kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+**Atlas data sources.** WMBv1 (CCN20230722) · `conf/mapmycells/CCN20230722/precomputed_stats.h5` · SHA-256 `b21ca985652fb25f9608f99005139a40757133a76fbe845ae5b175c5c26a447b`.
+
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote. Specific mapping limitations and caveats are documented per-candidate in the Discussion section.
+
+*Generated by evidencell `25c2b32` at 2026-06-08T18:14:05+00:00 from [kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml](kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+
+<details>
+<summary>Evidence base table</summary>
+
+| Edge ID | Evidence types | Supports | Source |
+|---|---|---|---|
+| edge_mpoa_esr1_neuron_to_cs20230722_supt_0486 | ATLAS_METADATA | SUPPORT | atlas-internal |
+| edge_mpoa_esr1_neuron_to_cs20230722_supt_0521 | BULK_CORRELATION | SUPPORT | [3] |
+| edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1466 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1536 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1885 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1887 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_mpoa_esr1_neuron_to_CS20230722_CLUS_2118 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0419 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0403 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0401 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0348 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0398 | ATLAS_METADATA | PARTIAL | atlas-internal |
+
+</details>
 
 </details>
 
@@ -187,66 +220,305 @@ likely requires a glut/GABA split.
 
 ## Discussion
 
-**Primary mapping:** → SUPT_0486 (GABAergic) and SUPT_0521 (glutamatergic) at MODERATE (co-primary) confidence. Key support: ATLAS_METADATA (Esr1=7.72 DEFINING at SUPT_0486) and BULK_CORRELATION (Knoedler 2022 [3]) for SUPT_0521. Key caveats: `AMBIGUOUS_MAPPING` (glut/GABA split — classical node may need to be split into GABAergic/glutamatergic subnodes).
+### Best candidate + caveats summary
 
-No Cell Ontology term currently assigned for this classical type.
+**Primary mapping:** MPOA estrogen receptor 1 (Esr1) neuron → two co-primary supertypes — 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] (GABAergic component) and 0521 AVPV-MEPO-SFO Tbr1 Glut_3 [CS20230722_SUPT_0521] (glutamatergic component), both at MODERATE confidence. Key support: atlas precomputed expression of Esr1/Ar/Pgr on SUPT_0486; Knoedler 2022 TRAP-seq δ rank-1 (CLUS_2085) plus 4-of-top-10 SUPT_0521 children on SUPT_0521. Key caveats: AMBIGUOUS_MAPPING (the classical type spans GABAergic and glutamatergic Esr1+ preoptic subpopulations); DISTRIBUTED_ACROSS_CLUSTERS (functional subpartitions — parental / male mating / female socio-sexual — likely distribute across child clusters within each supertype).
+
+No Cell Ontology term currently assigned. Candidate for new CL term(s); given the GABA/Glut split documented here, two CL contributions may be appropriate rather than one.
 
 ### Proposed experiments and follow-ups
 
-### 1. ISH / MERFISH co-staining for Esr1 with Slc17a6 (vGlut2) and Slc32a1 (vGAT) in MPOA
-
-**What:** Multiplexed in situ co-staining of Esr1 with Slc17a6 and Slc32a1 across MPOA subregions (MPN, PVpo, AVPV, MePO).
-
-**Target:** Quantitative GABAergic vs glutamatergic fractions of Esr1+ cells per subregion.
-
-**Expected output:** `MarkerAnalysisEvidence` documenting the empirical NT split, supporting the proposed glut/GABA decomposition of mpoa_esr1_neuron.
-
-**Resolves:** Open questions 3 and 4. Directly tests whether mpoa_esr1_neuron should be split into GABAergic and glutamatergic subnodes.
-
-### 2. MapMyCells annotation transfer of an MPOA Esr1+ scRNA-seq dataset against WMBv1
-
-**What:** Retrieve a published MPOA Esr1+ scRNA-seq dataset (e.g. Moffitt 2018) and run MapMyCells against WMBv1 at cluster resolution.
-
-**Target:** F1 ≥ 0.50 at supertype level on whichever NT fraction is matched (GABAergic cells → SUPT_0486; glutamatergic cells → SUPT_0521); F1 split between SUPT_0486 and SUPT_0521 expected.
-
-**Expected output:** `AnnotationTransferEvidence` entries on both edges (edge_mpoa_esr1_neuron_to_cs20230722_supt_0486 and edge_mpoa_esr1_neuron_to_cs20230722_supt_0521). Atlas: WMBv1. Tool: MapMyCells. Output: F1 matrix per cluster.
-
-**Resolves:** Open questions 1, 3, and 4. Confirms or refutes the co-primary glut/GABA mapping; identifies best child clusters within each supertype.
-
-### 3. Targeted child-cluster expression analysis within SUPT_0486 and SUPT_0521
-
-**What:** Inspect precomputed expression for Esr1, Ar, Pgr, Nts, and Gal across all child clusters of SUPT_0486 and SUPT_0521; identify clusters with peak co-expression and strongest MPN/AVPV anatomical signal.
-
-**Target:** Identification of best child cluster(s) for each supertype edge with quantitative thresholds (e.g. Esr1 mean ≥ 5.0 and MPN cell count ≥ 10).
-
-**Expected output:** Cluster-level mapping edges with `ATLAS_METADATA` evidence; potential resolution of the Nts+ female socio-sexual subpopulation.
-
-**Resolves:** Open questions 1 and 2.
-
----
+1. **Atlas-side marker confirmation on SUPT_0521.** Query the WMBv1 precomputed-stats HDF5 for Esr1, Ar, Pgr at SUPT_0521 and its top child clusters (CLUS_2085, 2087, 2086). Target: detect Esr1 ≥ MIN_DETECTABLE on at least one Tbr1 Glut_3 child cluster. Expected output: ATLAS_METADATA evidence items strengthening or refuting the SUPT_0521 mapping. Resolves: edge_mpoa_esr1_neuron_to_cs20230722_supt_0521 open marker NOT_ASSESSED rows.
+2. **ISH/MERFISH co-staining for Esr1 with Slc17a6 (vGlut2) and Slc32a1 (vGAT) in MPOA.** Target: quantify GABA vs Glut fractions of Esr1+ cells in MPN proper vs AVPV/MePO. Expected output: MarkerAnalysisEvidence + LiteratureEvidence supporting or refuting the GABA/Glut subdivision of the classical type. Resolves: AMBIGUOUS_MAPPING caveat on both primary edges; open question 1 (whether to split the classical node).
+3. **Cluster annotation transfer of published MPOA Esr1+ transcriptomic data (e.g. Moffitt 2018).** Target: F1 ≥ 0.5 at supertype level on each of SUPT_0486 and SUPT_0521, with a clear best child within each. Expected output: AnnotationTransferEvidence quantifying which classical Esr1+ functional subpopulations land on which transcriptomic supertype. Resolves: DISTRIBUTED_ACROSS_CLUSTERS caveat; open questions 2 and 4.
+4. **Curator review of edge_mpoa_esr1_neuron_to_cs20230722_supt_0486.** The edge property comparisons were not refreshed in the 2026-06-08 sweep; SUPT_0486 currently sits outside the Stage A top-50 at rank 1. Re-run Stage A and confirm or retire (cf. Cellular-Semantics/evidencell#111).
 
 ### Open questions
 
-1. Which clusters within SUPT_0486 [CS20230722_SUPT_0486] have highest Esr1/Ar/Pgr and strongest MPN anatomical signal? *(SUPT_0486 edge.)*
-2. Does the Nts+ female socio-sexual subpopulation map to SUPT_0486 or to a separate preoptic supertype? *(SUPT_0486 edge.)*
-3. Should mpoa_esr1_neuron be split into GABAergic (SUPT_0486) and glutamatergic (SUPT_0521) subnodes, or narrowed to MPN-proper Esr1+ neurons? *(SUPT_0521 edge; central organising question across both edges.)*
-4. Is the AVPV/MePO Esr1+ population (SUPT_0521) functionally distinct from MPN Esr1+ (SUPT_0486) in the parental/mating circuit literature? *(SUPT_0521 edge.)*
-
----
-
-### Evidence base
-
-| Edge ID | Evidence type | Supports |
-|---|---|---|
-| edge_mpoa_esr1_neuron_to_cs20230722_supt_0486 | ATLAS_METADATA | SUPPORT — Esr1=7.72 (DEFINING), Ar=8.15, Pgr=6.80; MBA:515 MPN n=37; GABAergic fraction |
-| edge_mpoa_esr1_neuron_to_cs20230722_supt_0521 | BULK_CORRELATION ([3] Knoedler 2022) | SUPPORT — POA_FR vs VMH_FR; CLUS_2085 rank 1/5322 (δ=0.0151); 4 child clusters in top 10; glutamatergic fraction |
+1. Should `mpoa_esr1_neuron` be split into GABAergic (SUPT_0486) and glutamatergic (SUPT_0521) subnodes, or narrowed to MPN-proper Esr1+ neurons?
+2. Which clusters within SUPT_0486 have the highest joint Esr1/Ar/Pgr expression and the strongest MPN anatomical signal?
+3. Does the Nts+ female socio-sexual subpopulation map to SUPT_0486 (GABAergic) or to a separate preoptic supertype?
+4. Is the AVPV/MePO Esr1+ population (SUPT_0521) functionally distinct from MPN-proper Esr1+ (SUPT_0486) in the parental / mating circuit literature?
+5. The legacy edge to SUPT_0486 fell outside the current Stage A top-50 and warrants curator review before being relied on (cf. Cellular-Semantics/evidencell#111).
 
 ---
 
 ## References
 
-| # | Citation | PMID | Used for |
+| # | Citation | Identifier | Used for |
 |---|---|---|---|
-| [1] | Zilkha et al. 2021 | [PMID:33910083](https://pubmed.ncbi.nlm.nih.gov/33910083/) | Soma location (MPOA); Esr1 / Ar marker context; sexually dimorphic MPOA |
-| [2] | bioRxiv 2021.09.02.458782 | — | Esr1, Ar, Pgr marker evidence (steroid hormone receptors in MPOA) |
-| [3] | Knoedler et al. 2022 | [PMID:35143761](https://pubmed.ncbi.nlm.nih.gov/35143761/) | Esr1+ TRAP-seq POA female-receptive vs VMH female-receptive bulk correlation against WMBv1 |
+| [1] | Zilkha et al. 2021 | [PubMed](https://pubmed.ncbi.nlm.nih.gov/33910083/) | Soma location; MPOA Esr1+ sexual dimorphism; Esr1+ parental subpopulation |
+| [2] | Hashikawa et al. 2021 (bioRxiv) | DOI:10.1101/2021.09.02.458782 | Esr1 / Ar / Pgr co-expression in MPOA; Esr1 / Gal / Nts functional partition |
+| [3] | Knoedler et al. 2022, *A functional cellular framework for sex and estrous cycle-dependent gene expression and behavior* | GSE183092 | Esr1+ TRAP-seq pooled POA female-receptive vs VMH female-receptive bulk correlation |
+
+---
+
+<!-- verdict-block-start: edge_mpoa_esr1_neuron_to_cs20230722_supt_0486 -->
+```yaml
+verdict:
+  confidence: MODERATE
+  confidence_score: 0.55
+  relationship: skos:broadMatch
+  mapping_cardinality: "1:n"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:STRONGEST] Atlas precomputed expression on CS20230722_SUPT_0486
+    confirms all three classical defining markers (Esr1=7.72 DEFINING,
+    Ar=8.15, Pgr=6.80) and the supertype carries MBA:515 (MPN) cells
+    concordant with the classical MBA:523 soma label; this captures the
+    GABAergic component of the Esr1+ MPOA population. Co-primary with
+    CS20230722_SUPT_0521 (glutamatergic component). Property comparisons
+    on this edge were not refreshed in the 2026-06-08 sweep; the edge
+    sits outside the current Stage A top-50 at rank 1 and warrants
+    curator review (cf. evidencell#111).
+  reconciliation_note: >
+    Paired with CS20230722_SUPT_0521 as co-primary: SUPT_0486 captures
+    the GABAergic fraction, SUPT_0521 the glutamatergic fraction of the
+    classical Esr1+ MPOA population. Together they argue for splitting
+    the classical node or narrowing it to MPN-proper.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        MPOA Esr1+ neurons are functionally heterogeneous (parental
+        behavior, male mating, female socio-sexual via Nts+). The
+        classical node spans multiple transcriptomic supertypes;
+        CS20230722_SUPT_0486 captures only the GABAergic fraction.
+    - caveat_type: DISTRIBUTED_ACROSS_CLUSTERS
+      description: >
+        Functional subpopulations (parental, mating, female
+        socio-sexual) likely distribute across multiple child clusters
+        within CS20230722_SUPT_0486.
+    - caveat_type: OTHER
+      description: >
+        Property comparisons on this edge were not refreshed in the
+        2026-06-08 Stage A sweep; the edge sits outside the current
+        top-50 at rank 1 and warrants curator review (cf. evidencell#111).
+  proposed_experiments:
+    - >
+      Cluster-level resolution within CS20230722_SUPT_0486 quantifying
+      which child cluster has the strongest joint Esr1/Ar/Pgr profile
+      and densest MPN anatomical signal. Expected output:
+      ATLAS_METADATA and MarkerAnalysisEvidence.
+    - >
+      ISH or MERFISH co-staining for Esr1, Slc32a1 (vGAT) and
+      Slc17a6 (vGlut2) in MPOA to quantify the GABA vs Glut split of
+      Esr1+ cells. Expected output: MarkerAnalysisEvidence.
+    - >
+      Cluster annotation transfer of published MPOA Esr1+
+      transcriptomic data (e.g. Moffitt 2018) onto
+      CS20230722_SUPT_0486 vs CS20230722_SUPT_0521; target F1 >= 0.5
+      at supertype level with a clear best-child.
+  unresolved_questions:
+    - >
+      Which clusters within CS20230722_SUPT_0486 have highest
+      Esr1/Ar/Pgr and strongest MPN anatomical signal?
+    - >
+      Does the Nts+ female socio-sexual subpopulation map to
+      CS20230722_SUPT_0486 or to a separate preoptic supertype?
+    - >
+      Curator review of edge_mpoa_esr1_neuron_to_cs20230722_supt_0486:
+      property_comparisons not refreshed in 2026-06-08 sweep; edge
+      outside current Stage A top-50 (cf. evidencell#111).
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_mpoa_esr1_neuron_to_cs20230722_supt_0521 -->
+```yaml
+verdict:
+  confidence: MODERATE
+  confidence_score: 0.55
+  relationship: skos:broadMatch
+  mapping_cardinality: "1:n"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:NEXT] Knoedler 2022 (GSE183092) Esr1+ TRAP-seq POA_FR vs
+    VMH_FR bulk-correlation ranks a CS20230722_SUPT_0521 child cluster
+    first of 5322 atlas clusters (delta=0.0151), with three further
+    CS20230722_SUPT_0521 child clusters in the top 10, concentrating
+    the bulk Esr1+ preoptic signal on a single glutamatergic
+    supertype. Co-primary with
+    CS20230722_SUPT_0486 (GABAergic component). Location is APPROXIMATE
+    (region_fraction_100um: 0.138) because Knoedler's POA dissection
+    captures a broader preoptic zone (AVPV/MePO) than MPN proper.
+    Atlas-side Esr1/Ar/Pgr expression is NOT_ASSESSED on this
+    supertype - direct atlas-side marker confirmation is the
+    next-step gap.
+  reconciliation_note: >
+    Paired with CS20230722_SUPT_0486 as co-primary: SUPT_0521 captures
+    the glutamatergic fraction, SUPT_0486 the GABAergic fraction of
+    the classical Esr1+ MPOA population.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Co-primary candidate alongside
+        edge_mpoa_esr1_neuron_to_cs20230722_supt_0486. The two
+        supertypes capture different NT-typed Esr1+ preoptic
+        populations; the classical node may need to be split
+        (mpoa_esr1_neuron_GABAergic vs mpoa_esr1_neuron_glutamatergic)
+        or narrowed to MPN proper.
+    - caveat_type: OTHER
+      description: >
+        ATLAS_DISSECTION_OVERLAP - Knoedler's "POA" dissection
+        captures a broader preoptic zone than MPN proper; AVPV and
+        MePO Esr1+ neurons (anatomically anterior to MPN) are likely
+        included in the bulk pool and contribute to the
+        CS20230722_SUPT_0521 signal. Reflected in
+        region_fraction_100um: 0.138 (boundary scatter).
+    - caveat_type: OTHER
+      description: >
+        Atlas-side Esr1, Ar, Pgr expression are NOT_ASSESSED at
+        CS20230722_SUPT_0521 (genes absent from Stage A
+        expression_detail and precomputed expression). Direct
+        atlas-side marker confirmation is the highest-priority
+        follow-up.
+  proposed_experiments:
+    - >
+      Targeted query of the WMBv1 precomputed-stats HDF5 for Esr1,
+      Ar, Pgr at CS20230722_SUPT_0521 and its top child clusters
+      (the Knoedler 2022 POA_FR vs VMH_FR bulk-correlation top
+      hits). Target detect Esr1 >= MIN_DETECTABLE on at least one
+      Tbr1 Glut_3 child cluster.
+    - >
+      ISH or MERFISH co-staining for Esr1, Slc17a6 (vGlut2),
+      Slc32a1 (vGAT) in MPOA to quantify the GABA vs Glut fractions
+      of Esr1+ cells in MPN proper vs AVPV/MePO.
+    - >
+      Cluster annotation transfer of published MPOA Esr1+
+      transcriptomic data (e.g. Moffitt 2018) onto
+      CS20230722_SUPT_0521 vs CS20230722_SUPT_0486; expected F1
+      split between the two supertypes.
+  unresolved_questions:
+    - >
+      Should mpoa_esr1_neuron be split into GABAergic
+      (CS20230722_SUPT_0486) and glutamatergic
+      (CS20230722_SUPT_0521) subnodes, or narrowed to MPN-proper
+      Esr1+ neurons?
+    - >
+      Is the AVPV/MePO Esr1+ population (CS20230722_SUPT_0521)
+      functionally distinct from MPN Esr1+ (CS20230722_SUPT_0486)
+      in the parental/mating circuit literature?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1466 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1466 sits in MPO-ADP with
+    region_fraction_100um=0.529 but carries no atlas-side
+    expression for Esr1, Ar, or Pgr; anatomical proximity alone is
+    insufficient to map a steroid-receptor-defined classical type.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1536 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1536 (PVR Six3 Sox3 Gaba_9) carries
+    only an anatomical proximity signal (region_fraction_100um=0.694)
+    with no atlas-side Esr1, Ar, or Pgr expression.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1885 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1885 (PVpo-VMPO-MPN Hmx2 Gaba_1) sits
+    in the preoptic region (region_fraction_100um=0.750) but lacks
+    atlas-side expression for the defining markers Esr1, Ar, Pgr.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1887 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1887 (PVpo-VMPO-MPN Hmx2 Gaba_1)
+    region_fraction_100um=0.612 but carries no atlas-side Esr1,
+    Ar, or Pgr expression.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_mpoa_esr1_neuron_to_CS20230722_CLUS_2118 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_2118 (ADP-MPO Trp73 Glut_1) sits
+    largely within MPO (region_fraction_100um=0.818) but lacks
+    atlas-side expression for the defining steroid-receptor
+    markers Esr1, Ar, Pgr.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0419 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0419 (PVR Six3 Sox3 Gaba_9) carries
+    anatomical proximity (region_fraction_100um=0.560) without
+    atlas-side Esr1, Ar, or Pgr expression.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0403 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0403 (MPO-ADP Lhx8 Gaba_2)
+    region_fraction_100um=0.641 with no atlas-side defining-marker
+    expression.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0401 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0401 (SI-MPO-LPO Lhx8 Gaba_6) sits
+    largely within preoptic zones (region_fraction_100um=0.812)
+    but carries no atlas-side Esr1, Ar, or Pgr expression.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0348 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0348 (MEA-BST Lhx6 Sp9 Gaba_2) is
+    a medial-amygdala / BNST resident supertype with
+    region_fraction_100um=0.203 (off-target); irrelevant to
+    classical MPOA Esr1+ neurons.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0398 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.2
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0398 (SI-MPO-LPO Lhx8 Gaba_3)
+    region_fraction_100um=0.568 with no atlas-side defining-marker
+    expression.
+```
+<!-- verdict-block-end -->

--- a/reports/sexually_dimorphic/pmv_otr_neuron_summary.md
+++ b/reports/sexually_dimorphic/pmv_otr_neuron_summary.md
@@ -1,148 +1,312 @@
 # Ventral premammillary nucleus (PMv) oxytocin receptor neuron — WMBv1 Mapping Report
-*draft · 2026-04-25 · Source: `kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
-
-**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+*2026-04-25 · Source: `kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
 
 ---
 
 ## Introduction
 
-### Classical type
+The ventral premammillary nucleus (PMv) is a well-established sexually
+dimorphic hypothalamic nucleus implicated in maternal aggression,
+reproductive control, male social behaviour, and intermale aggression,
+and is one of two hypothalamic regions identified by recent spatial
+transcriptomic mapping as exhibiting significant male/female cellular
+abundance differences [1]. Within the PMv, multiple molecularly defined
+neuronal populations have been described, including dopamine-transporter
+(Slc6a3) expressing neurons (PMv-DAT), PACAP (Adcyap1) expressing neurons
+(PMv-PACAP), and oxytocin receptor (Oxtr) expressing neurons, whose
+sexually dimorphic OTR expression was demonstrated by OTR-Venus reporter
+mice across postnatal development with significantly higher PMv OTR in
+males than in females from P14 to P56 [2]. The classical type addressed
+here aggregates these intersecting marker-defined PMv subpopulations
+under a single male-biased OTR+ entity; whether the OTR+, DAT+, and
+PACAP+ subsets fully overlap inside the PMv is an open biological
+question that bears directly on the resolution at which this type can
+be mapped onto the WMBv1 taxonomy.
 
-**Ventral premammillary nucleus (PMv) oxytocin receptor neuron** is a male-biased
-sexually dimorphic population in the ventral premammillary nucleus, defined by
-neurochemical criteria (Oxtr, Slc6a3, Adcyap1). The classical node aggregates
-three molecularly defined subpopulations of the PMv that may not fully overlap:
-PMv-OTR (Oxtr+), PMv-DAT (Slc6a3+, dopaminergic), and PMv-PACAP (Adcyap1+).
-No CL term currently maps this population — it is a candidate for new term creation.
+### Classical type table
 
 | Property | Value | References |
 |---|---|---|
 | Soma location | Ventral premammillary nucleus [MBA:1004] | [1], [2] |
-| Defining markers | Oxtr (transcript), Slc6a3, Adcyap1 | [1], [2] |
+| Defining markers | Oxtr [2]; Slc6a3 [1]; Adcyap1 | [1], [2] |
+| Sex bias | Male-biased (males > females) | [2] |
+| Definition basis | CLASSICAL_NEUROCHEMICAL | — |
+| Notes | Aggregates potentially distinct PMv-OTR, PMv-DAT, PMv-PACAP subpopulations; candidate for new CL term | — |
 
 <details>
-<summary>Literature support — expand for verbatim quotes</summary>
+<summary>Details — source evidence for classical type properties</summary>
 
-**[2] Newmaster et al. 2019 · PMID:32313029 — Neuronal Markers and Molecular Characteristics**
+- **Soma location (PMv) and sex-biased OTR expression:** OTR-Venus
+  reporter immunolabelling across postnatal development, N=5 male and
+  female brains per timepoint · [2]
+  > Sexual dimorphism of OTR expression. OTR is expressed in a sexually
+  > dimorphic manner as a part of neural circuit mechanism to generate
+  > behavioral differences in males and females. […] The ventral
+  > premammillary nucleus (PMv) showed significantly higher OTR
+  > expression in males compared to females between P14 and P56.
+  > — Newmaster et al. 2019, Neuronal Markers and Molecular
+  > Characteristics · [2] <!-- quote_key: 201207691_ff444c30 -->
 
-> Sexual dimorphism of OTR expression. OTR is expressed in a sexually dimorphic manner as a part of neural circuit mechanism to generate behavioral differences in males and females 34,35 . Therefore, we compared OTR-Venus expression in male and female mice (N = 5 in male and female brains at different ages) to determine if there were any regions showing strong sexual dimorphism. Across the entire brain region throughout the postnatal development, we found significant sexual dimorphism in two hypothalamic regions (Fig. 7). The ventral premammillary nucleus (PMv) showed significantly higher OTR expression in males compared to females between P14 and P56 (Fig. 7a-d). In contrast, the anteroventral periventricular nucleus (AVPV) near the medial preoptic area showed higher OTR expression in females than males at P56, but not before (Fig. 7e-h). A recent study identified abundant estrogen- dependent OTR-expressing cells in the AVPV, co-expressing estrogen receptor in female mice 36 . This result suggests a potential role of OTR in sexual behavior [36][37][38] .
-> — Newmaster et al. 2019, Neuronal Markers and Molecular Characteristics · [2] <!-- quote_key: 201207691_ff444c30 -->
+- **PMv sexual dimorphism and named subpopulations (PMv-DAT,
+  PMv-PACAP):** spatial single-cell mapping across genetic backgrounds,
+  prior PMv subpopulation literature · [1]
+  > Region 2, the PMv, is a well- established sexually dimorphic region,
+  > with roles in maternal aggression 38 , reproductive control 39 , male
+  > social behavior 40 , and intermale aggression 41 . Previous studies
+  > identified sexually dimorphic neuron populations within the PMv
+  > (e.g., PMv-DAT 42 , PMv- PACAP 43 ), complementing our systematic
+  > identification of subclass-level abundance changes.
+  > — Hemminger et al. 2024, Sexually Dimorphic Brain Regions and
+  > Structures · [1] <!-- quote_key: 273240437_af6642f9 -->
 
-**[1] Hemminger et al. 2024 · PMID:39416191 — Sexually Dimorphic Brain Regions and Structures**
-
-> We identified two adjacent regions within the hypothalamus that exhibited significant sexual dimorphism. Region 1 overlaps with the anterior hypothalamic nucleus (AHN), while Region 2 primarily overlaps with the ventral premammillary nucleus (PMv). Both regions are known to be sexually dimorphic (Vries et al., 2002) , though they have been studied to different extents
-> — Hemminger et al. 2024, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 273240437_ed3a4faa -->
-
-**[1] Hemminger et al. 2024 · PMID:39416191 — Sexually Dimorphic Brain Regions and Structures**
-
-> Our findings of specific neuronal subclass differences help further refine the molecular resolution of its dimorphic nature and providing a cellular basis for its role in sex-specific behaviors like aggression and parental care. Region 2, the PMv, is a well- established sexually dimorphic region, with roles in maternal aggression 38 , reproductive control 39 , male social behavior 40 , and intermale aggression 41 . Previous studies identified sexually dimorphic neuron populations within the PMv (e.g., PMv-DAT 42 , PMv- PACAP 43 ), complementing our systematic identification of subclass-level abundance changes.
-> — Hemminger et al. 2024, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 273240437_af6642f9 -->
+- **PMv as a sexually dimorphic region (corroborating):** spatial
+  registration to MBA · [1]
+  > Region 2 primarily overlaps with the ventral premammillary nucleus
+  > (PMv). Both regions are known to be sexually dimorphic (Vries et al.,
+  > 2002) , though they have been studied to different extents
+  > — Hemminger et al. 2024, Sexually Dimorphic Brain Regions and
+  > Structures · [1] <!-- quote_key: 273240437_ed3a4faa -->
 
 </details>
+
+### Cell Ontology mapping
+
+No Cell Ontology term currently covers this type — candidate for a new
+CL term. The classical definition spans multiple intersecting
+marker-defined PMv subpopulations (Oxtr+, Slc6a3+/DAT+, Adcyap1+/PACAP+)
+that do not yet have dedicated CL representatives.
 
 ---
 
 ## Results
 
-### Mapping candidates
+Soma-location concordance with the queried PMv (MBA:1004) and atlas-side
+co-expression of all three classical defining markers identify the PMv
+hypothalamic glutamatergic supertype 0607 PMv-TMv Pitx2 Glut_3
+[CS20230722_SUPT_0607] as the supertype-level match (see candidate
+audit table and property comparison tables below), with its child
+cluster 2470 PMv-TMv Pitx2 Glut_3 [CS20230722_CLUS_2470] as the
+cluster-level lead (the largest PMv-resident child of the supertype,
+concentrating Oxtr, Slc6a3, and Adcyap1 expression). The supertype
+co-expresses all three classical markers simultaneously, indicating
+that this WMBv1 type aggregates neurons the classical taxonomy treats
+as potentially distinct PMv-OTR / PMv-DAT / PMv-PACAP subpopulations;
+the supertype-level mapping is therefore committed as a broader,
+many-to-one relationship while the cluster-level call is held at low
+confidence pending male-bias and finer subpopulation confirmation.
 
-Two mapping edges are recorded for pmv_otr_neuron: a supertype-level edge to SUPT_0607
-(the highest-DB-scoring candidate at any rank, expressing all three classical defining
-markers) and a child-cluster edge to CLUS_2470 (the PMv-dominant child cluster with
-the highest expression of all three markers).
+### 0607 PMv-TMv Pitx2 Glut_3 [CS20230722_SUPT_0607] · 🟡 MODERATE
 
-| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
-|---|---|---|---|---|---|---|
-| 1 | 2470 PMv-TMv Pitx2 Glut_3 [CS20230722_CLUS_2470] | 0607 PMv-TMv Pitx2 Glut_3 | 284 | 🔴 LOW | Oxtr/Slc6a3/Adcyap1 CONSISTENT; sex ratio NOT_ASSESSED | Speculative |
-| 2 | 0607 PMv-TMv Pitx2 Glut_3 [CS20230722_SUPT_0607] | (self) | 547 | 🔴 LOW | Oxtr/Slc6a3/Adcyap1 CONSISTENT; nt_type APPROXIMATE | Speculative |
-2 edges total. Relationship type: PARTIAL_OVERLAP (CLUS_2470) and CROSS_CUTTING (SUPT_0607).
-
-### Property alignment — primary candidate (CLUS_2470)
-
-**Table 1 — Property comparison.**
+**Property comparison (supertype).**
 
 | Property | Classical | Supertype | Best cluster | Alignment |
 |---|---|---|---|---|
-| Soma location | MBA:1004 (Ventral premammillary nucleus) | MBA:1004 (PMv) n=347 (dominant location) | MBA:1004 (PMv) n=192 (primary soma — dominant location) | CONSISTENT |
-| Oxtr expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=2.0 (DEFINING_SCOPED atlas marker) | precomputed mean_expression=4.45 (vs supertype mean 2.0) | CONSISTENT |
-| Slc6a3 expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=3.07 (DEFINING atlas marker) | precomputed mean_expression=6.02 (vs supertype mean 3.07) | CONSISTENT |
-| Adcyap1 expression | POSITIVE (defining marker) | precomputed mean_expression=4.8 | precomputed mean_expression=8.13 (vs supertype mean 4.8) | CONSISTENT |
-| NT type | not specified; DAT+ subpopulation implies dopaminergic co-release | Glutamatergic (PMv-TMv Pitx2 Glut) | not assessed | SUPT: APPROXIMATE |
-| Sex ratio | male-biased (PMv OTR expression higher in males, P14–P56) | not available | NOT_ASSESSED — MFR absent from DB for CLUS_2470 | NOT_ASSESSED |
-| Annotation transfer F1 | not applicable | NOT_ASSESSED | NOT_ASSESSED | NOT_ASSESSED |
+| Soma location | Ventral premammillary nucleus [MBA:1004] | PMv 473/1165 cells at 100µm (region_fraction_100um=0.865; strict=0.634) | PMv 255/451 cells (region_fraction_100um=0.898; strict=0.676) at CLUS_2470 | CONSISTENT |
+| NT type | not asserted on classical | not asserted at supertype | Glut at CLUS_2470 | NOT_ASSESSED (classical side) |
+| Oxtr expression | Defining marker | mean=2.0 (DEFINING_SCOPED on atlas) | mean=4.45 at CLUS_2470 | CONSISTENT (both sides positive) |
+| Slc6a3 expression | Defining marker | mean=3.07 (DEFINING on atlas) | mean=6.02 at CLUS_2470 | CONSISTENT |
+| Adcyap1 expression | Defining marker | mean=4.8 | mean=8.13 at CLUS_2470 | CONSISTENT |
+| Sex ratio | Male-biased | not available at supertype | not available — MFR absent from DB for CLUS_2470 | NOT_ASSESSED |
 
-**Table 2 — Evidence support.**
+*(All five named PMv-resident child clusters of SUPT_0607 carry PMv as
+the dominant or co-dominant soma location; CLUS_2470 leads on every
+defining marker simultaneously. Within the supertype, the OTR / DAT /
+PACAP marker signatures co-occur rather than segregate across children,
+indicating supertype-level aggregation of the three classical
+subpopulations. Best child: CLUS_2470.)*
+
+**Evidence support.**
 
 | Evidence | Type | Supports | Headline | Source |
 |---|---|---|---|---|
-| Atlas precomputed expression (CLUS_2470 Oxtr/Slc6a3/Adcyap1) | Atlas metadata | SUPPORT | Oxtr=4.45, Slc6a3=6.02, Adcyap1=8.13; PMv n=192; MFR absent | atlas-internal |
-| SUPT_0607 atlas metadata (top DB score across all ranks) | Atlas metadata | SUPPORT | DB score=4 (top); Oxtr=2.0, Slc6a3=3.07, Adcyap1=4.8; Tac1=8.95; PMv n=347 | atlas-internal |
+| Atlas precomputed expression + region painting | Atlas metadata | SUPPORT | PMv region_fraction_100um=0.865; Oxtr=2.0, Slc6a3=3.07, Adcyap1=4.8 co-expressed | atlas-internal |
 
-*(1 of multiple SUPT_0607 child clusters — CLUS_2470 — concentrates the Oxtr/Slc6a3/Adcyap1 co-expression at PMv (n=192) with all three markers substantially above supertype means; sister supertype SUPT_0605 may capture an additional portion of the OTR+ population. MFR is absent at both supertype level and for CLUS_2470. Best match: CLUS_2470.)*
+**Supporting evidence.**
 
----
+- The PMv-TMv Pitx2 Glut_3 supertype is the highest-scoring candidate
+  at any rank for this classical type. Of its 1165 cells, 473 (proximity
+  count at 100µm) sit in PMv; the dominant atlas anatomical labels are
+  Hypothalamus (count=546), Ventral premammillary nucleus
+  [MBA:1004] (count=473), and Dorsomedial nucleus of the hypothalamus
+  [MBA:830] (count=206), giving region_fraction_100um=0.865 (strict
+  region_fraction=0.634).
+- All three classical defining markers are detected at the supertype
+  level (Oxtr=2.0, tagged DEFINING_SCOPED on the atlas annotation;
+  Slc6a3=3.07, tagged DEFINING; Adcyap1=4.8).
 
+**Marker evidence provenance.**
 
+- **Oxtr:** classical-side evidence is OTR-Venus reporter
+  immunolabelling across postnatal development in PMv [2] — a
+  protein-level readout tied to a defined hypothalamic region, with
+  explicit demonstration of male-biased PMv expression. Atlas-side
+  Oxtr=2.0 is consistent with detectable expression but is tagged
+  DEFINING_SCOPED, meaning it discriminates within the relevant atlas
+  subclass rather than across the full taxonomy; the alignment is
+  therefore supportive at the supertype level but not a strong
+  cluster-level discriminator on its own.
+- **Slc6a3:** referenced through prior PMv-DAT subpopulation literature
+  [1] (which cites Slc6a3 as the PMv-DAT marker without re-deriving it
+  in the cited study). Atlas-side Slc6a3=3.07 is tagged DEFINING for
+  this supertype, providing transcript-level corroboration that the
+  classical PMv-DAT signature is part of this WMBv1 type.
+- **Adcyap1:** carries no primary citation on the classical node (the
+  PMv-PACAP subpopulation is named in [1] only as a previously
+  identified subpopulation, without an original-study citation
+  available in the gathered corpus). Atlas-side Adcyap1=4.8 is the
+  highest mean among the three defining markers but cannot currently
+  be anchored to a primary study from the gathered references — a
+  targeted literature search for PMv PACAP / Adcyap1 primary
+  characterisation would close the provenance gap.
+- **Unexpected high-expressing marker (Tac1):** Tac1 is tagged DEFINING
+  on the atlas for this supertype with mean=8.95 — substantially higher
+  than any of the three classical defining markers — and is absent from
+  the classical pmv_otr_neuron definition. This is informational rather
+  than disqualifying; it suggests the supertype may be more accurately
+  characterised at the atlas level as a Tac1+ PMv glutamatergic
+  population with OTR / DAT / PACAP signatures as co-expressed
+  subtype-level features, and is recorded as a curator-facing follow-up
+  caveat (see Discussion).
+
+**Concerns.**
+
+- **Cross-cutting marker aggregation.** SUPT_0607 simultaneously
+  expresses Oxtr, Slc6a3, and Adcyap1, the three markers that the
+  classical definition treats as potentially labelling distinct PMv
+  subpopulations. If the OTR+, DAT+, and PACAP+ subsets are functionally
+  separable populations, the supertype-level mapping inherently
+  aggregates them; finer (cluster-level or sub-cluster) resolution is
+  required to test whether they segregate. This is the basis for the
+  many-to-one (broader) supertype call rather than an exact match.
+- **Sister supertype 0605 PMv-TMv Pitx2 Glut_1 [CS20230722_SUPT_0605]**
+  also resides predominantly in PMv (region_fraction_100um=0.631;
+  strict=0.307) but did not surface co-expression of all three classical
+  markers in the gathered facts. It may capture an additional portion
+  of the OTR+ male-biased population not absorbed by SUPT_0607; it
+  appears in the candidate audit table as a lower-ranked PMv-resident
+  glutamatergic supertype.
+- **Tac1 atlas DEFINING marker not in classical definition** — see
+  marker provenance above.
+
+**What would upgrade confidence.**
+
+- Annotation transfer of published PMv transcriptomic datasets
+  (e.g. Oxtr-targeted, DAT-Cre, or PACAP-Cre lineage RNA profiling)
+  against WMBv1, with F1 ≥ 0.7 to SUPT_0607 at supertype level, would
+  add an AnnotationTransferEvidence anchor for the classical → atlas
+  relationship.
+- Curator decision on whether to split `pmv_otr_neuron` into separate
+  `pmv_otr`, `pmv_dat`, and `pmv_pacap` sub-nodes would clarify whether
+  the natural mapping resolution is one supertype to one classical type
+  (current) or three classical types to one supertype (cross-cutting).
 
 ### 2470 PMv-TMv Pitx2 Glut_3 [CS20230722_CLUS_2470] · 🔴 LOW
 
-### Supporting evidence
+**Property comparison (cluster, child of SUPT_0607).**
 
-- **All three classical defining markers reach CONSISTENT alignment at cluster level.** CLUS_2470 shows substantially higher expression than the supertype mean for all three: Oxtr = 4.45 (vs supertype 2.0), Slc6a3 = 6.02 (vs 3.07), Adcyap1 = 8.13 (vs 4.8). Expression concentrates the marker-expressing PMv cells of SUPT_0607 into this cluster.
-- **PMv soma location is the dominant annotation.** MBA:1004 (Ventral premammillary nucleus) is the primary soma for n=192 cells in CLUS_2470 — the largest PMv cluster in SUPT_0607, providing a direct anatomical link to the classical type.
-- **Cluster was identified as the best PMv child within the top-DB supertype.** SUPT_0607 received the highest DB score (4) of any candidate at any rank for pmv_otr_neuron [1], [2]; CLUS_2470 is the child cluster within SUPT_0607 that concentrates all three classical marker signals at PMv.
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Ventral premammillary nucleus [MBA:1004] | PMv region_fraction_100um=0.865 at SUPT_0607 | PMv 255/451 cells (region_fraction_100um=0.898; strict=0.676) at CLUS_2470 | CONSISTENT |
+| NT type | not asserted on classical | not asserted at SUPT_0607 | Glut at CLUS_2470 | NOT_ASSESSED (classical side) |
+| Oxtr expression | Defining marker | mean=2.0 at SUPT_0607 | mean=4.45 at CLUS_2470 | CONSISTENT |
+| Slc6a3 expression | Defining marker | mean=3.07 at SUPT_0607 | mean=6.02 at CLUS_2470 | CONSISTENT |
+| Adcyap1 expression | Defining marker | mean=4.8 at SUPT_0607 | mean=8.13 at CLUS_2470 | CONSISTENT |
+| Sex ratio | Male-biased | not available | MFR absent from precomputed-stats DB for CLUS_2470 | NOT_ASSESSED |
 
-### Marker evidence provenance
+*(CLUS_2470 is the PMv-leading child of SUPT_0607: of the supertype's
+children, it has the largest count of PMv-resident cells (n=192 at
+strict region match within the precomputed location data) and the
+highest mean expression of all three classical defining markers.)*
 
-- **Oxtr** — at CLUS_2470, Oxtr = 4.45 and is annotated as DEFINING_SCOPED at supertype level (mean = 2.0). Classical evidence is transcript-based ([2] Newmaster 2019, OTR-Venus reporter expression). Atlas precomputed values are transcript-based (10x Chromium). No data-source discrepancy.
-- **Slc6a3** — CLUS_2470 Slc6a3 = 6.02 and is a DEFINING atlas marker at supertype level (mean = 3.07). Classical evidence comes from [1] Hemminger 2024, identifying PMv-DAT as a sexually dimorphic PMv subpopulation. Both classical and atlas signals are transcript-based — no data-source discrepancy.
-- **Adcyap1** — CLUS_2470 Adcyap1 = 8.13 (vs supertype 4.8). Classical evidence in the facts file lacks a specific PMID citation on the Adcyap1 marker (`refs: []` on the classical node). This is a gap: PMv-PACAP is referenced via [1] Hemminger 2024 in the broader sexually-dimorphic-PMv-subpopulations narrative, but a primary citation establishing Adcyap1 as a defining marker for this classical type is not in the facts. *(note: a targeted cite-traverse for "Adcyap1 PACAP PMv" may resolve this).*
+**Evidence support.**
 
-### Concerns
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas precomputed expression + region painting | Atlas metadata | SUPPORT | Oxtr=4.45, Slc6a3=6.02, Adcyap1=8.13; PMv region_fraction_100um=0.898 | atlas-internal |
 
-- **Sex bias cannot be confirmed at cluster level.** male_female_ratio is absent from the DB for CLUS_2470 (n=192). Until sex bias is confirmed, confidence is capped at LOW. The absent MFR may reflect a DB ingest gap rather than a genuine absence in the precomputed stats. CLUS_2473 (PMv, n=86) has MFR=2.23 (mild male bias) but very low marker expression — it is a distinct PMv subtype, not a surrogate. *(note: source-side sex bias is well established at population level in [2]; target-side still unresolvable from atlas metadata until MFR is recovered or annotation transfer is run.)*
-- **Marker co-expression may conflate three classical subpopulations.** CLUS_2470 co-expresses Oxtr, Slc6a3, and Adcyap1 at levels suggesting it captures the PMv-OTR, PMv-DAT, and PMv-PACAP subpopulations simultaneously. If these are functionally distinct cell types, a single cluster-level edge conflates them. Node splitting (pmv_otr, pmv_dat, pmv_pacap) may be required before a higher-confidence cluster assignment can be made.
-- **Annotation transfer not yet performed.** No independent, data-driven cell-level mapping of published PMv scRNA-seq or Oxtr-Cre / Slc6a3-Cre lineage data has been run against WMBv1. This is the most important remaining gap in the evidence base.
+**Supporting evidence.**
 
-### What would upgrade confidence
+- CLUS_2470 carries the highest expression of all three classical
+  defining markers among the children of SUPT_0607: Oxtr=4.45,
+  Slc6a3=6.02, Adcyap1=8.13 — each substantially above the supertype
+  means. The cluster concentrates the marker-expressing PMv cells
+  inside its parent supertype.
+- The cluster's soma location is dominantly PMv: of its 451 cells, 255
+  fall within the 100µm proximity of PMv (region_fraction_100um=0.898;
+  strict region_fraction=0.676), with the next-largest atlas labels
+  being the umbrella Hypothalamus [MBA:1097] and Dorsomedial nucleus of
+  the hypothalamus [MBA:830] — adjacent to PMv and consistent with
+  registration-boundary scatter rather than off-target placement.
+- NT type at this cluster is Glut, consistent with the glutamatergic
+  identity expected of PMv-DAT / PMv-PACAP / PMv-OTR neurons described
+  in the cited literature [1], though the classical node does not
+  itself assert an NT type.
 
-- **Direct precomputed-HDF5 query** for CLUS_2470 male_female_ratio (proposed in this edge) would distinguish a DB ingest gap from a genuine absence in the precomputed stats and immediately address the primary uncertainty cap on this edge.
-- **MapMyCells annotation transfer** of published PMv scRNA-seq or Oxtr-Cre / Slc6a3-Cre lineage data against WMBv1 at cluster resolution; F1 ≥ 0.80 against CLUS_2470 would substantially support upgrading to MODERATE/HIGH confidence and would add `AnnotationTransferEvidence`.
-- **Single-cell co-expression analysis within CLUS_2470** to determine whether Oxtr, Slc6a3, and Adcyap1 mark separable subpopulations or co-localise within individual cells. Resolution informs whether pmv_otr_neuron should be split into separate sub-nodes.
+**Concerns.**
+
+- **Male-bias (MFR) not retrievable for CLUS_2470.** The classical
+  definition is explicitly male-biased ([2]), and the survey cohort
+  filter that surfaced this candidate was `sex_bias=male`. However,
+  the male/female ratio is currently absent from the precomputed-stats
+  DB for CLUS_2470. Confidence at cluster level is capped at LOW until
+  the male bias is confirmed. The absence may reflect a DB ingest gap
+  rather than genuine absence in the underlying precomputed stats —
+  a direct query of the precomputed HDF5 is the recommended check.
+- **Single-cluster aggregation of three potentially distinct
+  subpopulations.** CLUS_2470 co-expresses all three classical defining
+  markers at high levels. If PMv-OTR, PMv-DAT, and PMv-PACAP are
+  functionally distinct cell types within PMv, a single cluster-level
+  edge conflates them. Resolution at sub-cluster level (single-cell
+  inspection within the cluster) would test whether the three marker
+  signatures co-localise per cell or label distinct populations within
+  CLUS_2470. This is also the basis for keeping the relationship
+  cluster-level call non-exact (close, not exact).
+- **Sister cluster CLUS_2471 in the same supertype** also sits in PMv
+  but with lower proximity (region_fraction_100um=0.676;
+  strict=0.341) and weaker marker co-expression in the gathered
+  facts — it may capture additional PMv-resident OTR+ cells not in
+  CLUS_2470, contributing to the supertype-level aggregation story.
+
+**What would upgrade confidence.**
+
+- Direct query of the precomputed HDF5 for CLUS_2470 male/female ratio
+  to confirm whether the male bias documented at PMv tissue level [2]
+  is reflected at this cluster. Confirmed male bias would lift cluster
+  confidence to MODERATE.
+- Within-cluster single-cell inspection (or cluster-resolved gene
+  co-expression analysis) for Oxtr, Slc6a3, and Adcyap1 to determine
+  whether the three classical subpopulations co-occur in individual
+  cells or segregate within CLUS_2470.
+- Cluster annotation transfer of published PMv lineage transcriptomic
+  data (Oxtr-Cre, Slc6a3-Cre, or Adcyap1-Cre profiled cells) against
+  WMBv1, with F1 ≥ 0.7 to CLUS_2470 at cluster level, would add a
+  direct experimental anchor.
 
 ---
 
-### 0607 PMv-TMv Pitx2 Glut_3 [CS20230722_SUPT_0607] · 🔴 LOW
+<details>
+<summary>Candidates audited (full top-K)</summary>
 
-### Supporting evidence
+| WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key evidence | Verdict |
+|---|---|---:|---|---|---|
+| 0607 PMv-TMv Pitx2 Glut_3 [CS20230722_SUPT_0607] | — | 1165 | 🟡 MODERATE | PMv region_fraction_100um=0.865; all 3 markers co-expressed | Primary (supertype) |
+| 2470 PMv-TMv Pitx2 Glut_3 [CS20230722_CLUS_2470] | 0607 PMv-TMv Pitx2 Glut_3 | 451 | 🔴 LOW | Highest Oxtr/Slc6a3/Adcyap1 child; PMv region_fraction_100um=0.898; MFR missing | Secondary (best child of primary supertype) |
+| 2471 PMv-TMv Pitx2 Glut_3 [CS20230722_CLUS_2471] | 0607 PMv-TMv Pitx2 Glut_3 | 274 | ⚪ UNCERTAIN | PMv region_fraction_100um=0.676; sibling of CLUS_2470 | Eliminated (weaker PMv proximity and marker support than sister CLUS_2470) |
+| 2314 VMH Nr5a1 Glut_4 [CS20230722_CLUS_2314] | 0569 VMH Nr5a1 Glut_4 | 231 | 🔴 LOW | region_fraction_100um=0.018; dominant in VMH not PMv | Eliminated (wrong region — VMH, not PMv) |
+| 2575 MM Foxb1 Glut_2 [CS20230722_CLUS_2575] | 0631 MM Foxb1 Glut_2 | 487 | 🔴 LOW | region_fraction_100um=0.029; dominant in medial mammillary | Eliminated (wrong region — medial mammillary) |
+| 2395 PH-ant-LHA Otp Bsx Glut_2 [CS20230722_CLUS_2395] | 0592 PH-ant-LHA Otp Bsx Glut_2 | 105 | ⚪ UNCERTAIN | PMv region_fraction_100um=0.596 but no marker support gathered | Eliminated (lower PMv proximity than primary supertype's children; no marker confirmation) |
+| 0605 PMv-TMv Pitx2 Glut_1 [CS20230722_SUPT_0605] | — | 1202 | ⚪ UNCERTAIN | PMv region_fraction_100um=0.631; sister of primary supertype | Eliminated (no atlas marker support gathered; may carry residual OTR+ population — see Discussion) |
+| 0557 ARH-PVp Tbx3 Glut_4 [CS20230722_SUPT_0557] | — | 246 | 🔴 LOW | region_fraction_100um=0.067; dominant in VMH | Eliminated (wrong region) |
+| 0429 TMv-PMv Tbx3 Hist-Gaba_1 [CS20230722_SUPT_0429] | — | 534 | ⚪ UNCERTAIN | region_fraction_100um=0.247; histaminergic GABA | Eliminated (boundary PMv overlap; histaminergic GABA identity, not glutamatergic) |
+| 0430 TMv-PMv Tbx3 Hist-Gaba_2 [CS20230722_SUPT_0430] | — | 321 | ⚪ UNCERTAIN | region_fraction_100um=0.157; histaminergic GABA | Eliminated (boundary PMv overlap; histaminergic GABA identity) |
 
-- **Highest DB candidate score across all ranks.** SUPT_0607 received the top DB score (4) of any candidate at any rank for pmv_otr_neuron — the single best supertype hit by atlas-metadata scoring.
-- **Direct PMv anatomical match.** MBA:1004 (Ventral premammillary nucleus) is the dominant soma location with n=347 cells in SUPT_0607.
-- **All three classical defining markers are present.** Precomputed mean expression: Oxtr = 2.0 (DEFINING_SCOPED atlas marker), Slc6a3 = 3.07 (DEFINING atlas marker), Adcyap1 = 4.8. The supertype simultaneously expresses all three markers corresponding to the potentially distinct PMv subpopulations (PMv-OTR, PMv-DAT, PMv-PACAP).
-- **Child cluster CLUS_2470 concentrates the marker-expressing PMv cells.** Within SUPT_0607, CLUS_2470 (n=192 PMv) shows substantially higher Oxtr (4.45), Slc6a3 (6.02), and Adcyap1 (8.13) than the supertype means — see CLUS_2470 edge above.
+A fresh-emit duplicate edge targets each of SUPT_0607 and CLUS_2470 with
+only `discovery_score` and stub property comparisons (no curator-
+authored caveats). The substantive structured evidence lives on the
+legacy edges narrated above; the fresh-emit duplicates are recorded
+for curator removal — see Discussion open questions.
 
-### Marker evidence provenance
-
-- **Oxtr** — DEFINING_SCOPED at supertype level (mean = 2.0). Classical evidence transcript-based via OTR-Venus reporter [2]. Atlas value transcript-based (10x Chromium). Moderate atlas value at supertype level is expected for a marker concentrated in a child cluster (CLUS_2470 = 4.45).
-- **Slc6a3** — DEFINING atlas marker (mean = 3.07). Classical evidence via PMv-DAT subpopulation [1]. Both transcript-based — no data-source discrepancy.
-- **Adcyap1** — atlas mean = 4.8. Classical evidence on the node lacks a specific PMID (`refs: []`); PMv-PACAP is referenced in [1] but without a primary citation in the facts. Flag as weak source-side evidence.
-- **Tac1 — atlas annotation/literature discrepancy.** Tac1 = 8.95 is the *highest-expressing* DEFINING atlas marker for SUPT_0607 but is absent from the classical pmv_otr_neuron definition. SUPT_0607 may be more accurately characterised as a Tac1+ PMv population with OTR/DAT/PACAP as co-expressed subtype markers. *(note: this suggests the classical definition may underspecify Tac1 — a candidate for a targeted literature search on Tac1 in PMv).*
-
-### Concerns
-
-- **Supertype is glutamatergic, not dopaminergic.** SUPT_0607 carries a Glut_3 (glutamatergic) label (PMv-TMv Pitx2 Glut). The classical node's PMv-DAT subpopulation implies dopaminergic co-release, which is captured only APPROXIMATEly at supertype level. Glutamatergic identity is likely for the OTR+ and PACAP+ populations; dopaminergic co-release is possible for the Slc6a3+ subset. *(adjacent NT phenotype — weak counter-evidence; co-release is biologically plausible).*
-- **Cross-cutting marker pattern conflates three classical subpopulations.** SUPT_0607 expresses all three marker signatures (Oxtr, Slc6a3, Adcyap1) simultaneously, indicating the supertype aggregates neurons the classical taxonomy may treat as distinct subtypes (PMv-OTR, PMv-DAT, PMv-PACAP). Sister supertype SUPT_0605 (PMv-TMv Pitx2 Glut_1, DB score = 2) may capture an additional portion of the OTR+ male-biased population.
-- **Tac1 as the strongest atlas marker is unaccounted for.** Tac1 = 8.95 (DEFINING) is higher than any of the three classical markers at supertype level, but is not in the classical node definition. This is a marker mismatch flagged for investigation.
-- **Sex ratio not available at supertype level.** MFR is computed only at rank 0 (cluster); the male-biased dimorphism — a defining feature of pmv_otr_neuron [2] — cannot be assessed from supertype metadata.
-- **Annotation transfer NOT_ASSESSED.**
-
-### What would upgrade confidence
-
-- **Child-cluster expression query for SUPT_0607.** Query Oxtr, Slc6a3, Adcyap1, Tac1 expression in all child clusters of SUPT_0607 to determine whether subpopulations are resolvable at cluster level — partially addressed for CLUS_2470 above.
-- **Annotation transfer** (MapMyCells) of published PMv scRNA-seq data against WMBv1; F1 ≥ 0.50 at SUPT_0607 level would upgrade this edge; F1 ≥ 0.80 at CLUS_2470 level would support the cluster-level edge. Expected output: `AnnotationTransferEvidence`.
-- **Targeted literature search** for primary citations on Adcyap1 (PMv-PACAP) and Tac1 in PMv to resolve the marker provenance gap.
-- **Node split decision.** Decide whether pmv_otr_neuron should be split into pmv_otr, pmv_dat, and pmv_pacap sub-nodes prior to final mapping, given that SUPT_0607 cross-cuts the three subpopulations.
+</details>
 
 ---
 
@@ -151,17 +315,57 @@ the highest expression of all three markers).
 <details>
 <summary>Data sources, analyses, and reproducibility receipts</summary>
 
-**Classical type definition.** See classical type table in Introduction; defining_basis on the classical node and per-property literature support are listed there. The KB-side definition lives at the source graph file linked in the reproducibility footer.
+**Classical type definition.** The classical node `pmv_otr_neuron`
+(definition basis: CLASSICAL_NEUROCHEMICAL) is defined by Oxtr [2],
+Slc6a3 [1], and Adcyap1 expression, with soma in the Ventral
+premammillary nucleus [MBA:1004] [1, 2] and a male-biased sex ratio
+documented at the level of OTR+ PMv tissue by OTR-Venus reporter
+immunolabelling [2]. The node carries an explicit curator note that
+the three marker-defined subpopulations (PMv-OTR, PMv-DAT, PMv-PACAP)
+may not fully overlap and could be split into separate sub-nodes
+before final mapping. No CL term is currently assigned.
 
-**Atlas mapping query.** Candidate atlas clusters were retrieved from CCN20230722 at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias). Full scoring rules: `workflows/map-cell-type.md`.
+**Atlas mapping query.** Candidate atlas clusters were retrieved from
+the WMBv1 taxonomy (CS20230722) at ranks 0 (cluster) and 1 (supertype)
+using metadata-based scoring (region match against MBA:1004, NT type,
+defining markers Oxtr / Slc6a3 / Adcyap1, sex bias filter for
+`male`). Full scoring rules: `workflows/map-cell-type.md`.
 
-**Property alignment.** Each defining property was compared to the corresponding atlas-side value via the `property_comparisons` schema; alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
+**Property alignment.** Each defining property of the classical type
+was compared to the corresponding atlas-side value via the
+`property_comparisons` schema, with alignments graded
+CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side
+numerical values came from precomputed expression on the cluster
+and from MERFISH spatial registration for soma location.
 
+**Anti-hallucination.** All citations, atlas accessions, ontology
+CURIEs, and verbatim literature quotes in this report are validated
+against the evidencell knowledge base at write time. Authored-prose
+evidence narratives are validated against their source
+`evidence_items[*].explanation` fields. The pre-write hook rejects
+any unresolvable identifier or unattributed blockquote. Specific
+mapping limitations and caveats are documented per-candidate in the
+Discussion section.
 
+*Generated by evidencell `25c2b32` at 2026-06-08T18:14:10+00:00 from
+[kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml](kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
 
-**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote.
+**Evidence base table.**
 
-*Generated by evidencell `0c97cfa` from [`kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`](../../kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+| Edge ID | Evidence types | Supports | Source |
+| --- | --- | --- | --- |
+| edge_pmv_otr_neuron_to_cs20230722_supt_0607 | ATLAS_METADATA | SUPPORT | atlas-internal |
+| edge_pmv_otr_neuron_to_cs20230722_clus_2470 | ATLAS_METADATA | SUPPORT | atlas-internal |
+| edge_pmv_otr_neuron_to_CS20230722_CLUS_2471 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pmv_otr_neuron_to_CS20230722_CLUS_2470 (fresh-emit duplicate) | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pmv_otr_neuron_to_CS20230722_CLUS_2314 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pmv_otr_neuron_to_CS20230722_CLUS_2575 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pmv_otr_neuron_to_CS20230722_CLUS_2395 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pmv_otr_neuron_to_CS20230722_SUPT_0607 (fresh-emit duplicate) | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pmv_otr_neuron_to_CS20230722_SUPT_0605 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pmv_otr_neuron_to_CS20230722_SUPT_0557 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pmv_otr_neuron_to_CS20230722_SUPT_0429 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pmv_otr_neuron_to_CS20230722_SUPT_0430 | ATLAS_METADATA | PARTIAL | atlas-internal |
 
 </details>
 
@@ -169,72 +373,99 @@ the highest expression of all three markers).
 
 ## Discussion
 
-**Primary mapping:** → 2470 PMv-TMv Pitx2 Glut_3 [CS20230722_CLUS_2470] at LOW confidence. Key support: ATLAS_METADATA (PMv-localised Pitx2 Glut subclass; Oxtr expression annotated on parent SUPT_0607). Key caveats: `MARKER_NOT_SPECIFIC` (Oxtr expression not directly resolvable at cluster rank); `LOW_CELL_COUNT`.
+**Primary mapping:** Ventral premammillary nucleus (PMv) oxytocin
+receptor neuron → 0607 PMv-TMv Pitx2 Glut_3 [CS20230722_SUPT_0607] at
+MODERATE confidence, with the supertype's PMv-resident child cluster
+2470 PMv-TMv Pitx2 Glut_3 [CS20230722_CLUS_2470] held at LOW confidence
+as the best cluster-level resolution available. Key support: atlas
+precomputed expression of all three classical defining markers (Oxtr,
+Slc6a3, Adcyap1) on a PMv-dominant glutamatergic supertype, with PMv
+soma proximity at region_fraction_100um=0.865 at supertype level and
+0.898 at the cluster. Key caveats: the supertype aggregates the three
+marker-defined PMv subpopulations the classical definition treats as
+potentially distinct (cross-cutting many-to-one); and male-bias at the
+cluster level remains unconfirmed (MFR missing from the precomputed-
+stats DB for CLUS_2470).
 
-No Cell Ontology term currently assigned for this classical type.
+No Cell Ontology term currently covers this classical type. The
+intersecting marker-defined PMv subpopulations described in the
+literature (PMv-OTR, PMv-DAT, PMv-PACAP) do not yet have CL
+representatives, and the type is flagged as a candidate for a new CL
+term — the natural prerequisite is the curator decision (see open
+questions) on whether the three subpopulations are one type or three.
 
 ### Proposed experiments and follow-ups
 
-### 1. Direct precomputed-HDF5 query for CLUS_2470 male_female_ratio
+**Within-cluster marker co-expression resolution.**
+- **What:** Single-cell inspection of Oxtr, Slc6a3, and Adcyap1
+  co-expression within CLUS_2470 (and to a lesser extent CLUS_2471) to
+  determine whether the three classical subpopulations co-localise per
+  cell or segregate into separable subclusters.
+- **Target:** Identify whether ≥ 90% of marker-positive cells co-express
+  all three markers (one population) or whether the markers label
+  largely non-overlapping cells (three populations within one cluster).
+- **Expected output:** MarkerAnalysisEvidence on the cluster edge; if
+  separation is found, basis for splitting `pmv_otr_neuron` into
+  `pmv_otr`, `pmv_dat`, `pmv_pacap` sub-nodes.
+- **Resolves:** open questions 1, 3.
 
-**What:** Query the precomputed HDF5 stats directly for CLUS_2470 male_female_ratio, bypassing the DB ingest layer.
+**Cluster annotation transfer from PMv lineage datasets.**
+- **What:** Cluster-level annotation transfer of published PMv
+  transcriptomic data targeting PMv-OTR (via Oxtr-Cre or
+  OTR-reporter-sorted cells), PMv-DAT (Slc6a3-Cre), or PMv-PACAP
+  (Adcyap1-Cre) against WMBv1.
+- **Target:** F1 ≥ 0.7 to SUPT_0607 at supertype level; F1 ≥ 0.6 to
+  CLUS_2470 at cluster level.
+- **Expected output:** AnnotationTransferEvidence on the supertype and
+  cluster edges; direct experimental anchor for the classical → atlas
+  identity at both resolutions.
+- **Resolves:** open questions 1, 2, 4.
 
-**Target:** Recover MFR for CLUS_2470 (n=192 cells) and confirm whether sex bias matches the classical male-biased dimorphism.
+**Direct precomputed-stats query for cluster-level male/female ratio.**
+- **What:** Direct HDF5 query of CLUS_2470 male/female cell counts to
+  confirm whether the male bias documented for PMv OTR+ tissue [2] is
+  reflected at this cluster, and whether the DB-level MFR absence is
+  a genuine signal or an ingest gap.
+- **Target:** Recover MFR; confirm male predominance consistent with
+  [2] (males > females from P14–P56).
+- **Expected output:** Sex-ratio property comparison populated; if
+  confirmed, lifts cluster confidence to MODERATE.
+- **Resolves:** open question 4.
 
-**Expected output:** Updated property_comparison on the CLUS_2470 edge with sex_ratio alignment resolved (CONSISTENT / DISCORDANT / NOT_ASSESSED if genuinely absent in the source HDF5).
-
-**Resolves:** Open question 1 (the primary cap on confidence for the CLUS_2470 edge). Distinguishes a DB ingest gap from a genuine absence.
-
-### 2. MapMyCells annotation transfer of an external PMv scRNA-seq dataset against WMBv1
-
-**What:** Retrieve a published scRNA-seq dataset enriched for PMv neurons (e.g. Oxtr-Cre, Slc6a3-Cre, or PMv-DAT lineage preparations; sex-stratified hypothalamic atlases). Run MapMyCells against WMBv1 at cluster resolution.
-
-**Target:** F1 ≥ 0.50 at SUPT_0607 level; F1 ≥ 0.80 at CLUS_2470 level for Oxtr+/Slc6a3+/Adcyap1+ cells.
-
-**Expected output:** `AnnotationTransferEvidence` entries on both edges (edge_pmv_otr_neuron_to_cs20230722_supt_0607 and edge_pmv_otr_neuron_to_cs20230722_clus_2470). Atlas: WMBv1. Tool: MapMyCells. Output format: F1 matrix per cluster, fed back as `AnnotationTransferEvidence` YAML.
-
-**Resolves:** Open questions 2 and 3. Addresses the `annotation_transfer_f1` NOT_ASSESSED gap on both edges.
-
-### 3. Single-cell marker co-expression analysis within CLUS_2470
-
-**What:** Within-cluster re-clustering of CLUS_2470 cells, stratified by Oxtr+/Slc6a3+/Adcyap1+ profiles. Determine whether the three markers co-localise within individual cells or mark separable subpopulations.
-
-**Target:** Detection of separable PMv-OTR, PMv-DAT, and PMv-PACAP sub-populations within CLUS_2470, or formal demonstration that they are co-extensive at this resolution.
-
-**Expected output:** Additional `MarkerAnalysisEvidence` records and a node-split decision (pmv_otr / pmv_dat / pmv_pacap as separate classical nodes, or retain as a single aggregated node).
-
-**Resolves:** Open questions 2 and 4 (node splitting decision).
-
-### 4. Targeted literature search for Adcyap1 and Tac1 in PMv
-
-**What:** Cite-traverse for primary citations establishing Adcyap1 as a defining marker for the classical PMv-PACAP population, and for Tac1 expression in PMv.
-
-**Target:** Recover primary PMID(s) supporting Adcyap1 as a PMv-PACAP defining marker; assess whether Tac1 should be added to the classical node definition.
-
-**Expected output:** Additional `LiteratureEvidence` entries; updated classical node definition if Tac1 is supported.
-
-**Resolves:** Adcyap1 marker provenance gap; Tac1 atlas/literature discrepancy (open question 5).
-
----
+**Curator decision on splitting `pmv_otr_neuron`.**
+- **What:** Curator review of whether the classical node should be
+  split into separate `pmv_otr`, `pmv_dat`, and `pmv_pacap` sub-nodes
+  prior to committing a final mapping.
+- **Expected output:** Either (a) confirmation that the aggregated type
+  is the correct unit and the supertype-level broader call is the
+  natural resolution, or (b) three classical nodes mapping into the
+  same supertype as a cross-cutting many-to-one.
+- **Resolves:** open questions 1, 3.
 
 ### Open questions
 
-1. Why is MFR absent for CLUS_2470 (n=192 cells)? Is this a DB ingest gap or a genuine absence in precomputed stats? *(Appears on the cluster edge.)*
-2. Do Oxtr, Slc6a3, and Adcyap1 co-localise within individual CLUS_2470 cells, or do they mark distinct subpopulations within the cluster? *(Appears on the cluster edge.)*
-3. Do individual clusters within SUPT_0607 segregate by marker (Oxtr-high, Slc6a3-high, Adcyap1-high), allowing sub-resolution mapping? *(Appears on the supertype edge; partially addressed by CLUS_2470 ATLAS_METADATA evidence.)*
-4. Should pmv_otr_neuron be split into separate pmv_otr, pmv_dat, pmv_pacap sub-nodes prior to final mapping? *(Appears on the supertype edge.)*
-5. What is the role of Tac1 (mean = 8.95, highest DEFINING atlas marker in SUPT_0607) relative to the classical pmv_otr_neuron definition? Should it be added as a co-expressed marker or treated as a distinguishing feature of a related but distinct supertype? *(Appears on the supertype edge.)*
-
----
-
-### Evidence base
-
-| Edge ID | Evidence type | Supports |
-|---|---|---|
-| edge_pmv_otr_neuron_to_cs20230722_supt_0607 | ATLAS_METADATA | SUPPORT — DB top score=4; Oxtr=2.0 (DEFINING_SCOPED), Slc6a3=3.07 (DEFINING), Adcyap1=4.8; Tac1=8.95 unexpected; MBA:1004 PMv n=347 |
-| edge_pmv_otr_neuron_to_cs20230722_clus_2470 | ATLAS_METADATA | SUPPORT — Oxtr=4.45, Slc6a3=6.02, Adcyap1=8.13 (all above supertype means); MBA:1004 PMv n=192 (largest PMv cluster); MFR absent |
-
-All evidence is atlas-metadata only. No literature, annotation transfer, or direct experimental evidence has been incorporated at this stage.
+1. Do the PMv-OTR, PMv-DAT, and PMv-PACAP marker signatures co-localise
+   in individual cells within CLUS_2470, or do they label distinct
+   subpopulations within the cluster?
+2. Do individual child clusters within SUPT_0607 segregate by marker
+   (Oxtr-high, Slc6a3-high, Adcyap1-high), allowing higher-resolution
+   sub-supertype mapping?
+3. Should `pmv_otr_neuron` be split into separate `pmv_otr`, `pmv_dat`,
+   and `pmv_pacap` sub-nodes prior to final mapping?
+4. Why is MFR (male/female ratio) absent in the precomputed-stats DB
+   for CLUS_2470 (n=192 PMv cells)? Is this a DB ingest gap or a
+   genuine absence in the precomputed stats?
+5. Does sister supertype 0605 PMv-TMv Pitx2 Glut_1 [CS20230722_SUPT_0605]
+   capture an additional portion of the OTR+ male-biased PMv population
+   not absorbed by SUPT_0607?
+6. Is the atlas DEFINING marker Tac1 (mean=8.95 on SUPT_0607) a
+   feature that should be added to the classical definition, or is it
+   a co-expressed but classically irrelevant marker?
+7. Curator removal of duplicate fresh-emit edges
+   `edge_pmv_otr_neuron_to_CS20230722_SUPT_0607` and
+   `edge_pmv_otr_neuron_to_CS20230722_CLUS_2470` — legacy/fresh-emit
+   ID collisions on the same `taxonomy_type` accessions; the legacy
+   edges carry the substantive evidence and should be retained.
 
 ---
 
@@ -242,5 +473,296 @@ All evidence is atlas-metadata only. No literature, annotation transfer, or dire
 
 | # | Citation | PMID | Used for |
 |---|---|---|---|
-| [1] | Hemminger et al. 2024 | [PMID:39416191](https://pubmed.ncbi.nlm.nih.gov/39416191/) | Soma location (PMv); PMv-DAT and PMv-PACAP sexually dimorphic subpopulations |
-| [2] | Newmaster et al. 2019 | [PMID:32313029](https://pubmed.ncbi.nlm.nih.gov/32313029/) | Soma location (PMv); Oxtr (OTR) marker; male-biased PMv OTR expression P14–P56 |
+| [1] | Hemminger et al. 2024. Spatial Single-Cell Mapping of Transcriptional Differences Across Genetic Backgrounds in Mouse Brains. | [39416191](https://pubmed.ncbi.nlm.nih.gov/39416191) | PMv soma location; PMv-DAT and PMv-PACAP subpopulation naming |
+| [2] | Newmaster et al. 2019. (PMID 32313029) | [32313029](https://pubmed.ncbi.nlm.nih.gov/32313029) | OTR-Venus reporter demonstration of male-biased PMv OTR expression P14–P56; Oxtr marker; PMv soma location |
+
+---
+
+## Verdict blocks
+
+<!-- verdict-block-start: edge_pmv_otr_neuron_to_cs20230722_supt_0607 -->
+```yaml
+verdict:
+  confidence: MODERATE
+  confidence_score: 0.62
+  relationship: skos:broadMatch
+  mapping_cardinality: "1:n"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:STRONGEST] PMv-resident glutamatergic supertype 0607
+    PMv-TMv Pitx2 Glut_3 (region_fraction_100um=0.865; strict=0.634)
+    co-expresses all three classical defining markers (Oxtr=2.0,
+    Slc6a3=3.07, Adcyap1=4.8) and is the highest-scoring candidate
+    at any rank; the broader 1:n call reflects supertype aggregation
+    of the three classical PMv-OTR / PMv-DAT / PMv-PACAP subpopulations
+    rather than a clean 1:1.
+  reconciliation_note: >
+    Supertype-level call (CS20230722_SUPT_0607) paired with cluster-level
+    secondary CS20230722_CLUS_2470 (LOW); the supertype absorbs marker
+    signatures that the classical definition treats as potentially
+    distinct subpopulations, so the natural resolution is broader at
+    supertype level and uncertain at cluster level pending male-bias
+    and within-cluster co-expression resolution.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Cross-cutting marker aggregation — SUPT_0607 simultaneously
+        expresses Oxtr, Slc6a3, and Adcyap1, the three markers the
+        classical definition treats as potentially labelling distinct
+        PMv subpopulations (PMv-OTR, PMv-DAT, PMv-PACAP); the
+        supertype-level mapping inherently aggregates them and a
+        sub-supertype split may be required if curator decides the
+        subpopulations are functionally distinct.
+    - caveat_type: MARKER_NOT_SPECIFIC
+      description: >
+        Tac1 is tagged DEFINING on the atlas for this supertype with
+        mean=8.95 — substantially higher than any of the three
+        classical defining markers — and is absent from the classical
+        pmv_otr_neuron definition; the supertype may be more
+        accurately characterised at the atlas level as a Tac1+ PMv
+        glutamatergic population with OTR / DAT / PACAP signatures
+        as co-expressed subtype-level features.
+    - caveat_type: OTHER
+      description: >
+        Sister supertype 0605 PMv-TMv Pitx2 Glut_1 also resides
+        predominantly in PMv (region_fraction_100um=0.631; strict=0.307)
+        and may capture an additional portion of the OTR+ male-biased
+        population not absorbed by SUPT_0607.
+  proposed_experiments:
+    - >
+      Cluster annotation transfer of published PMv lineage
+      transcriptomic data (Oxtr-Cre, Slc6a3-Cre, or Adcyap1-Cre
+      profiled cells) against WMBv1, with F1 >= 0.7 to SUPT_0607
+      at supertype level, to provide an AnnotationTransferEvidence
+      anchor for the classical-to-atlas relationship.
+    - >
+      Query Oxtr, Slc6a3, Adcyap1, and Tac1 expression across the
+      child clusters of SUPT_0607 to test whether the three classical
+      marker signatures segregate at cluster level (suggesting
+      sub-supertype splitting) or co-occur across children (supporting
+      the aggregated broader call).
+    - >
+      Curator decision on whether to split pmv_otr_neuron into
+      separate pmv_otr, pmv_dat, and pmv_pacap sub-nodes, which would
+      reframe this edge as a cross-cutting many-to-one mapping into
+      SUPT_0607 rather than a single broader 1:n mapping.
+  unresolved_questions:
+    - >
+      Do individual child clusters within SUPT_0607 segregate by
+      marker (Oxtr-high, Slc6a3-high, Adcyap1-high), allowing
+      sub-supertype resolution mapping?
+    - >
+      Should pmv_otr_neuron be split into separate pmv_otr, pmv_dat,
+      pmv_pacap sub-nodes prior to final mapping?
+    - >
+      Is the atlas DEFINING marker Tac1 (mean=8.95 on SUPT_0607) a
+      feature that should be added to the classical definition, or a
+      co-expressed but classically irrelevant marker?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pmv_otr_neuron_to_cs20230722_clus_2470 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.38
+  relationship: skos:closeMatch
+  mapping_cardinality: "1:1"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:NEXT] CLUS_2470 is the PMv-leading child of SUPT_0607
+    (region_fraction_100um=0.898; strict=0.676; 255/451 cells in PMv)
+    and concentrates the supertype's classical-marker expression
+    (Oxtr=4.45, Slc6a3=6.02, Adcyap1=8.13); confidence held at LOW
+    pending male-bias confirmation (MFR missing from precomputed-stats
+    DB) and within-cluster co-expression resolution of the three
+    putative subpopulations.
+  reconciliation_note: >
+    Cluster-level secondary to the supertype primary
+    (CS20230722_SUPT_0607, MODERATE broadMatch); the cluster call
+    is non-exact (close, not exact) because the cluster appears to
+    aggregate the three classical marker-defined subpopulations into
+    a single transcriptomic unit.
+  caveats:
+    - caveat_type: OTHER
+      description: >
+        Male-bias (MFR) not retrievable for CLUS_2470 — the classical
+        definition is explicitly male-biased ([2]) but the male/female
+        ratio is currently absent from the precomputed-stats DB for
+        this cluster; absence may reflect a DB ingest gap rather than
+        a genuine signal, and confidence is capped at LOW until the
+        male bias is confirmed.
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Single-cluster aggregation of three potentially distinct
+        subpopulations — CLUS_2470 co-expresses Oxtr, Slc6a3, and
+        Adcyap1 at high levels, and if PMv-OTR, PMv-DAT, and PMv-PACAP
+        are functionally distinct cell types within PMv, a single
+        cluster-level edge conflates them; resolution at sub-cluster
+        level would test whether the three marker signatures
+        co-localise per cell or label distinct populations within
+        the cluster.
+    - caveat_type: OTHER
+      description: >
+        Sister cluster CLUS_2471 in the same supertype also sits in
+        PMv but with lower proximity (region_fraction_100um=0.676;
+        strict=0.341) and weaker marker co-expression in the gathered
+        facts — it may capture additional PMv-resident OTR+ cells not
+        in CLUS_2470, contributing to the supertype-level aggregation.
+  proposed_experiments:
+    - >
+      Direct query of the precomputed HDF5 for CLUS_2470 male/female
+      ratio to confirm whether the male bias documented for PMv OTR+
+      tissue [2] is reflected at this cluster, and whether the
+      DB-level MFR absence is a genuine signal or an ingest gap;
+      confirmed male predominance would lift cluster confidence to
+      MODERATE.
+    - >
+      Within-cluster single-cell inspection (or cluster-resolved gene
+      co-expression analysis) for Oxtr, Slc6a3, and Adcyap1 to
+      determine whether the three classical subpopulations co-occur
+      in individual cells or segregate within CLUS_2470.
+    - >
+      Cluster annotation transfer of published PMv lineage
+      transcriptomic data (Oxtr-Cre, Slc6a3-Cre, or Adcyap1-Cre
+      profiled cells) against WMBv1, with F1 >= 0.6 to CLUS_2470
+      at cluster level, to add a direct experimental anchor.
+  unresolved_questions:
+    - >
+      Do Oxtr, Slc6a3, and Adcyap1 co-localise within individual
+      CLUS_2470 cells, or do they mark distinct subpopulations within
+      the cluster?
+    - >
+      Why is MFR absent for CLUS_2470 (n=192 PMv cells)? DB ingest
+      gap or genuine absence in precomputed stats?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pmv_otr_neuron_to_CS20230722_CLUS_2471 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.22
+  rationale: >
+    [tier:CUT] Sibling cluster of CLUS_2470 in SUPT_0607 with lower
+    PMv proximity (region_fraction_100um=0.676; strict=0.341) and
+    weaker marker support than its sister; eliminated in favour of
+    CLUS_2470 as the best PMv-resident child.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pmv_otr_neuron_to_CS20230722_CLUS_2314 -->
+```yaml
+verdict:
+  confidence: REFUTED
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] Wrong region — CS20230722_CLUS_2314 is a VMH Nr5a1
+    glutamatergic cluster dominant in the ventromedial hypothalamic
+    nucleus (region_fraction_100um=0.018 against PMv), not PMv.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pmv_otr_neuron_to_CS20230722_CLUS_2575 -->
+```yaml
+verdict:
+  confidence: REFUTED
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] Wrong region — CS20230722_CLUS_2575 is a medial
+    mammillary Foxb1 glutamatergic cluster (region_fraction_100um=0.029
+    against PMv), not PMv.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pmv_otr_neuron_to_CS20230722_CLUS_2395 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.18
+  rationale: >
+    [tier:CUT] PH-ant-LHA Otp Bsx glutamatergic cluster with moderate
+    PMv proximity (region_fraction_100um=0.596) but no atlas-side
+    confirmation of the classical defining markers; weaker than the
+    PMv-TMv Pitx2 Glut_3 lineage and eliminated.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pmv_otr_neuron_to_CS20230722_SUPT_0607 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.10
+  rationale: >
+    [tier:CUT] Fresh-emit duplicate of the legacy supertype edge
+    edge_pmv_otr_neuron_to_cs20230722_supt_0607, carrying only
+    discovery_score and stub property comparisons; the substantive
+    evidence lives on the legacy edge and this duplicate is recorded
+    for curator removal.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pmv_otr_neuron_to_CS20230722_SUPT_0605 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.25
+  rationale: >
+    [tier:CUT] Sister supertype to SUPT_0607 with PMv residency
+    (region_fraction_100um=0.631; strict=0.307) but no atlas-side
+    confirmation of the classical defining markers in the gathered
+    facts; flagged as a possible carrier of additional OTR+ population
+    but eliminated at this round pending direct marker evidence.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pmv_otr_neuron_to_CS20230722_SUPT_0557 -->
+```yaml
+verdict:
+  confidence: REFUTED
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] Wrong region — ARH-PVp Tbx3 glutamatergic supertype
+    dominant in VMH (region_fraction_100um=0.067 against PMv), not PMv.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pmv_otr_neuron_to_CS20230722_SUPT_0429 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.12
+  rationale: >
+    [tier:CUT] TMv-PMv histaminergic GABAergic supertype with boundary
+    PMv overlap (region_fraction_100um=0.247) and a histaminergic
+    GABA identity inconsistent with the glutamatergic PMv-OTR / DAT /
+    PACAP populations described in the literature.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pmv_otr_neuron_to_CS20230722_SUPT_0430 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.12
+  rationale: >
+    [tier:CUT] TMv-PMv histaminergic GABAergic supertype with boundary
+    PMv overlap (region_fraction_100um=0.157) and a histaminergic
+    GABA identity inconsistent with the glutamatergic PMv-OTR / DAT /
+    PACAP populations described in the literature.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pmv_otr_neuron_to_CS20230722_CLUS_2470 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.10
+  rationale: >
+    [tier:CUT] Fresh-emit duplicate of the legacy cluster edge
+    edge_pmv_otr_neuron_to_cs20230722_clus_2470, carrying only
+    discovery_score and stub property comparisons; the substantive
+    evidence lives on the legacy edge and this duplicate is recorded
+    for curator removal.
+```
+<!-- verdict-block-end -->

--- a/reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
+++ b/reports/sexually_dimorphic/pvn_crfr1_neuron_summary.md
@@ -1,163 +1,168 @@
 # PVN corticotropin-releasing factor receptor 1 (CRFR1) neuron — WMBv1 Mapping Report
-*draft · 2026-04-25 · Source: `kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
-
-**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+*2026-04-25 · Source: `kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
 
 ---
 
 ## Introduction
 
-### Classical type
+PVN CRFR1 neurons are paraventricular hypothalamic cells defined by expression of the corticotropin-releasing factor receptor 1 (Crhr1). They show a male-biased sexual dimorphism that emerges around puberty, persists into old age, and is sensitive to adult gonadectomy in males but not females; the population co-expresses estrogen receptor alpha (moderate) and androgen receptor (high), consistent with regulation by circulating gonadal steroids [1]. Because Crhr1 marks the postsynaptic recipient of CRH input rather than CRH-producing neurons, the population is biologically distinct from the canonical "corticotropin-releasing neuron" defined by CRH secretion, and its placement against the WMBv1 hypothalamic taxonomy is an open question.
 
-**PVN corticotropin-releasing factor receptor 1 (CRFR1) neuron** is defined neurochemically by
-expression of CRFR1 (Crhr1) and obligate co-expression of estrogen receptor alpha (Esr1, moderate)
-and androgen receptor (Ar, high). Somas are concentrated in the paraventricular hypothalamic
-nucleus (PVN). The population is male-biased (males > females), with the sex difference emerging
-during puberty/early adulthood and persisting into old age; adult gonadectomy in males (but not
-females) reduces CRFR1-immunoreactive cell counts, indicating gonadal-hormone-dependent
-regulation. Characterisation rests on a single primary source (Rosinger 2019).
-
-CL term: **corticotropin-releasing neuron (CL:4072021)** — mapping is RELATED only. CL:4072021
-defines neurons by CRH *secretion*, while this node is defined by CRFR1 *receptor* expression.
-No exact CL term exists; this is a candidate for a new term.
+### Classical type table
 
 | Property | Value | References |
 |---|---|---|
 | Soma location | Paraventricular hypothalamic nucleus [MBA:38] | [1] |
-| Defining markers | Crhr1 (transcript), Esr1 (transcript, moderate co-expression), Ar (transcript, high co-expression) | [1] |
-| CL term | CL:4072021 (corticotropin-releasing neuron) — RELATED only | |
+| Markers | Crhr1; Esr1 (moderate co-expression); Ar (high co-expression) | [1] |
+| Sex bias | Male-biased (males > females); emerges at puberty; reduced by adult gonadectomy in males | [1] |
+| Cell Ontology mapping | corticotropin-releasing neuron [CL:4072021] (RELATED) | — |
 
 <details>
-<summary>Literature support — expand for verbatim quotes</summary>
+<summary>Details — source evidence for classical type properties</summary>
 
-**[1] Rosinger et al. 2019 · PMID:31055007 — Soma location, Crhr1/Esr1/Ar markers, sex dimorphism**
-
-> Sex differences in neural structures are generally believed to underlie sex differences reported in anxiety, depression, and the hypothalamic-pituitary-adrenal axis, although the specific circuitry involved is largely unclear. Using a corticotropin-releasing factor receptor 1 (CRFR1) reporter mouse line, we report a sexually dimorphic distribution of CRFR1 expressing cells within the paraventricular hypothalamus (PVN; males > females). Relative to adult levels, PVN CRFR1-expressing cells are sparse and not sexually dimorphic at postnatal days 0, 4, or 21. This suggests that PVN cells might recruit CRFR1 during puberty or early adulthood in a sex-specific manner. The adult sex difference in PVN CRFR1 persists in old mice (20-24 months). Adult gonadectomy (6 weeks) resulted in a significant decrease in CRFR1-immunoreactive cells in the male but not female PVN. CRFR1 cells show moderate co-expression with estrogen receptor alpha (ERα) and high co-expression with androgen receptor, indicating potential mechanisms through which circulating gonadal hormones might regulate CRFR1 expression and function. Finally, we demonstrate that a psychological stressor, restraint stress, induces a sexually dimorphic pattern of neural activation in PVN CRFR1 cells (males >females) as assessed by co-localization with the transcription/neural activation marker phosphorylated CREB. Given the known role of CRFR1 in regulating stress-associated behaviors and hormonal responses, this CRFR1 PVN sex difference might contribute to sex differences in these functions.
-> — Rosinger et al. 2019, Introduction · [1] <!-- quote_key: 143424909_2b990710 -->
-
+- **Soma location, sexual dimorphism, marker co-expression:** CRFR1 reporter mouse line; immunohistochemistry against the reporter, ERα, and androgen receptor; gonadectomy and restraint-stress activation by phosphorylated CREB [1].
+  > Using a corticotropin-releasing factor receptor 1 (CRFR1) reporter mouse line, we report a sexually dimorphic distribution of CRFR1 expressing cells within the paraventricular hypothalamus (PVN; males > females). … CRFR1 cells show moderate co-expression with estrogen receptor alpha (ERα) and high co-expression with androgen receptor, indicating potential mechanisms through which circulating gonadal hormones might regulate CRFR1 expression and function.
+  > — Rosinger et al. 2019, Introduction · [1] <!-- quote_key: 143424909_2b990710 -->
 </details>
+
+### Cell Ontology mapping
+
+Cell Ontology mapping: corticotropin-releasing neuron [[CL:4072021](https://www.ebi.ac.uk/ols4/ontologies/cl/classes?obo_id=CL:4072021)] (RELATED).
+
+The closest existing CL term (CL:4072021) defines neurons by CRH **secretion**, whereas this population is defined by CRFR1 **receptor** expression — biologically distinct, since CRFR1+ PVN cells receive CRH input rather than producing it. No exact CL term currently exists and this type is a candidate for a new CL contribution.
 
 ---
 
 ## Results
 
-### Mapping candidates
+The strongest available placement is to the PVN-resident glutamatergic supertype 0585 PVH-SO-PVa Otp Glut_1 [CS20230722_SUPT_0585], driven by atlas-side concordance of soma location (MBA:38) and of the steroid-hormone-receptor profile (Esr1, Ar) reported by Rosinger 2019 [1]; this remains a LOW-confidence call because Crhr1 itself is not in the atlas precomputed expression panel and the supertype-level Crhr1 mean (0.84) implies that CRFR1+ cells are a minority subset of the supertype. No annotation transfer evidence is available, so resolution of which child cluster within 0585 (or among its sister supertypes 0586/0587/0589) best represents the dimorphic CRFR1+ population is deferred to a Crhr1-targeted transcriptomic or post-hoc immunostained sequencing experiment.
 
-One mapping edge is recorded for pvn_crfr1_neuron: a supertype-level edge to SUPT_0585
-(0585 PVH-SO-PVa Otp Glut_1), the highest rank-1 candidate by DB score (=3) among PVN-localised
-supertypes.
-
-| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
-|---|---|---|---|---|---|---|
-| 1 | 0585 PVH-SO-PVa Otp Glut_1 [CS20230722_SUPT_0585] | (self) | 183 | 🟡 MODERATE | Esr1 APPROXIMATE; Ar APPROXIMATE; Crhr1 APPROXIMATE (low) | Best candidate |
-1 edge total. Relationship type: PARTIAL_OVERLAP.
-
-### Property alignment — primary candidate (SUPT_0585)
+### Property alignment + Evidence support — 0585 PVH-SO-PVa Otp Glut_1 [CS20230722_SUPT_0585] · 🔴 LOW
 
 **Table 1 — Property comparison.**
 
 | Property | Classical | Supertype | Best cluster | Alignment |
 |---|---|---|---|---|
-| Soma location | Paraventricular hypothalamic nucleus [MBA:38] | MBA:38 (PVN) n=98 (primary location) | not assessed | CONSISTENT |
-| NT type | not stated; PVN principal neurons predominantly glutamatergic | Glutamatergic (PVH-SO-PVa Otp Glut) | not assessed | CONSISTENT |
-| Crhr1 expression | POSITIVE (transcript, primary defining marker) | precomputed mean_expression=0.84 | not assessed | APPROXIMATE |
-| Esr1 expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=3.65 (DEFINING_SCOPED atlas marker) | not assessed | APPROXIMATE |
-| Ar expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=4.95 | not assessed | APPROXIMATE |
-| Sex ratio | MALE_BIASED (males > females; emerges at puberty; gonadectomy-sensitive in males) | not available | not assessed | NOT_ASSESSED |
+| Soma location | Paraventricular hypothalamic nucleus [MBA:38] | 175/645 cells in PVN, additional 74 in adjacent anterior hypothalamic nucleus | CLUS_2366: 17/64 cells in PVN, region_fraction_100um=0.810 | CONSISTENT |
+| NT type | not asserted | not asserted (Glut at cluster level) | Glut | NOT_ASSESSED |
+| Crhr1 expression | defining marker | mean 0.84 (atlas-internal; minority subset) | not available | NOT_ASSESSED |
+| Esr1 expression | defining marker (moderate) | mean 3.65 (DEFINING_SCOPED atlas marker) | not available | NOT_ASSESSED |
+| Ar expression | defining marker (high) | mean 4.95 | not available | NOT_ASSESSED |
+| Sex ratio | male-biased | not available | not available | NOT_ASSESSED |
+
+*(Atlas Crhr1 mean of 0.84 across SUPT_0585 was reported by Stage A discovery — see Supporting evidence below. Per-child-cluster Crhr1, Esr1, and Ar means were not extracted into property_comparisons, so cluster-level alignment is not resolvable from the current facts.)*
 
 **Table 2 — Evidence support.**
 
 | Evidence | Type | Supports | Headline | Source |
 |---|---|---|---|---|
-| SUPT_0585 atlas metadata (PVN n=98; Crhr1/Esr1/Ar; rank-1 DB score=3) | Atlas metadata | PARTIAL | MBA:38 n=98; Crhr1=0.84; Esr1=3.65 (DEFINING_SCOPED); Ar=4.95; Crh=2.5 | atlas-internal |
+| Atlas precomputed expression + location | Atlas metadata | PARTIAL | Esr1=3.65 (DEFINING_SCOPED), Ar=4.95, Crh=2.5, Crhr1=0.84; 175/645 PVN cells | atlas-internal |
 
-*(Child-cluster breakdown not assessed — see proposed experiments. Note: rank-0 candidate CLUS_2382, child of SUPT_0589, has male_female_ratio=2.7 consistent with male-biased dimorphism, suggesting SUPT_0589 is an alternative or co-equal mapping target.)*
+**Supporting evidence**
 
----
+- **Atlas metadata (atlas-internal):** SUPT_0585 has Paraventricular hypothalamic nucleus [MBA:38] as primary painted location (175 of 645 cells, region_fraction_100um=0.665). It is the highest-ranked rank-1 candidate within the PVN region cohort. The steroid-receptor profile reported by Rosinger 2019 — moderate Esr1, high Ar — aligns with atlas-internal precomputed means Esr1=3.65 (also a DEFINING_SCOPED atlas marker on this supertype) and Ar=4.95. Crh=2.5 is consistent with the PVN neuroendocrine identity of this supertype.
 
+**Marker evidence provenance**
 
+- **Crhr1.** Established as the defining marker by Rosinger 2019 [1] using a Crhr1 reporter mouse line, with morphological localization to PVN and quantitative cell counts by sex. Single-study evidence at protein level (via the reporter). Crhr1 is absent from the Stage A expression_detail and from the precomputed_expression block on the candidate supertype, so transcript-level cross-check is not currently possible. Atlas-internal Crhr1 mean of 0.84 on SUPT_0585 indicates Crhr1+ cells are a minority of the supertype — consistent with a receptor-defined subpopulation embedded within a broader PVN glutamatergic supertype, but not direct concordance.
+- **Esr1.** Reported by Rosinger 2019 [1] as moderately co-expressed with the Crhr1 reporter via immunohistochemistry — protein-level evidence on the morphologically confirmed PVN CRFR1+ population. Atlas-side Esr1 mean=3.65 on SUPT_0585 (DEFINING_SCOPED) is broadly consistent, but does not establish that the Esr1-high cells within SUPT_0585 are the same subset as the Crhr1+ cells.
+- **Ar.** Reported by Rosinger 2019 [1] as highly co-expressed at protein level (immunohistochemistry on reporter-positive cells). Atlas-side Ar mean=4.95 is consistent. As with Esr1, supertype-level concordance does not resolve whether the Crhr1+ subset specifically carries the high Ar signal.
 
-### 0585 PVH-SO-PVa Otp Glut_1 [CS20230722_SUPT_0585] · 🟡 MODERATE
+**Concerns**
 
-### Supporting evidence
+- **Single primary source.** All marker, location, and dimorphism claims rest on Rosinger 2019 [1]. Caveat `SINGLE_DATASET` on the edge caps achievable confidence at MODERATE pending replication; in the absence of any transcriptomic confirmation it is currently LOW.
+- **Subset embedding.** Atlas Crhr1 mean of 0.84 across SUPT_0585 implies CRFR1+ cells are a small fraction of this supertype. The mapping is therefore one-to-subset rather than one-to-one with the supertype as a whole.
+- **Sister supertype ambiguity.** The unresolved question carried on the edge ("Is SUPT_0589 a better or co-equal mapping target?") notes that the rank-0 candidate cluster CLUS_2382 (parent SUPT_0589) carries a male-biased sex ratio of 2.7, consistent with the dimorphism reported by Rosinger 2019. CLUS_2382 / SUPT_0589 do not currently appear as edges on this node in the graph; they should be emitted at both ranks before any further mapping pass.
+- **Sex-ratio not assessed at supertype level.** Male/female ratios are only computed at cluster level (rank 0), so the supertype-level evidence cannot directly confirm the male-bias signature.
 
-- **Direct PVN soma location match.** SUPT_0585 (PVH-SO-PVa Otp Glut_1) has Paraventricular
-  hypothalamic nucleus [MBA:38] as its primary location with n=98 cells, providing CONSISTENT
-  anatomical alignment with the classical node's PVN soma criterion [1].
-- **Steroid hormone receptor co-expression strongly supported.** Precomputed mean expression
-  Esr1=3.65 (a DEFINING_SCOPED atlas marker for SUPT_0585) and Ar=4.95 directly support the
-  classical node's defining estrogen receptor alpha (moderate) and androgen receptor (high)
-  co-expression profile. The relative magnitudes — Ar > Esr1 — are consistent with the
-  "high androgen receptor / moderate ERα" pattern reported in [1].
-- **Glutamatergic identity is concordant.** The supertype carries a Glut label (PVH-SO-PVa Otp
-  Glut), consistent with the predominantly glutamatergic phenotype expected of PVN principal
-  neurons. The classical node does not specify NT type, but glutamatergic identity is the
-  expected default for non-magnocellular PVN populations *(note: NT type not stated in [1];
-  glutamatergic is inferred from regional convention and the supertype Otp Glut label.)*
-- **Crh expression confirms PVN neuroendocrine identity.** Precomputed mean Crh = 2.5 within
-  SUPT_0585 confirms the supertype is part of the PVN CRH/neuroendocrine network, the expected
-  context in which CRFR1+ cells reside.
-- **Highest DB score among rank-1 candidates.** SUPT_0585 was selected as the best candidate
-  by DB score = 3, the highest among rank-1 PVN-localised supertypes.
+**What would upgrade confidence**
 
-### Marker evidence provenance
+- A transcriptomic experiment targeting Crhr1+ PVN cells (FACS-sorted from a Crhr1 reporter line or post-hoc immunostained after sequencing), with cluster-level annotation transfer to WMBv1, would convert the present location-and-steroid-receptor alignment into direct cell-identity evidence (target: F1 ≥ 0.7 at supertype, F1 ≥ 0.5 at cluster). Expected output: AnnotationTransferEvidence on the edge.
+- Per-child-cluster precomputed expression of Crhr1, Esr1, and Ar from the WMBv1 reference store, and per-cluster male/female ratio, would identify the best-matching child cluster within SUPT_0585 and discriminate it from SUPT_0586/0587/0589. Expected output: refreshed property_comparisons with cluster-level node_b_values.
+- A second primary literature source (replication of the PVN CRFR1 dimorphism, ideally via transcriptomic profiling) would lift the SINGLE_DATASET cap. Expected output: additional LiteratureEvidence on the classical node.
 
-- **Crhr1** — classical node evidence is from a CRFR1 reporter mouse line (transgenic
-  fluorescent reporter; protein-level cell counting) [1], with co-expression confirmed by
-  immunofluorescence (CRFR1-IR cells). Atlas precomputed Crhr1 = 0.84 is transcript-based
-  (10x Chromium). The atlas value is low — consistent with CRFR1+ neurons being a *subset*
-  of SUPT_0585 rather than the entire supertype. *(note: this is the expected pattern when a
-  classical type is defined by a sparsely expressed receptor whose protein is detectable by
-  reporter line but whose transcript is diluted across a heterogeneous transcriptomic
-  supertype.)* No data-source contradiction; the discrepancy reflects scope, not absence.
-- **Esr1** — classical node evidence is protein-level (ERα immunoreactivity co-localisation
-  with CRFR1) [1]. Atlas precomputed Esr1 = 3.65 is transcript-based and listed as a
-  DEFINING_SCOPED atlas marker for SUPT_0585. Strong cross-modal agreement.
-- **Ar** — classical node evidence is protein-level (androgen receptor immunoreactivity
-  co-localisation with CRFR1, "high" co-expression) [1]. Atlas precomputed Ar = 4.95 is
-  transcript-based and is the highest of the three steroid-related markers, in agreement with
-  the "high" qualitative ranking in [1]. Strong cross-modal agreement.
-- **Single-source caveat.** All three defining markers (Crhr1, Esr1, Ar) and the soma location
-  are sourced from a single primary study (Rosinger 2019, PMID:31055007). Marker provenance is
-  internally consistent but lacks independent literature replication.
+### Property alignment + Evidence support — 2366 PVH-SO-PVa Otp Glut_1 [CS20230722_CLUS_2366] · 🔴 LOW
 
-### Concerns
+**Table 1 — Property comparison.**
 
-- **Crhr1 expression is low at supertype level (APPROXIMATE).** Precomputed mean Crhr1 = 0.84
-  indicates CRFR1+ neurons are a minority subset of SUPT_0585. Mapping at supertype resolution
-  averages the CRFR1 signal across many cells, most of which may not express Crhr1.
-  Cluster-level resolution would be required to identify the specific Crhr1-enriched
-  subpopulation. *(weak counter-evidence — expected pattern for a subset-defining marker.)*
-- **Sex ratio not available at supertype level.** Male-biased sex dimorphism — a defining
-  feature of pvn_crfr1_neuron [1] — cannot be assessed from supertype-level metadata
-  (male_female_ratio is computed only at rank 0). The rank-0 candidate CLUS_2382 (parent
-  SUPT_0589, *not* SUPT_0585) shows male_female_ratio = 2.7, consistent with male-biased
-  dimorphism — raising the possibility that SUPT_0589 is a better or co-equal mapping target.
-- **Alternative supertype (SUPT_0589) not yet assessed in detail.** Because the male-biased
-  child cluster CLUS_2382 belongs to SUPT_0589 rather than SUPT_0585, curator review is needed
-  to determine whether SUPT_0589 should be added as a co-equal or preferred mapping edge.
-- **Single-dataset characterisation.** All classical-node evidence is from Rosinger 2019
-  (PMID:31055007). Confidence is capped at MODERATE pending secondary literature validation.
-- **Annotation transfer NOT_ASSESSED.** No independent, data-driven cell-level mapping of
-  CRFR1+ PVN cells to WMBv1 has been run.
+| Property | Classical | Cluster (this row) | Alignment |
+|---|---|---|---|
+| Soma location | Paraventricular hypothalamic nucleus [MBA:38] | 17/64 cells in PVN; an additional 15 in PVN descending division; region_fraction_100um=0.810 | CONSISTENT |
+| NT type | not asserted | Glut | NOT_ASSESSED |
+| Crhr1 expression | defining marker | no atlas expression data | NOT_ASSESSED |
+| Esr1 expression | defining marker | no atlas expression data | NOT_ASSESSED |
+| Ar expression | defining marker | no atlas expression data | NOT_ASSESSED |
+| Sex ratio | male-biased | not available | NOT_ASSESSED |
 
-### What would upgrade confidence
+**Table 2 — Evidence support.**
 
-- **Child-cluster expression analysis of SUPT_0585** to identify the specific cluster(s)
-  combining peak Crhr1 expression with male-biased sex ratio (male_female_ratio > 1) would
-  resolve unresolved question 1 and clarify whether the CRFR1 subset is concentrated in one
-  child cluster. Expected output: refined `MappingEdge` at cluster level with stronger
-  Crhr1 alignment and (where MFR is available) CONSISTENT sex-ratio support.
-- **Comparative assessment of SUPT_0589** (parent of male-biased CLUS_2382, MFR=2.7) against
-  SUPT_0585 to determine whether SUPT_0589 is a better or co-equal mapping target. Expected
-  output: an additional `MappingEdge` to SUPT_0589 with property comparisons documenting the
-  sex-ratio agreement.
-- **MapMyCells annotation transfer** of an external CRFR1-reporter or Crhr1+ FACS-sorted PVN
-  scRNA-seq dataset against WMBv1 at cluster resolution; F1 ≥ 0.50 at the supertype level
-  would upgrade this edge. Expected output: `AnnotationTransferEvidence`.
-- **Targeted cite-traverse** for primary studies independently profiling PVN Crhr1+ neurons
-  (scRNA-seq, RNAscope, or alternative reporter lines) would address the SINGLE_DATASET caveat
-  and could promote confidence beyond MODERATE.
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas location | Atlas metadata | PARTIAL | region_fraction_100um=0.810; 17/64 cells in PVN | atlas-internal |
+
+**Supporting evidence**
+
+- **Atlas metadata (atlas-internal):** CLUS_2366 is the highest-scoring rank-0 (cluster) candidate within the MBA:38 cohort, with the tightest PVN proximity (region_fraction_100um=0.810) of any candidate cluster within SUPT_0585's children that surfaced. As a child of the primary supertype it is the natural cluster-level entry point.
+
+**Concerns**
+
+- **No marker evidence at cluster level.** Crhr1, Esr1, and Ar are all absent from the cluster's atlas expression panel; the cluster-level call rests entirely on location and on parent-supertype steroid-receptor concordance.
+- **Small absolute cell count.** n=64 cells at this cluster reduces statistical power for any per-cluster sex-ratio or marker assessment.
+- **No direct evidence that CLUS_2366 captures the male-biased CRFR1+ subset rather than another fraction of SUPT_0585.** The supertype-internal heterogeneity flagged by the parent edge (CRFR1+ as a minority subset) cannot be resolved from existing facts.
+
+**What would upgrade confidence**
+
+- Per-cluster precomputed Crhr1, Esr1, Ar means and per-cluster male/female ratio for all children of SUPT_0585 (and of sister supertypes 0586/0587/0589), to identify which child cluster carries both the steroid-receptor signature and the male bias.
+- Annotation transfer from a Crhr1+ PVN sorted/captured dataset against WMBv1 at cluster level (target: F1 ≥ 0.5 with CLUS_2366 as the best cluster).
+
+### Property alignment + Evidence support — 0587 PVH-SO-PVa Otp Glut_3 [CS20230722_SUPT_0587] · 🔴 LOW
+
+**Table 1 — Property comparison.**
+
+| Property | Classical | Supertype | Alignment |
+|---|---|---|---|
+| Soma location | Paraventricular hypothalamic nucleus [MBA:38] | 472/2093 cells in PVN, 139 in PVN descending division; region_fraction_100um=0.975 | CONSISTENT |
+| NT type | not asserted | not asserted (atlas Glut at lower levels) | NOT_ASSESSED |
+| Crhr1 / Esr1 / Ar expression | defining markers | no atlas expression data on this edge | NOT_ASSESSED |
+| Sex ratio | male-biased | not available | NOT_ASSESSED |
+
+**Table 2 — Evidence support.**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas location | Atlas metadata | PARTIAL | region_fraction_100um=0.975; 472/2093 PVN cells | atlas-internal |
+
+**Supporting evidence**
+
+- **Atlas metadata (atlas-internal):** SUPT_0587 carries the cleanest PVN spatial fingerprint of any candidate (region_fraction_100um=0.975), with the largest absolute count of PVN-located cells. It is a sister supertype to the primary candidate SUPT_0585 within the broader PVH-SO-PVa Otp Glut subclass and therefore plausibly carries part of the CRFR1+ population.
+
+**Concerns**
+
+- **No steroid-receptor concordance carried forward.** Unlike SUPT_0585, this edge does not record atlas-side Esr1 / Ar / Crh expression values, so the receptor-profile bridge from Rosinger 2019 [1] to atlas data is not available here. Without that bridge, the candidate is supported by location alone.
+- **The cell type is a receptor-defined subset, not a region.** Higher PVN spatial enrichment alone does not establish identity with the Crhr1+ dimorphic population; the SUPT_0585 candidate's stronger steroid-receptor signature is currently the better biological bridge.
+
+**What would upgrade confidence**
+
+- Atlas-side Crhr1, Esr1, Ar means and sex ratio for SUPT_0587 and its child clusters, comparable to the data already available on SUPT_0585. If Esr1 and Ar are also elevated on SUPT_0587, this candidate would rise to co-equal status with SUPT_0585.
+- Annotation transfer from a Crhr1+ PVN dataset; if cells distribute across both SUPT_0585 and SUPT_0587, that would support a one-to-many broadMatch onto the PVH-SO-PVa Otp Glut subclass rather than to either supertype alone.
+
+<details>
+<summary>Candidates audited (full top-K)</summary>
+
+| WMBv1 target | Supertype | Cells (10x) | Confidence | Key evidence | Verdict |
+|---|---|---:|---|---|---|
+| 0585 PVH-SO-PVa Otp Glut_1 [CS20230722_SUPT_0585] | — | 645 | 🔴 LOW | PVN location; Esr1=3.65, Ar=4.95, Crh=2.5 (atlas) | Primary |
+| 2366 PVH-SO-PVa Otp Glut_1 [CS20230722_CLUS_2366] | 0585 PVH-SO-PVa Otp Glut_1 | 64 | 🔴 LOW | Best child of SUPT_0585; PVN region_fraction_100um=0.810 | Secondary (best child within primary) |
+| 0587 PVH-SO-PVa Otp Glut_3 [CS20230722_SUPT_0587] | — | 2093 | 🔴 LOW | Highest PVN spatial enrichment (0.975); no marker bridge | Co-equal location candidate |
+| 0585 PVH-SO-PVa Otp Glut_1 [CS20230722_SUPT_0585] (duplicate edge) | — | 645 | ⚪ UNCERTAIN | Impoverished duplicate of primary edge | Eliminated (legacy/fresh-emit ID collision; merge upstream) |
+| 0586 PVH-SO-PVa Otp Glut_2 [CS20230722_SUPT_0586] | — | 744 | ⚪ UNCERTAIN | PVN location only; no marker bridge | Eliminated (no steroid-receptor evidence) |
+| 1549 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1549] | 0423 BST-MPN Six3 Nrgn Gaba_4 | 218 | ⚪ UNCERTAIN | GABAergic; primarily BST/medial preoptic | Eliminated (wrong subclass; GABA not glutamatergic) |
+| 1550 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1550] | 0423 BST-MPN Six3 Nrgn Gaba_4 | 215 | ⚪ UNCERTAIN | GABAergic; primarily medial preoptic | Eliminated (wrong subclass) |
+| 1561 BST-MPN Six3 Nrgn Gaba_6 [CS20230722_CLUS_1561] | 0425 BST-MPN Six3 Nrgn Gaba_6 | 282 | ⚪ UNCERTAIN | GABAergic; weak PVN proximity (0.378) | Eliminated (wrong subclass; weak location) |
+| 1563 BST-MPN Six3 Nrgn Gaba_6 [CS20230722_CLUS_1563] | 0425 BST-MPN Six3 Nrgn Gaba_6 | 157 | ⚪ UNCERTAIN | GABAergic; very weak PVN proximity (0.111) | Eliminated (wrong subclass; distant region) |
+| 0414 PVR Six3 Sox3 Gaba_4 [CS20230722_SUPT_0414] | — | 388 | 🔴 REFUTED | DISCORDANT location; striatum/pallidum dominant | Eliminated (distant region) |
+| 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] | — | 933 | 🔴 REFUTED | DISCORDANT location; periventricular preoptic, MPN | Eliminated (preoptic, not PVN) |
+
+</details>
 
 ---
 
@@ -166,17 +171,31 @@ supertypes.
 <details>
 <summary>Data sources, analyses, and reproducibility receipts</summary>
 
-**Classical type definition.** See classical type table in Introduction; defining_basis on the classical node and per-property literature support are listed there. The KB-side definition lives at the source graph file linked in the reproducibility footer.
+**Classical type definition.** PVN CRFR1 neurons are defined by Crhr1 receptor expression in the paraventricular hypothalamic nucleus [MBA:38], with co-expression of Esr1 (moderate) and Ar (high), and a male-biased sex ratio that emerges at puberty and is androgen-sensitive in adulthood (`definition_basis: CLASSICAL_NEUROCHEMICAL`) [1].
 
-**Atlas mapping query.** Candidate atlas clusters were retrieved from CCN20230722 at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias). Full scoring rules: `workflows/map-cell-type.md`.
+**Atlas mapping query.** Candidate atlas clusters were retrieved from the WMBv1 taxonomy (CCN20230722) at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match against MBA:38, NT type, defining markers, sex bias when applicable). Full scoring rules: `workflows/map-cell-type.md`.
 
-**Property alignment.** Each defining property was compared to the corresponding atlas-side value via the `property_comparisons` schema; alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
+**Property alignment.** Each defining property of the classical type was compared to the corresponding atlas-side value via the `property_comparisons` schema, with alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from spatial registration for soma location.
 
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote. Specific mapping limitations and caveats are documented per-candidate in the Discussion section.
 
+*Generated by evidencell `25c2b32` at 2026-06-08T18:14:07+00:00 from [kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml](kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
 
-**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote.
+**Evidence base table.**
 
-*Generated by evidencell `0c97cfa` from [`kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`](../../kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+| Edge ID | Evidence types | Supports | Source |
+| --- | --- | --- | --- |
+| edge_pvn_crfr1_neuron_to_cs20230722_supt_0585 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pvn_crfr1_neuron_to_CS20230722_CLUS_2366 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1549 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1550 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1561 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1563 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0585 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0587 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0586 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0414 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0486 | ATLAS_METADATA | PARTIAL | atlas-internal |
 
 </details>
 
@@ -184,69 +203,40 @@ supertypes.
 
 ## Discussion
 
-**Primary mapping:** → 0585 PVH-SO-PVa Otp Glut_1 [CS20230722_SUPT_0585] at MODERATE confidence. Key support: ATLAS_METADATA (PVN/SO/PVa anatomy match; Otp Glut subclass consistent with neuroendocrine PVN identity). Key caveats: `MARKER_NOT_SPECIFIC` (Crhr1 expression not directly resolvable in atlas metadata).
+**Primary mapping:** PVN corticotropin-releasing factor receptor 1 (CRFR1) neuron → 0585 PVH-SO-PVa Otp Glut_1 [CS20230722_SUPT_0585] at LOW confidence. Key support: PVN soma location alignment plus atlas-internal concordance of Esr1 (3.65, DEFINING_SCOPED) and Ar (4.95) with the steroid-receptor profile reported by Rosinger 2019 [1]. Key caveats: SINGLE_DATASET (the classical type rests entirely on one primary source), and AMBIGUOUS_MAPPING (Crhr1 mean of 0.84 on the supertype indicates CRFR1+ cells are a minority subset, and sister supertype SUPT_0589 — not currently edged on this node — carries a male-biased child cluster that should be assessed in parallel).
 
-No Cell Ontology term currently assigned for this classical type.
+corticotropin-releasing neuron [[CL:4072021](https://www.ebi.ac.uk/ols4/ontologies/cl/classes?obo_id=CL:4072021)] is a related but non-identical Cell Ontology term. CL:4072021 defines neurons by CRH **secretion**, whereas the PVN CRFR1 node is defined by CRFR1 **receptor** expression — these are biologically distinct populations: CRFR1+ PVN neurons receive CRH input, they do not necessarily secrete CRH. The mapping is RELATED only, and no CL term for CRFR1-receptor-expressing neurons currently exists; this type is a candidate for a new CL term.
 
 ### Proposed experiments and follow-ups
 
-### 1. Child-cluster expression analysis of SUPT_0585 (and SUPT_0589) for Crhr1 and male-biased MFR
+1. **Targeted transcriptomic profiling of Crhr1+ PVN cells.**
+   - **What:** capture Crhr1-expressing PVN cells (Crhr1 reporter line FACS, or post-hoc immunostaining of sequenced PVN cells) and run cluster-level annotation transfer against WMBv1.
+   - **Target:** F1 ≥ 0.7 at supertype, F1 ≥ 0.5 at cluster.
+   - **Expected output:** AnnotationTransferEvidence on the primary edge.
+   - **Resolves:** primary mapping confidence (currently LOW); open questions 1 and 2 below.
 
-**What:** For each child cluster of SUPT_0585 and SUPT_0589, retrieve precomputed
-mean_expression for Crhr1, Esr1, Ar, and male_female_ratio. Identify cluster(s) with peak
-Crhr1 combined with MFR > 1.
+2. **Per-child-cluster expression and sex-ratio extraction within candidate supertypes.**
+   - **What:** pull precomputed Crhr1, Esr1, Ar means and male/female ratio for every child cluster of SUPT_0585, SUPT_0586, SUPT_0587, and SUPT_0589 from the WMBv1 reference store.
+   - **Target:** identify the child cluster with combined high Crhr1, elevated Esr1 + Ar, and male-biased ratio.
+   - **Expected output:** refreshed property_comparisons; possible upgrade of CLUS_2366 (or a sibling cluster) to MODERATE.
+   - **Resolves:** open question 1.
 
-**Target:** At least one cluster with Crhr1 ≥ supertype mean and MFR ≥ 1.5 (male-biased).
+3. **Emit candidate edges for SUPT_0589 and its child cluster CLUS_2382.**
+   - **What:** run `just emit-stage-b` for SUPT_0589 (rank 1) and CLUS_2382 (rank 0). The current evidence (CLUS_2382 male/female ratio 2.7) suggests SUPT_0589 is a co-equal target for the male-biased CRFR1+ population but is not currently edged on this node.
+   - **Expected output:** two new MappingEdge entries, then re-run mapping assessment.
+   - **Resolves:** open question 2.
 
-**Expected output:** A refined `MappingEdge` at cluster level (rank 0) with stronger
-Crhr1 alignment and CONSISTENT sex-ratio support.
-
-**Resolves:** Open questions 1 and 2.
-
-### 2. MapMyCells annotation transfer of an external CRFR1+ PVN scRNA-seq dataset against WMBv1
-
-**What:** Retrieve a published scRNA-seq dataset enriched for PVN CRFR1+ neurons
-(e.g., Crhr1-Cre or CRFR1-reporter sorted preparations, sex-stratified). Run MapMyCells
-against WMBv1 at cluster resolution.
-
-**Target:** F1 ≥ 0.50 at SUPT_0585 (or SUPT_0589) level; F1 ≥ 0.80 at the best child cluster.
-
-**Expected output:** `AnnotationTransferEvidence` entry on the edge, atlas: WMBv1, tool:
-MapMyCells, output: F1 matrix per cluster.
-
-**Resolves:** The annotation_transfer_f1 NOT_ASSESSED gap and questions 1–2.
-
-### 3. Targeted cite-traverse for secondary literature on PVN Crhr1+ neurons
-
-**What:** Run a `cite-traverse` skill query for primary studies independently profiling PVN
-Crhr1+ neurons (scRNA-seq, RNAscope, alternative reporter lines, or sex-stratified
-characterisations).
-
-**Target:** At least one independent primary study (non-Rosinger) describing PVN Crhr1+
-neuron molecular profile or sex dimorphism.
-
-**Expected output:** Additional `LiteratureEvidence` entries; lifts the SINGLE_DATASET caveat
-and could support upgrading confidence beyond MODERATE.
-
-**Resolves:** SINGLE_DATASET caveat.
-
----
+4. **Replication of PVN CRFR1 sexual dimorphism.**
+   - **What:** secondary literature search (cite-traverse) for independent confirmation of the male-biased Crhr1 distribution in PVN, ideally via a transcriptomic or in-situ hybridization study.
+   - **Expected output:** additional LiteratureEvidence on the classical node.
+   - **Resolves:** SINGLE_DATASET caveat.
 
 ### Open questions
 
-1. Which cluster within the PVH-SO-PVa Otp Glut subclass shows highest Crhr1 expression
-   combined with male-biased sex ratio?
-2. Is SUPT_0589 a better or co-equal mapping target compared to SUPT_0585? *(The rank-0
-   candidate CLUS_2382, with male_female_ratio = 2.7 consistent with male-biased dimorphism,
-   is a child of SUPT_0589 rather than SUPT_0585.)*
-
----
-
-### Evidence base
-
-| Edge ID | Evidence type | Supports |
-|---|---|---|
-| edge_pvn_crfr1_neuron_to_cs20230722_supt_0585 | ATLAS_METADATA | PARTIAL — MBA:38 PVN n=98 (primary); Crhr1=0.84 (low, subset); Esr1=3.65 (DEFINING_SCOPED); Ar=4.95; Crh=2.5; rank-1 DB score=3 |
+1. Which cluster within the PVH-SO-PVa Otp Glut subclass shows the highest Crhr1 expression combined with male-biased sex ratio?
+2. Is SUPT_0589 (parent of male-biased CLUS_2382, ratio 2.7) a better or co-equal mapping target compared to SUPT_0585?
+3. Does the CRFR1+ population distribute across multiple sister supertypes within the PVH-SO-PVa Otp Glut subclass (supporting a broadMatch onto the subclass) or concentrate in one supertype (supporting a closeMatch)?
+4. Curator follow-up: resolve the legacy/fresh-emit duplicate-ID collision on SUPT_0585 (`edge_pvn_crfr1_neuron_to_cs20230722_supt_0585` carries substantive evidence; `edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0585` is impoverished and should be removed).
 
 ---
 
@@ -254,4 +244,324 @@ and could support upgrading confidence beyond MODERATE.
 
 | # | Citation | PMID | Used for |
 |---|---|---|---|
-| [1] | Rosinger et al. 2019 | [PMID:31055007](https://pubmed.ncbi.nlm.nih.gov/31055007/) | Soma location (PVN); Crhr1, Esr1, Ar markers; male-biased sex dimorphism; gonadectomy and stress-activation findings |
+| [1] | Rosinger et al. 2019 — A sexually dimorphic distribution of corticotropin-releasing factor receptor 1 in the paraventricular hypothalamus | [31055007](https://pubmed.ncbi.nlm.nih.gov/31055007/) | soma location, defining markers (Crhr1, Esr1, Ar), male-biased dimorphism, pubertal emergence, gonadectomy effect |
+
+---
+
+<!-- verdict-block-start: edge_pvn_crfr1_neuron_to_cs20230722_supt_0585 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.35
+  relationship: skos:broadMatch
+  mapping_cardinality: "1:n"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:STRONGEST] PVN soma location (175/645 cells in MBA:38) and
+    atlas-internal Esr1=3.65 (DEFINING_SCOPED) plus Ar=4.95 align with the
+    moderate-Esr1 / high-Ar steroid-receptor profile reported by Rosinger
+    2019; however, atlas-internal Crhr1 mean of 0.84 indicates the
+    defining-marker-positive population is a minority subset of this
+    supertype, capping confidence at LOW pending direct transcriptomic
+    confirmation.
+  reconciliation_note: >
+    Paired with secondary candidate CLUS_2366 (best child cluster within
+    this supertype by PVN proximity). Sister supertype SUPT_0589 is
+    flagged as a co-equal candidate via its male-biased child CLUS_2382
+    (ratio 2.7) but is not currently edged on this node; emit and
+    re-assess.
+  caveats:
+    - caveat_type: SINGLE_DATASET
+      description: >
+        Classical type rests on a single primary source (Rosinger 2019,
+        PMID:31055007). Confidence capped at MODERATE pending secondary
+        literature validation; currently LOW because no transcriptomic
+        confirmation of Crhr1 on the candidate supertype is available.
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Atlas-internal Crhr1 mean of 0.84 across SUPT_0585 indicates
+        CRFR1+ cells are a minority subset. SUPT_0589 (parent of
+        male-biased CLUS_2382, ratio 2.7) is an alternative or
+        co-equal mapping target requiring assessment.
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Per-child-cluster Crhr1, Esr1, Ar expression and per-cluster
+        sex ratio are not in property_comparisons, so the best child
+        cluster within SUPT_0585 cannot be resolved from current
+        facts.
+  proposed_experiments:
+    - >
+      Crhr1-targeted transcriptomic profiling of PVN cells (Crhr1
+      reporter line FACS or post-hoc immunostained sequencing) with
+      cluster annotation transfer to WMBv1; target F1 >= 0.7 at
+      supertype, F1 >= 0.5 at cluster.
+    - >
+      Extract per-child-cluster precomputed Crhr1 / Esr1 / Ar means
+      and male/female ratio for SUPT_0585, SUPT_0586, SUPT_0587, and
+      SUPT_0589 from the WMBv1 reference store; identify the cluster
+      with combined receptor signature and male bias.
+    - >
+      Emit candidate edges for SUPT_0589 (rank 1) and CLUS_2382
+      (rank 0) and re-run mapping assessment; CLUS_2382 male/female
+      ratio of 2.7 suggests co-equal candidacy with SUPT_0585.
+    - >
+      Secondary literature search for independent confirmation of
+      the PVN CRFR1 male-biased dimorphism, ideally via
+      transcriptomic or in-situ hybridization data.
+  unresolved_questions:
+    - >
+      Which cluster within the PVH-SO-PVa Otp Glut subclass shows
+      highest Crhr1 expression combined with male-biased sex ratio?
+    - >
+      Is SUPT_0589 a better or co-equal mapping target compared to
+      SUPT_0585?
+    - >
+      Does the CRFR1+ population concentrate in one supertype or
+      distribute across the PVH-SO-PVa Otp Glut subclass (supporting
+      broadMatch onto the subclass rather than to a single supertype)?
+    - >
+      Curator removal of duplicate edge
+      edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0585 — legacy/fresh-emit
+      ID collision on taxonomy_type CS20230722_SUPT_0585.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pvn_crfr1_neuron_to_CS20230722_CLUS_2366 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.30
+  relationship: skos:closeMatch
+  mapping_cardinality: "1:1"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:NEXT] Best child cluster of the primary supertype SUPT_0585 by
+    PVN proximity (region_fraction_100um=0.810; 17 of 64 cells in MBA:38);
+    selected as the cluster-level entry point for the primary mapping
+    pending direct receptor-targeted evidence.
+  reconciliation_note: >
+    Paired with primary survivor SUPT_0585 (parent supertype, broadMatch
+    1:n). Cluster-level call rests on location alone; no atlas
+    expression data for Crhr1, Esr1, or Ar on this cluster.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Cluster-level Crhr1 / Esr1 / Ar means and male/female ratio
+        are not available in property_comparisons; cannot confirm
+        this cluster carries the receptor-defined male-biased subset
+        rather than another fraction of SUPT_0585.
+    - caveat_type: SINGLE_DATASET
+      description: >
+        Inherits the SINGLE_DATASET cap of the classical node
+        (Rosinger 2019 only).
+  proposed_experiments:
+    - >
+      Per-cluster Crhr1, Esr1, Ar expression and male/female ratio
+      pull for all children of SUPT_0585, comparing CLUS_2366 against
+      siblings.
+    - >
+      Crhr1-targeted annotation transfer (see primary edge); confirm
+      CLUS_2366 as best cluster at F1 >= 0.5.
+  unresolved_questions:
+    - >
+      Does CLUS_2366 specifically capture the male-biased CRFR1+ subset
+      of SUPT_0585, or is the subset distributed across multiple
+      sibling clusters?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0587 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.25
+  rationale: >
+    [tier:WEAKEST] Highest PVN spatial enrichment (region_fraction_100um
+    =0.975; 472/2093 PVN cells) of any candidate, but lacks the
+    steroid-receptor expression bridge that supports the primary
+    SUPT_0585 call. Co-equal location candidate pending atlas
+    Crhr1/Esr1/Ar pull.
+  reconciliation_note: >
+    Alternative to primary SUPT_0585 within the same PVH-SO-PVa Otp
+    Glut subclass. If atlas Esr1/Ar means on SUPT_0587 are also
+    elevated, this candidate rises to co-equal; in that case the
+    primary edge predicate may need migration to skos:broadMatch
+    onto the subclass.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        No atlas-side Esr1/Ar/Crh expression carried on this edge to
+        bridge to Rosinger 2019 steroid-receptor profile. Location
+        alone is insufficient because the cell type is defined by
+        receptor expression, not by region.
+    - caveat_type: SINGLE_DATASET
+      description: >
+        Inherits the SINGLE_DATASET cap of the classical node
+        (Rosinger 2019 only).
+  proposed_experiments:
+    - >
+      Pull atlas-internal Crhr1, Esr1, Ar means and child-cluster
+      sex ratios for SUPT_0587, comparable to the data on SUPT_0585.
+    - >
+      Crhr1-targeted annotation transfer (see primary edge); if
+      cells distribute across SUPT_0585 and SUPT_0587, migrate
+      primary predicate to broadMatch onto the parent subclass.
+  unresolved_questions:
+    - >
+      Is SUPT_0587 a co-equal candidate to SUPT_0585 once atlas
+      steroid-receptor expression is assessed?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0585 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] Impoverished duplicate of
+    edge_pvn_crfr1_neuron_to_cs20230722_supt_0585 (same taxonomy_type
+    CS20230722_SUPT_0585; legacy/fresh-emit ID collision). Carries
+    only location data; the lowercase-id edge carries the substantive
+    Esr1/Ar/Crh atlas evidence and curator-authored caveats. Cut
+    pending curator removal.
+  caveats:
+    - caveat_type: OTHER
+      description: >
+        Duplicate edge — same taxonomy_type as
+        edge_pvn_crfr1_neuron_to_cs20230722_supt_0585. Schedule for
+        curator removal.
+  unresolved_questions:
+    - >
+      Curator removal of duplicate edge
+      edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0585 (uppercase id)
+      in favour of legacy edge with substantive evidence.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0586 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] Sister supertype within the PVH-SO-PVa Otp Glut subclass
+    with PVN location (region_fraction_100um=0.610) but no
+    steroid-receptor expression evidence carried on this edge; without
+    a marker bridge to Rosinger 2019, location alone is insufficient
+    for a receptor-defined type.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Same PVH-SO-PVa Otp Glut subclass as primary SUPT_0585; could
+        carry part of the CRFR1+ population but no atlas marker
+        evidence to support.
+  unresolved_questions:
+    - >
+      Does the CRFR1+ population also include SUPT_0586 (broader
+      subclass-level mapping)?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1549 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.10
+  rationale: >
+    [tier:CUT] GABAergic cluster in the BST-MPN Six3 Nrgn Gaba_4
+    supertype; wrong subclass for a PVN glutamatergic CRFR1+
+    neuroendocrine type. PVN proximity (region_fraction_100um=0.821)
+    reflects BST-MPN adjacency rather than identity.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        GABAergic and predominantly BST / medial preoptic; not the
+        PVN glutamatergic CRFR1+ population. Survives only on
+        location proximity.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1550 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.08
+  rationale: >
+    [tier:CUT] GABAergic cluster in the BST-MPN Six3 Nrgn Gaba_4
+    supertype; wrong subclass and primary location is medial preoptic
+    rather than PVN (region_fraction_100um=0.521).
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        GABAergic; primary spatial signal in medial preoptic
+        nucleus rather than PVN.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1561 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] GABAergic cluster in BST-MPN Six3 Nrgn Gaba_6 supertype;
+    wrong subclass and weak PVN proximity (region_fraction_100um=0.378
+    with strict region_fraction=0.083 — boundary scatter).
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        GABAergic; primary spatial signal in medial preoptic rather
+        than PVN.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1563 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.03
+  rationale: >
+    [tier:CUT] GABAergic cluster in BST-MPN Six3 Nrgn Gaba_6 supertype;
+    wrong subclass and very weak PVN proximity
+    (region_fraction_100um=0.111; striatum among top-3 locations).
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        GABAergic; spatial distribution into striatum is inconsistent
+        with the PVN neuroendocrine identity.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0414 -->
+```yaml
+verdict:
+  confidence: REFUTED
+  confidence_score: 0.02
+  rationale: >
+    [tier:CUT] DISCORDANT location — primary painted locations are
+    striatum and pallidum rather than PVN
+    (region_fraction_100um=0.040; strict region_fraction=0.011). Not
+    a PVN-resident population.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        DISCORDANT location; striatum / pallidum dominant.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0486 -->
+```yaml
+verdict:
+  confidence: REFUTED
+  confidence_score: 0.02
+  rationale: >
+    [tier:CUT] DISCORDANT location — primary painted locations are
+    periventricular preoptic and medial preoptic
+    (region_fraction_100um=0.020). Not PVN.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        DISCORDANT location; preoptic rather than paraventricular.
+```
+<!-- verdict-block-end -->

--- a/reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
+++ b/reports/sexually_dimorphic/sdn_poa_calbindin_neuron_summary.md
@@ -1,154 +1,191 @@
 # Sexually dimorphic nucleus of the preoptic area (SDN-POA) calbindin neuron — WMBv1 Mapping Report
-*draft · 2026-04-25 · Source: `kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
-
-**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+*2026-04-25 · Source: `kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
 
 ---
 
 ## Introduction
 
-### Classical type
+The sexually dimorphic nucleus of the preoptic area (SDN-POA) is a cytoarchitectonically defined cluster of cells in the medial preoptic area of the rodent hypothalamus, larger in males than in females and implicated in the control of male sex behaviour [1][2]. It is delineated histologically by Nissl staining or, more selectively, by calbindin-D28K immunoreactivity, and contains no tyrosine hydroxylase (TH)-positive somata although TH-positive axons and synaptic profiles traverse it [2]. The nucleus is regarded as the rodent homolog of the third interstitial nucleus of the anterior hypothalamus (INAH3) in humans and has counterparts in sheep, rhesus macaque, and quail [2]. Mapping the SDN-POA calbindin neuron onto the WMBv1 taxonomy is of interest because, despite a well-established histological identity, this population has no dedicated single-cell transcriptomic identity in current whole-mouse-brain atlases.
 
-The **sexually dimorphic nucleus of the preoptic area (SDN-POA) calbindin neuron** is
-defined by neurochemical and histological criteria: Calbindin-D28K (Calb1)
-immunoreactivity in a histologically delineable subnucleus within the rodent medial
-preoptic nucleus, with absence of tyrosine hydroxylase (TH) cell bodies. The structure
-is male-biased in cell number and is considered the rodent homolog of the third
-interstitial nucleus of the anterior hypothalamus (INAH3) in humans, with homologous
-structures described in sheep, rhesus monkey, and quail.
-
-No CL term currently exists for this population — it is a candidate for a new term.
+### 3. Classical type table
 
 | Property | Value | References |
 |---|---|---|
-| Soma location | Medial preoptic nucleus [MBA:515] (SDN-POA is a histologically defined subnucleus within MPN) | [1], [2] |
-| Defining markers | Calb1 (calbindin-D28K, protein, IHC) | [2] |
-| Negative markers | Th (no TH-positive cell bodies in SDN-POA) | [2] |
+| Soma location | Medial preoptic nucleus [MBA:515] (named in source as SDN-POA) | [1][2] |
+| Defining markers | Calb1 | [2] |
+| Negative markers | Th (somatic; axonal TH present) | [2] |
+| Definition basis | CLASSICAL_NEUROCHEMICAL | — |
 
 <details>
-<summary>Literature support — expand for verbatim quotes</summary>
+<summary>Details — source evidence for classical type properties</summary>
 
-**[1] Negri-Cesi 2015 · PMID:26672480 — Sexually Dimorphic Brain Regions and Structures**
+- **Soma location:** classical histology · rodent (rat/mouse) · [1][2]
+  > The 2 best known dimorphic brain structures are the sexual dimorphic nucleus of the medial preoptic hypothalamic area (SDN-POA) in rodents, which correspond to the interstitial nucleus of the anterior hypothalamus (INAH) in humans, and the anteroventral periventricular (AVPV) nucleus. The first one controls male sex behavior and is larger in males than in females; the second one is critical for the cyclic control of ovulation and is larger in females than in males.
+  > — Negri-Cesi 2015, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 14863067_fa51fcf7 -->
 
-> The 2 best known dimorphic brain structures are the sexual dimorphic nucleus of the medial preoptic hypothalamic area (SDN-POA) in rodents, which correspond to the interstitial nucleus of the anterior hypothalamus (INAH) in humans, and the anteroventral periventricular (AVPV) nucleus. The first one controls male sex behavior and is larger in males than in females; the second one is critical for the cyclic control of ovulation and is larger in females than in males.
-> — Negri-Cesi 2015, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 14863067_fa51fcf7 -->
+  > One of the well-defined sexually dimorphic structures in the brain is the sexually dimorphic nucleus, a cluster of cells located in the preoptic area of the hypothalamus. The rodent sexually dimorphic nucleus of the preoptic area can be delineated histologically using conventional Nissl staining or immunohistochemically using calbindin D28K immunoreactivity
+  > — He et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 3481177_d6c3a647 -->
 
-**[2] He et al. 2013 · PMID:25206587 — Sexually Dimorphic Brain Regions and Structures**
+- **Defining marker (Calb1):** calbindin-D28K immunohistochemistry · rodent · [2]
+  > The sexually dimorphic nucleus of the preoptic area is highlighted by calbindin-D28K immunoreactivity: no TH-positive cells were found, but fine axon-like projections/synaptic structures were seen
+  > — He et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 3481177_17d4bd9d -->
 
-> One of the well-defined sexually dimorphic structures in the brain is the sexually dimorphic nucleus, a cluster of cells located in the preoptic area of the hypothalamus. The rodent sexually dimorphic nucleus of the preoptic area can be delineated histologically using conventional Nissl staining or immunohistochemically using calbindin D28K immunoreactivity
-> — He et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 3481177_d6c3a647 -->
-
-**[2] He et al. 2013 · PMID:25206587 — Sexually Dimorphic Brain Regions and Structures (cross-species homology)**
-
-> The sexually dimorphic nucleus has been specifically defined in the brains of human and other mammalian and non-mammalian and includes the third interstitial nucleus of the anterior hypothalamus in humans (Allen et al., 1989)(Allen et al., 1990) , the ovine sexually dimorphic nucleus in the medial preoptic area (Roselli et al., 2004) , the medial preoptic and anterior hypothalamic regions in rhesus monkeys (Byne, 1998) , a specific area in the medial preoptic nucleus in quail (Viglietti‐Panzica et al., 1986) , and the sexually dimorphic nucleus of the preoptic area in rats (Gorski et al., 1978)(Gorski et al., 1980) . The human sexually dimorphic nucleus of the preoptic area is located in the medial part of the preoptic area, between the dorsolateral supraoptic nucleus and the rostral pole of the paraventricular nucleus (Hofman et al., 1989)
-> — He et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 3481177_1098a86b -->
-
-**[2] He et al. 2013 · PMID:25206587 — Calbindin/TH profile of SDN-POA**
-
-> The sexually dimorphic nucleus of the preoptic area is highlighted by calbindin-D28K immunoreactivity: no TH-positive cells were found, but fine axon-like projections/synaptic structures were seen
-> — He et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 3481177_17d4bd9d -->
+- **Cross-species homology context:** [2]
+  > The sexually dimorphic nucleus has been specifically defined in the brains of human and other mammalian and non-mammalian and includes the third interstitial nucleus of the anterior hypothalamus in humans (Allen et al., 1989)(Allen et al., 1990) , the ovine sexually dimorphic nucleus in the medial preoptic area (Roselli et al., 2004) , the medial preoptic and anterior hypothalamic regions in rhesus monkeys (Byne, 1998) , a specific area in the medial preoptic nucleus in quail (Viglietti‐Panzica et al., 1986) , and the sexually dimorphic nucleus of the preoptic area in rats (Gorski et al., 1978)(Gorski et al., 1980) . The human sexually dimorphic nucleus of the preoptic area is located in the medial part of the preoptic area, between the dorsolateral supraoptic nucleus and the rostral pole of the paraventricular nucleus (Hofman et al., 1989)
+  > — He et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 3481177_1098a86b -->
 
 </details>
+
+### 4. Cell Ontology mapping
+
+**No Cell Ontology term currently covers this type — candidate for a new CL term.**
+
+The classical node notes flag this as a candidate for a new CL term covering the rodent SDN-POA calbindin population and its cross-species homologs.
 
 ---
 
 ## Results
 
-### Mapping candidates
+Calbindin (Calb1)-expressing, male-biased candidate clusters in the medial preoptic nucleus [MBA:515] anchor a plausible but unconfirmed mapping to the BST-MPN Six3 Nrgn Gaba supertype family, with 0423 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_SUPT_0423] and its child 1550 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1550] offering the only MPN-primary supertype/cluster pair (see candidates table and property comparisons below). However, the SDN-POA is a histologically defined subnucleus within the broader medial preoptic nucleus and cannot be resolved as a distinct spatial domain in WMBv1 MERFISH data, so none of the candidate atlas clusters can be specifically equated with the SDN-POA itself.
 
-Two mapping edges are recorded for sdn_poa_calbindin_neuron: a supertype-level edge
-to SUPT_0423 and a cluster-level edge to CLUS_1550, the only child cluster of SUPT_0423
-whose primary soma is MBA:515 (MPN) and which carries an unambiguous male bias.
-Both edges are LOW confidence: SDN-POA is a histologically defined subnucleus within
-MPN that cannot be resolved as a distinct spatial domain in WMBv1 MERFISH data.
+### 4. Property alignment + Evidence support — Primary candidate pair (SUPT_0423 / CLUS_1550)
 
-| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
-|---|---|---|---|---|---|---|
-| 1 | 1550 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1550] | 0423 BST-MPN Six3 Nrgn Gaba_4 | 48 | 🔴 LOW | Calb1 CONSISTENT; MFR=3.35 CONSISTENT; Th DISCORDANT | Speculative |
-| 2 | 0423 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_SUPT_0423] | (self) | 336 | 🔴 LOW | Calb1 CONSISTENT; Th DISCORDANT | Speculative |
-2 edges total. Relationship type: PARTIAL_OVERLAP (CLUS_1550) / UNCERTAIN (SUPT_0423).
-
-### Property alignment — primary candidate (CLUS_1550)
-
-**Table 1 — Property comparison.**
+**Table 1 — Property comparison (0423 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_SUPT_0423] · supertype, and best child 1550 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1550]).**
 
 | Property | Classical | Supertype | Best cluster | Alignment |
 |---|---|---|---|---|
-| Soma location | Medial preoptic nucleus [MBA:515] (SDN-POA is histological subnucleus within MPN) | MBA:515 (MPN) n=47; also BNST n=18, AHN n=46, PVN n=31 | MBA:515 (MPN) n=22 (primary soma); also PVH n=9, PVHap n=4, Hypothalamus n=9 | APPROXIMATE (both levels) |
-| Calb1 expression | POSITIVE (protein, primary defining marker) | precomputed mean_expression=6.42 (DEFINING_SCOPED atlas marker) | precomputed mean_expression=6.66 | CONSISTENT (both levels) |
-| Th (negative marker) | ABSENT (negative marker; no TH cell bodies in SDN-POA) | precomputed mean_expression=0.99 | precomputed mean_expression=2.75 | DISCORDANT (both levels) |
-| Sex ratio | male-biased (SDN-POA larger in males; classical IHC) | not available at supertype level | MFR=3.35 (CLUS_1550) — male-biased | CONSISTENT |
-| Annotation transfer F1 | not applicable | NOT_ASSESSED | NOT_ASSESSED | NOT_ASSESSED |
+| Soma location | Medial preoptic nucleus [MBA:515] | MPN n=113 / Hypothalamus [MBA:1097] n=295 / AHN [MBA:88] n=86 (region_fraction_100um=0.336; strict=0.140) | MPN n=39 / Hypothalamus [MBA:1097] n=46 / PVH [MBA:38] n=25 (region_fraction_100um=0.812; strict=0.458) | SUPT: APPROXIMATE; CLUS: CONSISTENT |
+| NT type | not asserted | not asserted | GABA | NOT_ASSESSED |
+| Calb1 expression | defining marker | 6.42 (cohort pct 0.771; DEFINING_SCOPED; child-coverage 1.000) | 6.66 (cohort pct 0.704) | CONSISTENT (both) |
+| Th (negative) | absent in somata; axonal only | no atlas expression data | no atlas expression data | NOT_ASSESSED |
+| Sex ratio | male-biased | not available | MFR=3.35 (male-biased) | CONSISTENT |
 
-**Table 2 — Evidence support.**
+*(1 of 5 child clusters of SUPT_0423 — CLUS_1550 — shows MPN-primary location combined with male-biased MFR and high Calb1; the remaining children are not MPN-primary or were not surfaced in the candidates audit. Best match: CLUS_1550.)*
+
+**Table 2 — Evidence support (SUPT_0423 + CLUS_1550).**
 
 | Evidence | Type | Supports | Headline | Source |
 |---|---|---|---|---|
-| Atlas precomputed expression (CLUS_1550 Calb1/Th, MFR) | Atlas metadata | WEAK | Calb1=6.66; Th=2.75; MFR=3.35; MPN primary soma n=22 | atlas-internal |
-| SUPT_0423 atlas metadata (Calb1/Th, MBA:515 n=47) | Atlas metadata | WEAK | Calb1=6.42 (DEFINING_SCOPED); Th=0.99; MPN n=47 | atlas-internal |
+| Atlas precomputed expression + MERFISH location (SUPT_0423) | Atlas metadata | WEAK | Calb1=6.42 (DEFINING_SCOPED); MPN n=113 of 336 cells | atlas-internal |
+| Atlas precomputed expression + MERFISH location (CLUS_1550) | Atlas metadata | WEAK | Calb1=6.66; MPN-primary (39/85 in MBA:515); MFR=3.35 male-biased | atlas-internal |
 
-*(1 of an unreported number of child clusters of SUPT_0423 — CLUS_1550 — has MBA:515 (MPN) as primary soma and an unambiguous male-biased MFR; however, Th=2.75 at cluster level remains discordant with the classical Th NEGATIVE assertion, and the SDN-POA cytoarchitectonic zone cannot be resolved within MPN from MERFISH data alone. Best match: CLUS_1550.)*
+### 4. Property alignment + Evidence support — Secondary candidate (SUPT_0420)
 
----
+**Table 1 — Property comparison (0420 BST-MPN Six3 Nrgn Gaba_1 [CS20230722_SUPT_0420]).**
 
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Medial preoptic nucleus [MBA:515] | MPN n=289 / Hypothalamus [MBA:1097] n=315 / MPO [MBA:523] n=78 (region_fraction_100um=0.903; strict=0.759) | not assessed | CONSISTENT |
+| NT type | not asserted | not asserted | not assessed | NOT_ASSESSED |
+| Calb1 expression | defining marker | 6.53 (cohort pct 0.790; child-coverage 1.000) | not assessed | CONSISTENT |
+| Th (negative) | absent in somata; axonal only | no atlas expression data | not assessed | NOT_ASSESSED |
+| Sex ratio | male-biased | not available | not assessed | NOT_ASSESSED |
 
+*(Child-cluster breakdown not assessed — see proposed experiments.)*
 
-### 1550 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1550] · 🔴 LOW
+**Table 2 — Evidence support (SUPT_0420).**
 
-### Supporting evidence
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas precomputed expression + MERFISH location | Atlas metadata | PARTIAL | Calb1=6.53; MPN-primary (289/702; region_fraction_100um=0.903) | atlas-internal |
 
-- **Calb1 expression is high and concordant.** CLUS_1550 precomputed mean Calb1 = 6.66 directly matches the primary classical defining marker (calbindin-D28K immunoreactivity) [2]. This is the strongest atlas-side signal supporting the mapping.
-- **MPN primary soma is confirmed.** CLUS_1550 has MBA:515 (Medial preoptic nucleus) as its primary soma annotation (n=22 cells), placing the cluster in the broader brain region in which SDN-POA is histologically defined [1], [2].
-- **Sex ratio is concordant and unambiguous.** male_female_ratio = 3.35 in CLUS_1550 — clearly male-biased — directly matches the male-biased dimorphism that defines sdn_poa_calbindin_neuron [1]. CLUS_1550 is the only child cluster of SUPT_0423 with both MPN-primary soma and an unambiguous male bias.
-- **Cluster was identified by targeted child-cluster analysis.** CLUS_1550 emerged from systematic inspection of SUPT_0423 child clusters for an MPN-restricted, male-biased, Calb1-high cluster — the only one matching all three filters.
+### 5. Candidate paragraphs
 
-### Marker evidence provenance
+### 0423 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_SUPT_0423] · 🔴 LOW / ⚪ UNCERTAIN
 
-- **Calb1** — classical evidence is protein-level (calbindin-D28K immunohistochemistry, the histological criterion used to delineate SDN-POA from surrounding MPN) [2]. Atlas precomputed value (mean = 6.66) is transcript-based (10x Chromium). The high atlas value is consistent with the protein evidence; no data-source discrepancy. Calb1 is a DEFINING_SCOPED marker at the supertype level (mean = 6.42), confirming Calb1 as a marker shared across SUPT_0423 rather than specific to the SDN-POA subnucleus.
-- **Th (negative marker)** — classical evidence is protein-level: He et al. 2013 explicitly report "no TH-positive cells were found" within the calbindin-delineated SDN-POA [2]. Atlas precomputed Th = 2.75 at CLUS_1550 (transcript-based) is non-zero and discordant with the classical NEGATIVE assertion. The discrepancy is between **classical protein-IHC negative** and **atlas transcript positive at moderate level**. Transcript-level Th may reflect cells outside the SDN-POA cytoarchitectonic zone (PVH/PVHap components of CLUS_1550), or low-abundance transcript not translated to detectable protein. This concern persists at supertype level (Th = 0.99) and is amplified at cluster level (Th = 2.75).
+Atlas precomputed expression data and MERFISH spatial registration place this supertype in a constellation of preoptic-region GABAergic populations with calbindin expression at supertype level (Calb1=6.42; DEFINING_SCOPED; cohort percentile 0.771), making it the only rank-1 candidate in which the medial preoptic nucleus contributes a non-trivial fraction of soma counts. This is the closest supertype-level match to the classical SDN-POA description (Calb1+ neurons in the medial preoptic nucleus) that the WMBv1 atlas offers, but the mapping is at best a broader correspondence — see property comparison table.
 
-### Concerns
+**Supporting evidence**
+- Calbindin (Calb1) is the primary classical defining marker for SDN-POA neurons in rodent IHC studies [2]; its expression at supertype level on SUPT_0423 is in the upper third of the survival cohort (cohort percentile 0.771) and the marker is flagged DEFINING_SCOPED in atlas curation, meaning it discriminates within the parent subclass.
+- The supertype's soma counts include 113 cells in the medial preoptic nucleus [MBA:515], consistent with the classical soma location for SDN-POA cells.
+- All 5 of SUPT_0423's child clusters carry Calb1 expression (child-cluster coverage 1.000).
 
-- **SDN-POA is not resolvable as a distinct spatial domain in WMBv1 MERFISH.** SDN-POA is a histologically defined subnucleus within MPN [MBA:515]; WMBv1 MERFISH registers cells to MBA:515 as a whole and cannot distinguish SDN-POA cells from other MPN Calb1+ neurons. Mapping is possible only at MPN level. *(adjacent region — could reflect registration boundary error; weak counter-evidence at the level of SDN-POA-specific identity, but the broader MPN-level placement is correct)*
-- **Th = 2.75 at cluster level is discordant with the Th NEGATIVE classical assertion.** The classical negative-marker call is protein-level (no TH-positive cell bodies in SDN-POA) [2]; the atlas value is transcript-level. CLUS_1550 spans MPN, PVH, and PVHap — Th transcript signal may originate from non-MPN cells within the cluster, but this cannot be confirmed from MERFISH data alone. Spatial inspection of the Th MERFISH channel for CLUS_1550 cells assigned to MBA:515 is needed.
-- **CLUS_1550 is not MPN-restricted.** The cluster spans MBA:515 (MPN) n=22, PVH n=9, PVHap n=4, and Hypothalamus n=9. The MPN-primary soma annotation (n=22) is the largest single-region count, but the cluster as a whole is multi-regional.
-- **Annotation transfer NOT_ASSESSED.** No data-driven cell-level mapping of Calb1+ MPN/SDN-POA scRNA-seq cells to WMBv1 has been run; this is the most important remaining gap in the evidence base for this edge.
+**Concerns**
+- Location alignment is only APPROXIMATE at supertype level — strict `region_fraction: 0.140` against a `region_fraction_100um: 0.336` indicates that the bulk of SUPT_0423 soma sit outside the medial preoptic nucleus (the supertype also occupies hypothalamus [MBA:1097] and anterior hypothalamic nucleus [MBA:88]). The SUPT_0423 cohort cannot, on this evidence, be equated with SDN-POA neurons specifically.
+- Calb1 is broadly expressed across hypothalamic and limbic GABAergic populations; its DEFINING_SCOPED tag means it discriminates within-subclass but is not a specific SDN-POA marker. Calb1 alone is insufficient to identify SDN-POA neurons (MARKER_NOT_SPECIFIC caveat).
+- The SDN-POA is a histologically defined subnucleus within the broader medial preoptic nucleus; WMBv1 MERFISH cannot resolve it as a distinct spatial domain, so even an MPN-localised match could not be confirmed as SDN-POA-specific (MERFISH_REGISTRATION_UNCERTAINTY caveat).
+- Th (a classical somatic-negative marker for SDN-POA [2]) is absent from atlas precomputed expression for this supertype, so the negative-marker constraint cannot be cross-checked at supertype level.
 
-### What would upgrade confidence
+**Marker evidence provenance**
+- **Calb1.** Established in the gathered literature by calbindin-D28K immunohistochemistry on the rodent SDN-POA, with the histological identification of the nucleus carried by the IHC stain itself [2]. There is no transcript-level primary citation in the present references for Calb1 in morphologically/cytoarchitectonically confirmed SDN-POA cells; the marker is protein-level only in the gathered evidence.
+- **Th (negative).** The classical negative call is somatic: He et al. [2] explicitly report no TH-positive cells in the SDN-POA but describe TH-positive axon-like projections and synaptic structures within it. The atlas-side precomputed expression does not carry Th for this supertype, so the negative call cannot be cross-checked here.
+- Calb1 is listed as DEFINING_SCOPED for SUPT_0423 with a supertype mean of 6.42 (above MIN_DETECTABLE), so there is no atlas annotation/expression discrepancy at supertype level. The discrepancy that matters lies one level up: a histologically defined SDN-POA subnucleus is collapsed into a broader BST-MPN supertype that also spans non-SDN regions.
 
-- **MapMyCells annotation transfer** of an SDN-POA-focused or MPN Calb1+ scRNA-seq dataset against WMBv1 (see Proposed experiments) is the priority experiment. F1 ≥ 0.50 at CLUS_1550 would support upgrading to MODERATE confidence and would add `AnnotationTransferEvidence`.
-- **MERFISH spatial inspection of the Th channel** for CLUS_1550 cells assigned to MBA:515 would resolve whether Th transcript signal originates from MPN cells (refuting the mapping) or from PVH/PVHap components of the cluster (preserving the mapping).
-- **Sub-regional MERFISH spatial analysis** of CLUS_1550 cells within MBA:515 — testing for clustering consistent with the SDN-POA dorsomedial position — would address whether atlas data can recover the histological subnucleus despite the lack of explicit MBA-level annotation.
+**What would upgrade confidence**
+- Spatial inspection of SUPT_0423 MERFISH cells inside [MBA:515] for sub-regional clustering consistent with the SDN-POA dorsomedial position, to determine whether any subset of SUPT_0423 cells co-localises with the histologically defined SDN-POA cytoarchitectonic zone.
+- A focused transcriptomic dataset of calbindin-labelled or SDN-POA-microdissected cells, transferred by cluster annotation transfer to the WMBv1 taxonomy, would convert the supertype-level alignment into a defensible mapping (target: F1 ≥ 0.70 against SUPT_0423 or one of its children).
+- Targeted literature search for transcript-level (e.g. ISH, transcriptomic) confirmation of Calb1 specifically in cytoarchitectonically confirmed SDN-POA cells, anchoring the marker beyond the IHC literature.
 
----
+### 1550 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1550] · 🔴 LOW / ⚪ UNCERTAIN
 
-### 0423 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_SUPT_0423] · 🔴 LOW
+Among the children of SUPT_0423, CLUS_1550 is the only cluster whose primary soma location is the medial preoptic nucleus [MBA:515] (39 of 85 cells; region_fraction_100um=0.812), and its male-biased sex ratio (MFR=3.35) aligns with the male-biased dimorphism of the classical SDN-POA. Calb1 is expressed at 6.66 (cohort percentile 0.704). This makes CLUS_1550 the best available cluster-level approximation to the SDN-POA calbindin population in the WMBv1 atlas, but the cluster also spans paraventricular hypothalamic nucleus [MBA:38] and is not MPN-restricted, and the negative-marker (Th) constraint cannot be confirmed.
 
-### Supporting evidence
+**Supporting evidence**
+- MERFISH spatial counts place CLUS_1550's largest soma cohort in the medial preoptic nucleus [MBA:515] (39 cells; region_fraction_100um=0.812; strict region_fraction=0.458), matching the classical SDN-POA soma location [1][2].
+- Calb1 expression at 6.66 (cohort percentile 0.704) is consistent with the classical defining marker [2].
+- The cluster's male-biased MFR (3.35) matches the male-biased dimorphism of the classical SDN-POA (larger in males [1]).
+- The cluster is annotated as GABAergic by atlas curation.
 
-- **Calb1 is a DEFINING_SCOPED supertype marker.** Precomputed mean Calb1 = 6.42 at SUPT_0423 directly matches the classical primary defining marker [2]. This is the strongest quantitative agreement between classical node and supertype.
-- **MPN cells are present.** n = 47 cells within SUPT_0423 are labelled to Medial preoptic nucleus [MBA:515], providing a direct anatomical anchor for the broader MPN region in which SDN-POA is histologically defined [1], [2].
-- **DB-score rank-1 candidate at supertype level.** SUPT_0423 was the only anatomically plausible rank-1 candidate (DB score = 1) returned by atlas-metadata candidate search for Calb1+ MPN.
+**Concerns**
+- Th (a classical somatic-negative marker [2]) shows precomputed mean expression 2.75 in CLUS_1550, in apparent conflict with the classical assertion. The classical negative call is restricted to somata in the SDN-POA itself, and CLUS_1550 includes cells in PVH/PVHap (where Th-expressing populations are well documented), so the Th signal may originate from the non-MPN component of the cluster rather than from MPN cells. Spatial inspection of the Th channel for CLUS_1550 cells assigned to MBA:515 would be needed to resolve this.
+- Location is CONSISTENT but not MPN-restricted: 25 of 110 CLUS_1550 soma sit in paraventricular hypothalamic nucleus [MBA:38] and a further 11 in unspecified hypothalamus [MBA:1097], so the cluster spans more than the medial preoptic nucleus.
+- The SDN-POA is a subnucleus within MPN that cannot be resolved as a distinct MERFISH spatial domain in WMBv1; CLUS_1550 is the best available MPN-primary Calb1+ male-biased cluster but cannot be confirmed to occupy the SDN-POA cytoarchitectonic zone specifically (MERFISH_REGISTRATION_UNCERTAINTY caveat).
+- Calb1 is broadly expressed; its presence on CLUS_1550 is consistent with but not specific for SDN-POA identity (MARKER_NOT_SPECIFIC caveat).
+- An auto-repredication note flags CLUS_1550 as previously carrying the deprecated `evidencell:PartialOverlapMatch` predicate (auto-migrated to `skos:closeMatch` 2026-05-26); curator review recommended.
 
-### Marker evidence provenance
+**Marker evidence provenance**
+- **Calb1.** Protein-level histology (calbindin-D28K IHC) is the primary evidence in the gathered literature [2]; no transcript-level primary citation for Calb1 in cytoarchitectonically confirmed SDN-POA cells is present. Marker is consistent with cluster-level mean expression but not specific.
+- **Th (negative).** Classical assertion is somatic-absent in SDN-POA but axonal-present [2]. CLUS_1550 spans multiple anatomical regions and the precomputed mean (2.75) cannot be apportioned across components without spatial channel inspection. Discrepancy is real and surfaces in the Concerns list above.
 
-- **Calb1** — classical evidence is protein-level (calbindin-D28K IHC) [2]; atlas precomputed value is transcript-level (mean = 6.42, DEFINING_SCOPED). The values are concordant; specificity is reduced because Calb1 is widely expressed and is DEFINING_SCOPED rather than DEFINING — i.e. it is a defining marker only within the scope of SUPT_0423, not exclusive to it.
-- **Th (negative marker)** — classical protein-IHC evidence reports no TH-positive cell bodies in SDN-POA [2]. Atlas Th = 0.99 at supertype level is low but non-zero, discordant with the classical NEGATIVE assertion. The discrepancy is amplified at child-cluster level (CLUS_1550 Th = 2.75). Th transcript signal at supertype level may reflect Th-expressing cells in BST/AHN/PVN components of SUPT_0423 rather than MPN-proper cells.
+**What would upgrade confidence**
+- MERFISH spatial channel inspection of the Th signal for CLUS_1550 cells assigned to MBA:515 to determine whether Th expression co-occurs with MPN soma or originates from the PVH/PVHap component of this cluster.
+- Sub-regional MERFISH spatial analysis within [MBA:515] to test whether a subset of CLUS_1550 cells form a dorsomedial cluster consistent with the histologically defined SDN-POA position.
+- A targeted transcriptomic dataset of SDN-POA Calb1+ neurons (e.g. microdissection or Calb1-driver-targeted cells from the medial preoptic area) transferred by cluster annotation transfer to the WMBv1 taxonomy, with F1 ≥ 0.70 against CLUS_1550 or its supertype as the target.
 
-### Concerns
+### 0420 BST-MPN Six3 Nrgn Gaba_1 [CS20230722_SUPT_0420] · 🔴 LOW / ⚪ UNCERTAIN
 
-- **Supertype spans BST, MPN, AHN, and PVN.** SUPT_0423 covers MBA:515 (MPN, n=47), BNST (n=18), AHN (n=46), and PVN (n=31). Multiple classical types — not just SDN-POA Calb1 neurons — are expected to map to this same supertype; SDN-POA Calb1 neurons are a subset within the MPN component. *(distant regions — BST, AHN, PVN are anatomically distinct from MPN; this is a significant caveat at supertype level)*
-- **Calb1 alone is insufficient to identify SDN-POA neurons specifically.** Calb1 is expressed across many brain regions and is DEFINING_SCOPED (not DEFINING) in SUPT_0423. The supertype-level Calb1 signal does not discriminate SDN-POA from other MPN Calb1+ populations or from BST/AHN/PVN Calb1+ populations within the supertype.
-- **Th = 0.99 at supertype level is discordant with the Th NEGATIVE classical assertion.** Although low, this contradicts the protein-level IHC evidence [2] that no TH-positive cell bodies exist in SDN-POA. The signal may originate from non-MPN components.
-- **SDN-POA is not resolvable as a subnucleus within MPN in MERFISH data.** Matching is possible only at MPN level; SDN-POA cells cannot be distinguished from other MPN Calb1 neurons.
-- **Sex ratio data not available at supertype level.** Male-biased dimorphism — a defining feature of SDN-POA — cannot be assessed from supertype-level metadata. The signal is visible only in CLUS_1550 (MFR = 3.35).
-- **Annotation transfer NOT_ASSESSED.**
+This supertype carries the highest medial-preoptic concentration of any candidate in the audited set (region_fraction_100um=0.903; strict region_fraction=0.759; 289 of 702 soma counted at MBA:515) with Calb1 expressed at 6.53 (cohort percentile 0.790; child-cluster coverage 1.000). It is a credible MPN-anchored alternative to SUPT_0423 for a broader SDN-POA-containing population, but no child-cluster breakdown was carried into this audit, no sex-ratio assessment is available at supertype level, and the same MERFISH-resolution limitation prevents specific equation with the SDN-POA subnucleus.
 
-### What would upgrade confidence
+**Supporting evidence**
+- MERFISH spatial counts place the bulk of SUPT_0420 soma in the medial preoptic nucleus [MBA:515] (289 cells out of 526 total; region_fraction_100um=0.903), the strongest MPN concentration of any audited candidate.
+- Calb1 expression at 6.53 (cohort percentile 0.790) is consistent with the classical defining marker [2], with all child clusters expressing Calb1 (child-cluster coverage 1.000).
 
-- The child-cluster inspection (proposed in this edge) has already been carried out and is captured in the CLUS_1550 edge above.
-- MapMyCells annotation transfer of an SDN-POA-focused or MPN Calb1+ scRNA-seq dataset against WMBv1 — F1 ≥ 0.50 at SUPT_0423 would upgrade this edge; F1 ≥ 0.80 at CLUS_1550 level would support MODERATE confidence on the cluster edge. Expected output: `AnnotationTransferEvidence`.
-- Targeted cite-traverse for studies reporting scRNA-seq of histologically delineated SDN-POA Calb1+ cells from male and female rodents could provide independent transcriptomic confirmation of the supertype assignment and address the Th discrepancy.
+**Concerns**
+- Sex ratio is not assessed at supertype level; without a male-biased MFR signal on at least one child cluster, the male-biased dimorphism of the classical SDN-POA cannot be confirmed for this supertype.
+- No child-cluster breakdown is in scope for this audit; the supertype-level signal does not localise to a specific child.
+- The MERFISH-resolution limitation applies: SDN-POA cannot be resolved as a distinct spatial domain within MPN, so even the strongest MPN-concentration signal does not specifically identify SDN-POA cells (MERFISH_REGISTRATION_UNCERTAINTY).
+- Th is absent from atlas precomputed expression for this supertype, so the negative-marker constraint cannot be cross-checked.
+
+**Marker evidence provenance**
+- **Calb1.** As for the other candidates, protein-level IHC is the primary classical evidence [2]; no transcript-level primary citation in morphologically confirmed SDN-POA cells is present. Supertype-level mean expression is above MIN_DETECTABLE and there is no atlas annotation/expression discrepancy at supertype level.
+
+**What would upgrade confidence**
+- Identification and audit of SUPT_0420 child clusters in [MBA:515] with explicit male-biased MFR — currently the strongest gap is that the supertype-level MPN concentration is not yet matched to a specific male-biased child cluster.
+- A focused transcriptomic dataset of SDN-POA Calb1+ neurons transferred by cluster annotation transfer to the WMBv1 taxonomy, to test whether the source cells land on SUPT_0420 or SUPT_0423.
+
+### 4c. Candidates audited (full top-K)
+
+<details>
+<summary>Candidates audited (full top-K)</summary>
+
+| WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key evidence | Verdict |
+|---|---|---:|---|---|---|
+| 0423 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_SUPT_0423] | — | 1215 | ⚪ UNCERTAIN | Only MPN-bearing rank-1 candidate; Calb1=6.42 DEFINING_SCOPED | Primary (supertype) |
+| 1550 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1550] | 0423 BST-MPN Six3 Nrgn Gaba_4 | 215 | ⚪ UNCERTAIN | MPN-primary child of SUPT_0423; MFR=3.35; Calb1=6.66 | Primary (best child) |
+| 0420 BST-MPN Six3 Nrgn Gaba_1 [CS20230722_SUPT_0420] | — | 526 | ⚪ UNCERTAIN | Highest MPN concentration (region_fraction_100um=0.903); Calb1=6.53 | Secondary (broader MPN match) |
+| 0422 BST-MPN Six3 Nrgn Gaba_3 [CS20230722_SUPT_0422] | — | 1836 | 🔴 LOW | MPN-primary supertype but Calb1=5.49 lower; no sex-ratio audit | Eliminated (lower Calb1; no sex-ratio confirmation) |
+| 0421 BST-MPN Six3 Nrgn Gaba_2 [CS20230722_SUPT_0421] | — | 293 | 🔴 LOW | MPN-primary supertype; Calb1=4.86 modest | Eliminated (lower Calb1; no sex-ratio confirmation) |
+| 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] | — | 933 | 🔴 LOW | Periventricular preoptic; Calb1=4.16 only APPROXIMATE | Eliminated (PVpo-dominant; Calb1 modest) |
+| 1542 BST-MPN Six3 Nrgn Gaba_3 [CS20230722_CLUS_1542] | 0422 BST-MPN Six3 Nrgn Gaba_3 | 109 | 🔴 LOW | Calb1=3.26 APPROXIMATE; MPN tertiary | Eliminated (Calb1 below cohort median) |
+| 0360 MEA-BST Lhx6 Nfib Gaba_4 [CS20230722_SUPT_0360] | — | 339 | 🔴 LOW | High Calb1 (8.68) but MEA-BST origin; MPN secondary | Eliminated (wrong subclass — MEA-BST lineage) |
+| 1304 MEA-BST Lhx6 Nfib Gaba_5 [CS20230722_CLUS_1304] | 0361 MEA-BST Lhx6 Nfib Gaba_5 | 57 | 🔴 LOW | Calb1=10.28 but MEA-BST lineage | Eliminated (wrong subclass — MEA-BST lineage) |
+| 1305 MEA-BST Lhx6 Nfib Gaba_5 [CS20230722_CLUS_1305] | 0361 MEA-BST Lhx6 Nfib Gaba_5 | 92 | 🔴 LOW | Calb1=8.89 but MEA-BST lineage; AVPV secondary | Eliminated (wrong subclass — MEA-BST lineage) |
+| 1303 MEA-BST Lhx6 Nfib Gaba_4 [CS20230722_CLUS_1303] | 0360 MEA-BST Lhx6 Nfib Gaba_4 | 41 | 🔴 LOW | Calb1=8.52 but MEA-BST lineage; PD secondary | Eliminated (wrong subclass — MEA-BST lineage) |
+| 1310 MEA-BST Lhx6 Nfib Gaba_5 [CS20230722_CLUS_1310] | 0361 MEA-BST Lhx6 Nfib Gaba_5 | 232 | 🔴 LOW | Calb1=7.37 but MEA-BST lineage; pallidum secondary | Eliminated (wrong subclass — MEA-BST lineage) |
+
+12 edges audited; the eight `evidencell:UncertainRelationship` cuts are listed for audit only.
+
+</details>
 
 ---
 
@@ -157,17 +194,32 @@ MPN that cannot be resolved as a distinct spatial domain in WMBv1 MERFISH data.
 <details>
 <summary>Data sources, analyses, and reproducibility receipts</summary>
 
-**Classical type definition.** See classical type table in Introduction; defining_basis on the classical node and per-property literature support are listed there. The KB-side definition lives at the source graph file linked in the reproducibility footer.
+**Classical type definition.** The SDN-POA calbindin neuron is defined here on a CLASSICAL_NEUROCHEMICAL basis: calbindin-D28K immunoreactivity on cytoarchitectonically delineated SDN-POA neurons in rodent medial preoptic nucleus, with somatic Th absent and a male-biased dimorphism in nucleus size [1][2]. The node has no transcript-level primary citation for either Calb1 or Th in the gathered evidence; both are protein-level histological assertions in rodent material.
 
-**Atlas mapping query.** Candidate atlas clusters were retrieved from CCN20230722 at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias). Full scoring rules: `workflows/map-cell-type.md`.
+**Atlas mapping query.** Candidate atlas clusters were retrieved from the WMBv1 taxonomy (CCN20230722) at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match against MBA:515, sex bias = male, defining marker = Calb1). Full scoring rules: `workflows/map-cell-type.md`.
 
-**Property alignment.** Each defining property was compared to the corresponding atlas-side value via the `property_comparisons` schema; alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
+**Property alignment.** Each defining property of the classical type was compared to the corresponding atlas-side value via the `property_comparisons` schema, with alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
 
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote. Specific mapping limitations and caveats are documented per-candidate in the Discussion section.
 
+*Generated by evidencell `25c2b32` at 2026-06-08T18:14:04+00:00 from [kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml](kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
 
-**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote.
+**Evidence base table.**
 
-*Generated by evidencell `0c97cfa` from [`kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`](../../kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+| Edge ID | Evidence types | Supports | Source |
+| --- | --- | --- | --- |
+| edge_sdn_poa_calbindin_neuron_to_cs20230722_supt_0423 | ATLAS_METADATA | WEAK | atlas-internal |
+| edge_sdn_poa_calbindin_neuron_to_cs20230722_clus_1550 | ATLAS_METADATA | WEAK | atlas-internal |
+| edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1304 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1305 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1303 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1310 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1542 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0360 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0420 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0422 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0421 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0486 | ATLAS_METADATA | PARTIAL | atlas-internal |
 
 </details>
 
@@ -175,58 +227,39 @@ MPN that cannot be resolved as a distinct spatial domain in WMBv1 MERFISH data.
 
 ## Discussion
 
-**Primary mapping:** → 1550 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1550] at LOW confidence. Key support: ATLAS_METADATA (Calb1=1.6, MFR=3.35 male-biased, Th=2.75 — classical Th-negative criterion violated). Key caveats: `MARKER_NOT_SPECIFIC` (Calb1 expressed broadly; SDN-POA specificity not resolvable from atlas alone) and `Th` discordance.
+### 6. Best candidate + caveats summary
 
-No Cell Ontology term currently assigned for this classical type.
+**Primary mapping:** Sexually dimorphic nucleus of the preoptic area (SDN-POA) calbindin neuron → 0423 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_SUPT_0423] (supertype) with best child 1550 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1550] at UNCERTAIN confidence. Key support: medial-preoptic primary soma location with Calb1 expression at supertype level and a male-biased sex ratio on the best child cluster. Key caveats: MERFISH_REGISTRATION_UNCERTAINTY (SDN-POA cannot be resolved as a distinct spatial domain within MPN in WMBv1) and MARKER_NOT_SPECIFIC (Calb1 alone does not discriminate SDN-POA cells from other MPN Calb1+ populations); the Th somatic-negative call cannot be confirmed at atlas resolution.
 
-### Proposed experiments and follow-ups
+No Cell Ontology term currently covers this type. The classical node carries a note flagging this as a candidate for a new CL term that would cover the rodent SDN-POA calbindin population together with its cross-species homologs (INAH3 in humans, ovine SDN, rhesus medial preoptic area, quail SDN [2]).
 
-### 1. MapMyCells annotation transfer of an SDN-POA / MPN Calb1+ scRNA-seq dataset against WMBv1
+### 7. Proposed experiments and follow-ups
 
-**What:** Retrieve a published scRNA-seq dataset enriched for MPN Calb1+ cells, ideally a Calb1-Cre or SDN-POA-microdissected preparation from male and female rodents. Run MapMyCells against WMBv1 at cluster resolution.
+- **What:** spatial inspection of MERFISH cells (any SUPT_0423 / CLUS_1550 child cluster) inside [MBA:515] for sub-regional clustering consistent with the dorsomedial position of the histologically defined SDN-POA.
+  - **Target:** identification of a contiguous Calb1+ Th-negative dorsomedial sub-cluster of CLUS_1550 / SUPT_0423 within MBA:515.
+  - **Expected output:** spatial annotation that could be added as additional `property_comparisons` entries on the edges, or as new spatially refined edges if a sub-cluster is identified.
+  - **Resolves:** the SDN-POA-vs-MPN-Calb1+ identity question for both SUPT_0423 and CLUS_1550 (open question 1 and 2).
 
-**Target:** F1 ≥ 0.50 at SUPT_0423 level; F1 ≥ 0.80 at CLUS_1550 level for Calb1+ MPN cells.
+- **What:** MERFISH Th-channel inspection of CLUS_1550 cells assigned to MBA:515.
+  - **Target:** determination of whether the cluster-level mean Th=2.75 originates from MPN soma or from the PVH/PVHap components of this multi-region cluster.
+  - **Expected output:** updated `property_comparisons` row for `negative_marker_Th` on CLUS_1550 with spatially apportioned values.
+  - **Resolves:** open question 2.
 
-**Expected output:** `AnnotationTransferEvidence` entries on both edges (edge_sdn_poa_calbindin_neuron_to_cs20230722_supt_0423 and edge_sdn_poa_calbindin_neuron_to_cs20230722_clus_1550). Atlas: WMBv1. Tool: MapMyCells. Output format: F1 matrix per cluster, fed back as `AnnotationTransferEvidence` YAML.
+- **What:** cluster annotation transfer of an MPN/SDN-POA Calb1+ transcriptomic dataset (e.g. Calb1-Cre-targeted or SDN-POA-microdissected cells) to the WMBv1 taxonomy.
+  - **Target:** F1 ≥ 0.70 against SUPT_0423 (or SUPT_0420), with a child-cluster-level F1 ≥ 0.50 against CLUS_1550 (or an SUPT_0420 child) and a clean Purity / Coverage signal.
+  - **Expected output:** `AnnotationTransferEvidence` items added to the relevant edges.
+  - **Resolves:** the central uncertainty across all surviving candidates — would convert supertype-level alignment into a defensible cluster-level mapping.
 
-**Resolves:** Open questions 1 and 3. Confirms or refutes CLUS_1550 as the correct cluster assignment. Addresses the `annotation_transfer_f1` NOT_ASSESSED gap on both edges.
+- **What:** targeted literature search for transcript-level (ISH, transcriptomic) confirmation of Calb1 in cytoarchitectonically confirmed SDN-POA cells.
+  - **Target:** primary-source transcript-level citation for Calb1 on SDN-POA neurons.
+  - **Expected output:** `LiteratureEvidence` (transcript-level) added to the classical node.
+  - **Resolves:** the marker-provenance gap (Calb1 is currently protein-level only).
 
-### 2. MERFISH spatial inspection of the Th channel within CLUS_1550 cells at MBA:515
+### 8. Open questions
 
-**What:** For CLUS_1550 cells assigned to MBA:515 in WMBv1 MERFISH data, examine the per-cell Th channel intensity. Compare to CLUS_1550 cells in PVH and PVHap.
-
-**Target:** Determination of whether Th transcript signal in CLUS_1550 originates from the MPN component (refuting the SDN-POA mapping at cluster level) or from PVH/PVHap components (preserving the mapping by attributing Th to non-SDN-POA cells within a multi-region cluster).
-
-**Expected output:** Curatorial note attached to the CLUS_1550 edge summarising per-region Th signal; potentially a refined `MarkerAnalysisEvidence` record.
-
-**Resolves:** Open question 1 (Th source within CLUS_1550).
-
-### 3. Sub-regional MERFISH spatial analysis of CLUS_1550 cells within MBA:515
-
-**What:** Within MBA:515, test CLUS_1550 cells for sub-regional clustering consistent with the dorsomedial cytoarchitectonic position of the SDN-POA. Compare cell density and distribution between male and female samples.
-
-**Target:** Detection of a male-biased dorsomedial sub-cluster within MBA:515 cells of CLUS_1550 — the spatial signature of SDN-POA — or formal demonstration that no such sub-cluster exists at MERFISH spatial resolution.
-
-**Expected output:** Curatorial note or, if positive, a refined `MarkerAnalysisEvidence` / spatial-evidence record.
-
-**Resolves:** Open question 2 (sub-regional resolution of SDN-POA within MPN).
-
----
-
-### Open questions
-
-1. Do CLUS_1550 cells at MBA:515 (MPN) express Th, or does the cluster-level Th=2.75 signal originate from PVH/PVHap components of this multi-region cluster? *(Appears on the cluster edge.)*
-2. Can sub-regional MERFISH spatial data distinguish SDN-POA dorsomedial cells from other MPN Calb1+ neurons within CLUS_1550? *(Appears on the cluster edge; partially shared with the supertype edge.)*
-3. Do any clusters within SUPT_0423 — beyond CLUS_1550 — show peak Calb1 co-located with MBA:515 (MPN) and male-biased sex ratio consistent with SDN-POA identity? *(Appears on the supertype edge; partially addressed by the CLUS_1550 child-cluster analysis but not exhaustively surveyed.)*
-
----
-
-### Evidence base
-
-| Edge ID | Evidence type | Supports |
-|---|---|---|
-| edge_sdn_poa_calbindin_neuron_to_cs20230722_supt_0423 | ATLAS_METADATA | WEAK — Calb1=6.42 (DEFINING_SCOPED); Th=0.99 (discordant with NEGATIVE); MBA:515 n=47; supertype spans BST/MPN/AHN/PVN |
-| edge_sdn_poa_calbindin_neuron_to_cs20230722_clus_1550 | ATLAS_METADATA | WEAK — Calb1=6.66; Th=2.75 (discordant with NEGATIVE); MBA:515 primary soma n=22; MFR=3.35 (male-biased, concordant); cluster spans MPN/PVH/PVHap |
+1. Do any clusters within SUPT_0423 show peak Calb1 co-located with MBA:515 (medial preoptic nucleus) and male-biased sex ratio consistent with SDN-POA identity?
+2. Do CLUS_1550 cells at MBA:515 express Th, or does Th signal originate from PVH/PVHap components of this cluster?
+3. Can sub-regional MERFISH spatial data distinguish SDN-POA dorsomedial cells from other MPN Calb1+ neurons within CLUS_1550?
 
 ---
 
@@ -234,5 +267,296 @@ No Cell Ontology term currently assigned for this classical type.
 
 | # | Citation | PMID | Used for |
 |---|---|---|---|
-| [1] | Negri-Cesi 2015 | [PMID:26672480](https://pubmed.ncbi.nlm.nih.gov/26672480/) | Soma location; SDN-POA male-biased dimorphism; INAH homology |
-| [2] | He et al. 2013 | [PMID:25206587](https://pubmed.ncbi.nlm.nih.gov/25206587/) | Soma location; calbindin-D28K defining marker (IHC); Th NEGATIVE marker (no TH cell bodies); cross-species homology |
+| [1] | Negri-Cesi 2015 — *Bisphenol A Interaction With Brain Development and Functions* | [26672480](https://pubmed.ncbi.nlm.nih.gov/26672480) | soma location |
+| [2] | He et al. 2013 — *Development of the sexually dimorphic nucleus of the preoptic area and the influence of estrogen-like compounds* | [25206587](https://pubmed.ncbi.nlm.nih.gov/25206587) | soma location, defining marker (Calb1), negative marker (Th), cross-species homology |
+
+---
+
+<!-- verdict-block-start: edge_sdn_poa_calbindin_neuron_to_cs20230722_supt_0423 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.25
+  relationship: evidencell:UncertainRelationship
+  rationale: >
+    [tier:STRONGEST] CS20230722_SUPT_0423 is the only rank-1 candidate
+    where the medial preoptic nucleus [MBA:515] contributes a non-trivial
+    fraction of soma (region_fraction_100um: 0.336; strict region_fraction:
+    0.140) and Calb1=6.42 (DEFINING_SCOPED; cohort percentile 0.771;
+    child-coverage 1.000) matches the primary classical defining marker.
+    The SDN-POA is a histologically defined subnucleus within MPN and
+    cannot be resolved as a distinct spatial domain in WMBv1 MERFISH data;
+    Calb1 alone is not specific for SDN-POA identity.
+  reconciliation_note: >
+    Paired with best-child edge to CS20230722_CLUS_1550 (the only
+    MPN-primary child of this supertype with male-biased MFR); see report.
+  caveats:
+    - caveat_type: MERFISH_REGISTRATION_UNCERTAINTY
+      description: >
+        The SDN-POA is a histologically defined subnucleus within MPN, not
+        resolvable as a distinct spatial domain in WMBv1 MERFISH data.
+        Matching is possible only at MPN level (SUPT_0423 MBA:515, n=113);
+        SDN-POA cells cannot be distinguished from other MPN Calb1
+        neurons.
+    - caveat_type: MARKER_NOT_SPECIFIC
+      description: >
+        Calb1 is expressed across many brain regions and is DEFINING_SCOPED
+        (not DEFINING) on CS20230722_SUPT_0423. Calb1 alone is insufficient
+        to identify SDN-POA neurons specifically; the supertype spans BST,
+        MPN, AHN, and PVN.
+  proposed_experiments:
+    - >
+      Spatial inspection of CS20230722_SUPT_0423 MERFISH cells inside
+      MBA:515 for sub-regional clustering consistent with the dorsomedial
+      SDN-POA position.
+    - >
+      Cluster annotation transfer of an MPN/SDN-POA Calb1+ transcriptomic
+      dataset to the WMBv1 taxonomy, targeting F1 >= 0.70 against
+      CS20230722_SUPT_0423.
+  unresolved_questions:
+    - >
+      Do any clusters within CS20230722_SUPT_0423 show peak Calb1
+      co-located with MBA:515 and male-biased sex ratio consistent with
+      SDN-POA identity?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_sdn_poa_calbindin_neuron_to_cs20230722_clus_1550 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.3
+  relationship: evidencell:UncertainRelationship
+  rationale: >
+    [tier:NEXT] CS20230722_CLUS_1550 is the only child of CS20230722_SUPT_0423
+    whose primary soma location is MBA:515 (region_fraction_100um: 0.812;
+    strict region_fraction: 0.458), and its MFR=3.35 male-biased sex
+    ratio aligns with the male-biased SDN-POA dimorphism. Calb1=6.66
+    (cohort percentile 0.704) matches the classical defining marker.
+    Concerns: Th=2.75 is discordant with the classical somatic-negative
+    Th assertion, but the cluster spans MBA:515, MBA:1097, and MBA:38, so
+    the Th signal may originate from non-MPN cells; SDN-POA cannot be
+    resolved as a distinct MERFISH spatial domain within MPN.
+  reconciliation_note: >
+    Paired with parent supertype edge to CS20230722_SUPT_0423; see report.
+  caveats:
+    - caveat_type: MERFISH_REGISTRATION_UNCERTAINTY
+      description: >
+        SDN-POA is a histologically defined subnucleus within MPN; WMBv1
+        MERFISH cannot resolve it as a distinct spatial domain.
+        CS20230722_CLUS_1550 is the best available MPN-primary Calb1+
+        male-biased cluster but cannot be confirmed to occupy the SDN-POA
+        cytoarchitectonic zone specifically.
+    - caveat_type: MARKER_NOT_SPECIFIC
+      description: >
+        Th=2.75 in CS20230722_CLUS_1550 is discordant with the classical
+        somatic-Th-negative assertion. The cluster spans MBA:515,
+        MBA:1097, and MBA:38; the Th signal may originate from the PVH /
+        PVHap component rather than from MPN cells, but the apportionment
+        cannot be made without spatial channel inspection.
+    - caveat_type: OTHER
+      description: >
+        [AUTO_REPREDICATED_2026_05_26] Predicate auto-migrated from
+        deprecated evidencell:PartialOverlapMatch to skos:closeMatch by
+        refresh_predicates.py. Curator review recommended; this verdict
+        leaves the predicate as evidencell:UncertainRelationship pending
+        the spatial inspection above.
+  proposed_experiments:
+    - >
+      MERFISH Th-channel spatial inspection of CS20230722_CLUS_1550 cells
+      assigned to MBA:515, to determine whether Th expression co-occurs
+      with MPN cells or originates from the PVH / PVHap component.
+    - >
+      Sub-regional MERFISH spatial analysis within MBA:515 to test whether
+      a subset of CS20230722_CLUS_1550 cells form a dorsomedial sub-cluster
+      consistent with the histologically defined SDN-POA position.
+    - >
+      Cluster annotation transfer of MPN Calb1+ transcriptomic data
+      (Calb1-driver-targeted or SDN-POA-focused dataset) to assess F1
+      against CS20230722_CLUS_1550 (target F1 >= 0.50 at cluster level).
+  unresolved_questions:
+    - >
+      Do CS20230722_CLUS_1550 cells at MBA:515 express Th, or does Th
+      signal originate from PVH / PVHap components of this cluster?
+    - >
+      Can sub-regional MERFISH spatial data distinguish SDN-POA dorsomedial
+      cells from other MPN Calb1+ neurons within CS20230722_CLUS_1550?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0420 -->
+```yaml
+verdict:
+  confidence: UNCERTAIN
+  confidence_score: 0.25
+  relationship: evidencell:UncertainRelationship
+  rationale: >
+    [tier:WEAKEST] CS20230722_SUPT_0420 has the highest MPN concentration
+    of any audited candidate (region_fraction_100um: 0.903; strict
+    region_fraction: 0.759) with Calb1=6.53 (cohort percentile 0.790;
+    child-coverage 1.000). No child-cluster breakdown was carried into
+    this audit and no sex-ratio assessment is available at supertype
+    level, so the male-biased dimorphism of the classical SDN-POA cannot
+    be confirmed; SDN-POA cannot be resolved as a distinct MERFISH
+    spatial domain within MPN.
+  caveats:
+    - caveat_type: MERFISH_REGISTRATION_UNCERTAINTY
+      description: >
+        SDN-POA is a histologically defined subnucleus within MPN that
+        cannot be resolved as a distinct spatial domain in WMBv1 MERFISH
+        data. The strong MPN concentration of CS20230722_SUPT_0420 does
+        not specifically identify SDN-POA cells.
+    - caveat_type: MARKER_NOT_SPECIFIC
+      description: >
+        Calb1 is broadly expressed across hypothalamic and limbic
+        GABAergic populations; its presence on CS20230722_SUPT_0420 is
+        consistent with but not specific for SDN-POA identity.
+  proposed_experiments:
+    - >
+      Audit of CS20230722_SUPT_0420 child clusters at MBA:515 for
+      male-biased MFR, to test whether a specific child cluster matches
+      the male-biased SDN-POA dimorphism.
+    - >
+      Cluster annotation transfer of an MPN / SDN-POA Calb1+ transcriptomic
+      dataset to the WMBv1 taxonomy to test whether source cells land on
+      CS20230722_SUPT_0420 vs CS20230722_SUPT_0423.
+  unresolved_questions:
+    - >
+      Which children of CS20230722_SUPT_0420 in MBA:515 show male-biased
+      sex ratio consistent with the SDN-POA dimorphism?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1304 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  relationship: evidencell:UncertainRelationship
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1304 belongs to the MEA-BST Lhx6 Nfib Gaba
+    lineage rather than the BST-MPN Six3 Nrgn Gaba lineage that anchors
+    the MPN-primary candidates; although Calb1=10.28 is high and
+    region_fraction_100um: 0.605 includes MBA:515, the dominant
+    anatomical assignment is non-MPN and the subclass is inconsistent
+    with the classical SDN-POA's medial preoptic identity.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1305 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  relationship: evidencell:UncertainRelationship
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1305 belongs to the MEA-BST Lhx6 Nfib Gaba
+    lineage and its secondary soma cohort is in MBA:272 (anteroventral
+    periventricular nucleus), a female-biased structure distinct from
+    the male-biased SDN-POA; Calb1=8.89 alone does not rescue the
+    subclass mismatch.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1303 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  relationship: evidencell:UncertainRelationship
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1303 belongs to the MEA-BST Lhx6 Nfib Gaba
+    lineage with a secondary soma cohort in MBA:914 (posterodorsal
+    preoptic nucleus); the lineage and dominant anatomical signal are
+    inconsistent with the classical SDN-POA's medial preoptic identity
+    despite Calb1=8.52.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1310 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  relationship: evidencell:UncertainRelationship
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1310 belongs to the MEA-BST Lhx6 Nfib Gaba
+    lineage with a secondary soma cohort in MBA:803 (pallidum), distant
+    from the classical SDN-POA in the medial preoptic nucleus; subclass
+    mismatch not rescued by Calb1=7.37.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1542 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  relationship: evidencell:UncertainRelationship
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1542 sits in the correct BST-MPN Six3 Nrgn
+    Gaba lineage but Calb1=3.26 (cohort percentile 0.408) is below the
+    cohort median, and the tertiary anatomical assignment to MBA:515
+    (after MBA:1097 and MBA:88) is weaker than its siblings.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0360 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  relationship: evidencell:UncertainRelationship
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0360 carries high Calb1=8.68 (cohort
+    percentile 0.971; child-coverage 1.000) but belongs to the
+    MEA-BST Lhx6 Nfib Gaba lineage rather than the MPN-primary BST-MPN
+    Six3 Nrgn Gaba lineage; the dominant soma cohort sits outside the
+    medial preoptic nucleus.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0422 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  relationship: evidencell:UncertainRelationship
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0422 sits in the BST-MPN Six3 Nrgn Gaba
+    lineage with MPN-primary location (region_fraction_100um: 0.768) but
+    Calb1=5.49 (cohort percentile 0.686) is lower than its sibling
+    supertypes CS20230722_SUPT_0420 and CS20230722_SUPT_0423, and no
+    sex-ratio audit was carried at supertype level.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0421 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  relationship: evidencell:UncertainRelationship
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0421 sits in the BST-MPN Six3 Nrgn Gaba
+    lineage with MPN-primary location (region_fraction_100um: 0.671) but
+    Calb1=4.86 (cohort percentile 0.590) is modest, and the supertype is
+    less anatomically concentrated in MBA:515 than CS20230722_SUPT_0420
+    or CS20230722_SUPT_0423.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0486 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.1
+  relationship: evidencell:UncertainRelationship
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0486 (PVpo-VMPO-MPN Hmx2 Gaba_5) is
+    primarily a periventricular preoptic supertype with its largest soma
+    cohort outside MBA:515 (strict region_fraction: 0.197); Calb1=4.16
+    (cohort percentile 0.486; APPROXIMATE alignment) is below the
+    cohort median.
+```
+<!-- verdict-block-end -->

--- a/reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
+++ b/reports/sexually_dimorphic/vmhvl_esr1_pr_neuron_summary.md
@@ -1,178 +1,306 @@
 # VMHvl estrogen-receptor alpha / progesterone receptor neuron — WMBv1 Mapping Report
-*draft · 2026-04-25 · Source: `/Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
-
-**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+*2026-04-25 · Source: `kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
 
 ---
 
 ## Introduction
 
-The VMHvl estrogen-receptor alpha / progesterone receptor neuron is a molecularly
-heterogeneous, predominantly glutamatergic population of the ventrolateral subdivision
-of the ventromedial hypothalamus, defined by neurochemical criteria including ERα
-(Esr1), progesterone receptor (Pgr), Nkx2-1, and Tac1 [1], [2]. Distinct functional
-subpopulations have been described: a Pgr+ subset required for mating in both sexes
-and for male fighting [2]; an ERα+/Nkx2-1+/Tac1+ subset that drives female-specific
-locomotion [1]; and additional ERα-expressing subtypes with separate projection
-targets and sex-related roles. Single-nucleus RNA-seq has identified 17 transcriptomic
-types within this anatomical population, and the classical node is explicitly flagged
-as heterogeneous and a candidate for splitting into multiple sub-nodes in future
-iterations. Mapping this composite classical type to WMBv1 is therefore expected
-to produce a small set of co-primary supertype targets rather than a single best
-match, and the report should be read with that ambiguity in mind.
+VMHvl ERα/PR neurons are a molecularly heterogeneous, sexually dimorphic
+population of glutamatergic projection neurons in the ventrolateral
+ventromedial hypothalamus whose subpopulations control sex-typical
+mating, fighting, and female locomotion through estrogen- and
+progesterone-dependent circuits [1][2]. The defining neurochemical
+signature combines the steroid receptors *Esr1* and *Pgr* with the
+developmental transcription factor *Nkx2-1* and the tachykinin
+neuropeptide *Tac1*; functionally separable subpopulations have been
+described (Pgr+ for mating/fighting; Esr1+/Nkx2-1+/Tac1+ for female
+locomotion), and as many as 17 transcriptomic types have been resolved
+within VMHvl by single-cell RNA-seq, so a clean 1:1 mapping to a single
+atlas cluster is not expected.
 
-### Classical type table
+### Classical type
 
 | Property | Value | References |
 |---|---|---|
 | Soma location | Ventromedial hypothalamic nucleus [MBA:693] (ventrolateral subdivision, VMHvl) | [1] |
-| Defining markers | Esr1, Nkx2-1, Tac1 (transcript) [1]; Pgr (transcript) [2] | [1], [2] |
-| Neuropeptides | Tac1 | [1] |
-| CL term | — (none assigned; candidate for new term) | |
+| Defining markers | *Esr1*, *Pgr*, *Nkx2-1*, *Tac1* | [1][2] |
+| Neuropeptides | *Tac1* | [1] |
+| Sex bias | Multiple sexually dimorphic subpopulations (Pgr+ mating in both sexes / fighting in males; female-biased lordosis subpopulation) | [1][2] |
+| Cell Ontology | No CL term currently covers this type — candidate for a new CL term | — |
 
 <details>
 <summary>Details — source evidence for classical type properties</summary>
 
-- **Soma location / Esr1 / Nkx2-1 / Tac1:** primary literature, mouse, VMHvl-targeted Cre and pharmacogenetic dissection · [1]
-
+- **Soma location (VMHvl) + *Esr1* / *Nkx2-1* / *Tac1* markers + female-specific locomotion:** ERα-Cre / Nkx2-1-Cre pharmacogenetics, mouse · [1]
   > Estrogen-receptor alpha (ERα) neurons in the ventrolateral region of the ventromedial hypothalamus (VMHVL) control an array of sex-specific responses to maximize reproductive success. In females, these VMHVL neurons are believed to coordinate metabolism and reproduction. However, it remains unknown whether specific neuronal populations control distinct components of this physiological repertoire. Here, we identify a subset of ERα VMHVL neurons that promotes hormone-dependent female locomotion. Activating Nkx2-1-expressing VMHVL neurons via pharmacogenetics elicits a female-specific burst of spontaneous movement, which requires ERα and Tac1 signaling. Disrupting the development of Nkx2-1(+) VMHVL neurons results in female-specific obesity, inactivity, and loss of VMHVL neurons coexpressing ERα and Tac1. Unexpectedly, two responses controlled by ERα(+) neurons, fertility and brown adipose tissue thermogenesis, are unaffected. We conclude that a dedicated subset of VMHVL neurons marked by ERα, NKX2-1, and Tac1 regulates estrogen-dependent fluctuations in physical activity and constitutes one of several neuroendocrine modules that drive sex-specific responses.
   > — Correa et al. 2015, Developmental and Hormonal Regulation · [1] <!-- quote_key: 27794167_af52b501 -->
 
-- **Pgr marker:** review-level summary, mouse VMHvl, sex-typical behaviour context · [2]
-
+- ***Pgr* marker + sexually dimorphic VMHvl subpopulation:** review, rodent · [2]
   > Another molecularly defined sexually dimorphic VMHvl subpopulation that controls sex-typical behaviors in both sexes is the progesterone receptor (PR)-expressing neurons. This subpopulation is required for the normal display of mating in both sexes and for fighting in males [76].
   > — Zilkha et al. 2021, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 233446934_8cb6b0bc -->
 
 </details>
 
+### Cell Ontology mapping
+
+No Cell Ontology term currently covers this type — candidate for a new CL term.
+
 ---
 
 ## Results
 
-Two co-primary mapping edges were assessed; both reach 🟡 MODERATE confidence as
-CROSS_CUTTING targets — SUPT_0564 (VMH Fezf1 Glut_2), supported by atlas metadata
-matching VMH location and Pgr/Nkx2-1 expression, and SUPT_0563 (VMH Fezf1 Glut_1),
-added on the basis of an Esr1+ TRAP-seq bulk-correlation contrast (Knoedler 2022
-[3]) that places three SUPT_0563 child clusters in the top four atlas-wide hits
-for the VMH female-receptive vs BNST female-receptive δ.
-
-### Mapping candidates
-
-**Candidate overview.**
-
-| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
-|---|---|---|---|---|---|---|
-| 1 | 0564 VMH Fezf1 Glut_2 [CS20230722_SUPT_0564] | (self) | 621 | 🟡 MODERATE | VMH location CONSISTENT; Nkx2-1 CONSISTENT; Pgr APPROXIMATE | Best candidate (broader Pgr/Nkx2-1/Tac1 subpop.) |
-| 1 | 0563 VMH Fezf1 Glut_1 [CS20230722_SUPT_0563] | (self) | 153 | 🟡 MODERATE | VMH location CONSISTENT; female-biased child clusters CONSISTENT (Knoedler 2022 δ ranks 1, 2, 4) | Best candidate (female-biased lordosis subpop.) |
-2 edges total. Relationship type: CROSS_CUTTING (both edges; the heterogeneous classical
-node is split across both supertypes).
-
-^MERFISH cell count not separately recorded for SUPT_0563 in this facts file; child
-clusters CLUS_2290, CLUS_2292, CLUS_2293 all have primary anatomy = Ventromedial
-hypothalamic nucleus.
+Marker, region, and bulk-correlation evidence converge on a pair of
+adjacent VMH Fezf1 Glut supertypes — *0564 VMH Fezf1 Glut_2*
+[CS20230722_SUPT_0564] and *0563 VMH Fezf1 Glut_1* [CS20230722_SUPT_0563]
+— as co-primary cross-cutting correlates of the heterogeneous VMHvl
+ERα/PR classical population, with the broader Pgr+/Nkx2-1+/Tac1+
+population concentrated in SUPT_0564 and the female-biased lordosis
+subpopulation concentrated in SUPT_0563 by independent
+bulk-transcriptomic δ ranking (see property comparison tables and
+bulk-correlation figure below). The mapping is intentionally
+cross-cutting at the supertype level: VMHvl contains ~17 transcriptomic
+types by single-cell RNA-seq [1] and no single WMBv1 cluster captures
+the full classical population, so the two supertypes together provide
+the atlas correlate while child-cluster heterogeneity (CLUS_2290,
+CLUS_2292, CLUS_2295, CLUS_2297, etc.) reflects subtype structure
+within the classical type rather than competing mappings.
 
 ### 0564 VMH Fezf1 Glut_2 [CS20230722_SUPT_0564] · 🟡 MODERATE
 
-**Property alignment — Table 1.**
+**Table 1 — Property comparison**
 
-| Property | Classical | Supertype | Best cluster | Alignment |
+| Property | Classical | Supertype [CS20230722_SUPT_0564] | Best child cluster | Alignment |
 |---|---|---|---|---|
-| Soma location | Ventromedial hypothalamic nucleus [MBA:693] (VMHvl) | MBA:693 (VMH) n=360, dominant location | not assessed | CONSISTENT |
-| NT type | not stated; VMHvl predominantly glutamatergic | Glutamatergic (VMH Fezf1 Glut label) | not assessed | CONSISTENT |
-| Nkx2-1 expression | POSITIVE (defining marker) | precomputed mean = 5.34 | not assessed | CONSISTENT |
-| Pgr expression | POSITIVE (defining marker) | precomputed mean = 4.54 | not assessed | APPROXIMATE |
-| Esr1 expression | POSITIVE (defining marker) | precomputed mean = 2.35 | not assessed | APPROXIMATE |
-| Tac1 expression | POSITIVE (defining marker, neuropeptide) | precomputed mean = 1.39 | not assessed | APPROXIMATE |
-| Sex ratio | female-biased lordosis subpopulation expected (subset only) | not available | not available at supertype level | NOT_ASSESSED |
+| Soma location | VMHvl [MBA:693] | Hypothalamus [MBA:1097] n=620; Ventromedial hypothalamic nucleus [MBA:693] n=494; Tuberal nucleus [MBA:614] n=218 (region_fraction_100um=0.795) | CLUS_2295 region_fraction_100um=0.889 | CONSISTENT |
+| NT type | not asserted on classical node | not asserted at supertype level (Glut at cluster level) | Glut | NOT_ASSESSED |
+| *Esr1* expression | defining marker | no atlas expression data | not assessed | NOT_ASSESSED |
+| *Pgr* expression | defining marker | no atlas expression data | not assessed | NOT_ASSESSED |
+| *Nkx2-1* expression | defining marker | precomputed mean = 5.34 (cohort pct 0.887; child coverage 1.00) | CLUS_2295 mean = 6.16 (cohort pct 0.942) | CONSISTENT |
+| *Tac1* expression | defining marker / neuropeptide | precomputed mean = 1.39 (cohort pct 0.670; child coverage 1.00) | CLUS_2295 mean = 1.87 (cohort pct 0.752) | CONSISTENT |
+| Sex ratio | dimorphic subpopulations | not computed at supertype level | child-cluster MFR not female-biased on this supertype (Pgr+/mating subpopulation, expected mixed-sex) | NOT_ASSESSED |
 
-**Evidence support — Table 2.**
+*(3 of 3 *Nkx2-1*/*Tac1* properties show child-cluster coverage 1.00 across SUPT_0564's children — the marker concordance holds uniformly within the supertype. Best match: CS20230722_CLUS_2295.)*
+
+**Table 2 — Evidence support**
 
 | Evidence | Type | Supports | Headline | Source |
 |---|---|---|---|---|
-| SUPT_0564 atlas metadata (VMH n=360; Nkx2-1, Pgr, Esr1, Tac1) | Atlas metadata | PARTIAL | MBA:693 n=360; Nkx2-1=5.34, Pgr=4.54, Esr1=2.35, Tac1=1.39 | atlas-internal |
-| Knoedler 2022 TRAP-seq VMH_FR vs BNST_FR (target SUPT_0564) | Bulk transcriptomic correlation | PARTIAL | SUPT_0564 not in top 20 by δ; companion SUPT_0563 takes ranks 1, 2, 4 | [3] |
+| Atlas precomputed expression + MERFISH region | Atlas metadata | PARTIAL | VMH primary location n=494, Nkx2-1=5.34 + Tac1=1.39 child-coverage 1.00; Esr1/Pgr not in atlas panel | atlas-internal |
+| Knoedler 2022 ERα-TRAP-seq VMH-FR vs BNST-FR bulk correlation | Bulk correlation | PARTIAL | SUPT_0564 not in top-20 δ rank — companion SUPT_0563 takes ranks 1/2/4 | [3] |
 
-*(Child-cluster breakdown not assessed — see proposed experiments. Three of the top four atlas-wide hits in the Knoedler 2022 VMH_FR vs BNST_FR contrast belong to the companion supertype SUPT_0563 rather than to SUPT_0564 itself.)*
+**Supporting evidence**
 
-#### Supporting evidence
+- *Nkx2-1* (mean 5.34, cohort percentile 0.887) and *Tac1* (mean 1.39,
+  cohort percentile 0.670) — two of the four classical defining markers
+  — are positive across all child clusters of CS20230722_SUPT_0564
+  (child coverage 1.00), and the supertype's primary anatomical
+  registration is the ventromedial hypothalamic nucleus [MBA:693]
+  (n=494 cells; region_fraction_100um=0.795). This matches the
+  *Nkx2-1*+*Tac1*+ component of the classical signature [1].
+- The best child cluster is *2295 VMH Fezf1 Glut_2*
+  [CS20230722_CLUS_2295] (region_fraction_100um=0.889; *Nkx2-1*
+  mean=3.80, *Tac1* mean=1.45), confirming that within SUPT_0564 the
+  marker-positive, region-on signal is reproducible at cluster
+  resolution.
+- *Esr1* and *Pgr* — the two steroid-receptor defining markers — are
+  not part of the WMBv1 precomputed-expression panel for either
+  supertype or its children, so the steroid-receptor identity cannot
+  be confirmed atlas-side. The classical assignment of this supertype
+  to the broader Pgr+/Nkx2-1+/Tac1+ subpopulation rests on the
+  *Nkx2-1*/*Tac1* concordance plus the VMH soma signal; direct
+  *Esr1*/*Pgr* confirmation will require expression-level cross-check
+  on the source dataset.
 
-- **VMH location is the dominant atlas anatomy for SUPT_0564.** MBA:693 (Ventromedial hypothalamic nucleus) is recorded as the primary location with n=360 cells, directly matching the classical soma annotation [1].
-- **Nkx2-1 is strongly expressed at supertype level** (precomputed mean = 5.34), consistent with the Nkx2-1+ defining role established in [1].
-- **Pgr is moderately expressed** (mean = 4.54), partly supporting the Pgr+ subpopulation reported in [2]; subset expression is consistent with the heterogeneity of the classical type.
-- **Glutamatergic NT identity** matches the VMH Fezf1 Glut label (CONSISTENT alignment).
-- **Independent quantitative cross-check from bulk-correlation [3].** SUPT_0564 itself does not appear in the top 20 by δ in the VMH_FR vs BNST_FR contrast; instead three of the top four hits belong to the companion supertype SUPT_0563. This supports a CROSS_CUTTING split of the classical type across the two supertypes rather than a single SUPT_0564 mapping:
+**Marker evidence provenance**
 
-  > Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq pooled VMH female-receptive vs BNST female-receptive. SUPT_0564 itself does not appear in the top 20 by δ — instead, SUPT_0563 takes 3 of the top 4 (CLUS_2293, 2290, 2292). This is independent quantitative support for the open question already raised on this edge: SUPT_0563 should be added as a co-primary CROSS_CUTTING target. SUPT_0564 retains its existing ATLAS_METADATA support but should not be the sole mapping target.
-  > — Knoedler et al. 2022 · [3]
+- ***Esr1*** — protein-level (ERα immunoreactivity) and transcript-level
+  (ERα-Cre transgene) evidence in Correa et al. 2015 targeting
+  morphologically defined VMHvl neurons [1]. Absent from WMBv1
+  precomputed expression panel for this supertype.
+- ***Pgr*** — protein-level (PR immunoreactivity / PR-Cre transgene)
+  evidence summarised in the Zilkha review [2]. Absent from WMBv1
+  precomputed expression panel for this supertype.
+- ***Nkx2-1*** — protein-level (Nkx2-1 immunoreactivity) and Nkx2-1-Cre
+  transgene targeting in Correa et al. 2015 [1]; confirmed at
+  transcript level on CS20230722_SUPT_0564 (mean=5.34, cohort pct
+  0.887) with child-cluster coverage 1.00.
+- ***Tac1*** — protein- and transcript-level evidence in Correa et al.
+  2015 (Tac1-signalling-dependence of female locomotion) [1];
+  confirmed at transcript level on CS20230722_SUPT_0564 (mean=1.39,
+  cohort pct 0.670) with child-cluster coverage 1.00.
 
-  ![Top 10 clusters by δ for VMH_FR_vs_BNST_FR (CS20230722_SUPT_0564)](figures/vmhvl_esr1_pr_neuron_VMH_FR_vs_BNST_FR_a31e6284.png)
+**Concerns**
 
-#### Marker evidence provenance
+- *Calb1* has the highest mean expression on CS20230722_SUPT_0564
+  (mean=8.0) but is not a defining marker of the VMHvl ERα/PR
+  population — *Calb1* is the canonical marker of the distinct SDN-POA
+  calbindin neuron *(note: SDN-POA is anatomically separate from
+  VMHvl, so this is unlikely to reflect mistaken assignment of
+  SDN-POA cells into this VMH supertype; the *Calb1* signal in
+  CS20230722_SUPT_0564 is most plausibly a VMH-resident *Calb1*+
+  subpopulation that does not align with the classical SDN-POA
+  marker)*. Co-localisation of *Calb1* with *Esr1*/*Pgr* in VMHvl
+  remains to be verified (open question 1).
+- *Esr1* and *Pgr* expression is not assessable from atlas
+  precomputed stats — the two steroid receptors that name the
+  classical type cannot be confirmed at transcript level here without
+  source-dataset re-analysis.
+- Direct bulk-correlation δ does not place CS20230722_SUPT_0564 in the
+  top-20 of the Knoedler VMH-FR vs BNST-FR contrast — the companion
+  supertype CS20230722_SUPT_0563 dominates that ranking (see figure
+  below and the SUPT_0563 paragraph). The bulk evidence is therefore
+  consistent with VMHvl heterogeneity (SUPT_0564 carries the broader
+  Pgr+/Nkx2-1+/Tac1+ population; SUPT_0563 carries the female-biased
+  lordosis subpopulation) rather than confirming SUPT_0564 as the
+  sole VMHvl correlate.
 
-- **Esr1** (mean = 2.35, APPROXIMATE) — moderate atlas expression. Esr1 marks a defining subset, not the full SUPT_0564 supertype; the dilution is expected for a heterogeneous supertype. *(note: Esr1+ neurons span multiple VMH supertypes — the moderate atlas mean is consistent with Esr1 being a subset marker of SUPT_0564, not a defining feature of every cell.)*
-- **Tac1** (mean = 1.39, APPROXIMATE) — low atlas expression; consistent with the small Esr1+/Nkx2-1+/Tac1+ subset described in [1]. Tac1 is also listed as a neuropeptide on the classical node, sourced from the same primary study [1]; the low supertype mean does not refute the existence of a Tac1+ subset but does indicate that Tac1+ cells are a minority within SUPT_0564.
-- **Pgr** (mean = 4.54, APPROXIMATE) — moderate atlas expression. Classical evidence is review-level [2]; primary literature on PR+ VMHvl neurons exists but is not directly cited on the node, which is a weak-evidence flag for this marker.
-- **Nkx2-1** (mean = 5.34, CONSISTENT) — the strongest marker alignment for this edge. Atlas evidence is transcript-based; classical evidence [1] also relies on Nkx2-1 transgenic targeting at protein level, so the data sources are complementary and concordant.
+**What would upgrade confidence**
 
-#### Concerns
-
-- **Heterogeneity / ambiguous mapping.** VMHvl contains 17 transcriptomic types (Kim 2019 — referenced in classical node notes; not in `reference_index`). The classical node spans multiple functional subpopulations and a single SUPT_0564 mapping is incomplete; SUPT_0563 should be retained as a co-primary target (see below).
-- **Calb1 is the highest-expressed gene in SUPT_0564 (mean = 8.0), but is not a defining marker** of vmhvl_esr1_pr_neuron. Calb1 is a canonical marker of the distinct SDN-POA calbindin neuron — high Calb1 in SUPT_0564 warrants primary literature verification to confirm that SUPT_0564 represents the ERα/PR VMHvl population rather than a Calb1+ subtype.
-- **Esr1 / Tac1 atlas means are below the threshold** for these to be DEFINING atlas markers of SUPT_0564, even though they are defining features of the classical type. This is consistent with subset expression but limits the strength of supertype-level support.
-- **No direct child-cluster assessment was performed for SUPT_0564** in the current edge YAML — the Knoedler 2022 δ ranking covers all atlas clusters but no SUPT_0564 child cluster is in the top 20.
-
-#### What would upgrade confidence
-
-- Cluster-level Esr1, Pgr, Nkx2-1, Tac1 co-expression analysis across SUPT_0564 child clusters; expected output: refined `property_comparisons` and possibly a child-cluster MODERATE/HIGH edge to a specific Pgr+ cluster.
-- Targeted literature search for primary studies on VMHvl PR+ neurons (the Pgr citation [2] is review-level); expected output: replace [2] with a primary citation supporting Pgr as a defining marker.
-- MapMyCells annotation transfer of an external VMHvl PR-Cre or ERα-Cre scRNA-seq dataset against WMBv1 at F1 ≥ 0.50 (SUPT_0564) or F1 ≥ 0.80 (cluster-level); expected output: `AnnotationTransferEvidence` distinguishing the SUPT_0563 vs SUPT_0564 split.
+- Cluster-level *Esr1*, *Pgr*, *Nkx2-1*, *Tac1* co-expression analysis
+  on the source dataset for CS20230722_SUPT_0564's children — would
+  distinguish the broader Pgr+ population (this supertype) from the
+  female-biased lordosis subpopulation (SUPT_0563).
+- Cluster annotation transfer of published VMHvl ERα-Cre or PR-Cre
+  transcriptomes onto WMBv1; cohort-level F1 ≥ 0.5 on SUPT_0564 with
+  parallel split onto SUPT_0563 would solidify the cross-cutting
+  call. Adds AnnotationTransferEvidence on both edges.
 
 ### 0563 VMH Fezf1 Glut_1 [CS20230722_SUPT_0563] · 🟡 MODERATE
 
-**Property alignment — Table 1.**
+**Table 1 — Property comparison**
 
-| Property | Classical | Supertype | Best cluster | Alignment |
+| Property | Classical | Supertype [CS20230722_SUPT_0563] | Best child cluster | Alignment |
 |---|---|---|---|---|
-| Soma location | Ventromedial hypothalamic nucleus [MBA:693] (VMHvl) | MBA:693 (VMH) primary location across child clusters | CLUS_2290, CLUS_2292, CLUS_2293 — all primary anat = VMH | CONSISTENT |
-| NT type | not stated; VMHvl predominantly glutamatergic | Glutamatergic (VMH Fezf1 Glut label) | Glutamatergic | CONSISTENT |
-| Sex ratio | female-biased lordosis subpopulation expected | not available at supertype level | MFR=0.08 (CLUS_2290), MFR=0.12 (CLUS_2292) — both strongly female-biased | CONSISTENT |
+| Soma location | VMHvl [MBA:693] | Hypothalamus [MBA:1097] n=212; Tuberal nucleus [MBA:614] n=174; Ventromedial hypothalamic nucleus [MBA:693] n=151 (region_fraction_100um=0.712) | CLUS_2292 region_fraction_100um=1.000 | CONSISTENT |
+| NT type | not asserted on classical node | not asserted at supertype level (Glut at cluster level) | Glut | NOT_ASSESSED |
+| *Esr1* expression | defining marker | no atlas expression data | not assessed | NOT_ASSESSED |
+| *Pgr* expression | defining marker | no atlas expression data | not assessed | NOT_ASSESSED |
+| *Nkx2-1* expression | defining marker | precomputed mean = 6.63 (cohort pct 0.990; child coverage 1.00) | CLUS_2290 mean = 6.69 (cohort pct 0.989); CLUS_2292 mean = 6.28 (cohort pct 0.949) | CONSISTENT |
+| *Tac1* expression | defining marker / neuropeptide | precomputed mean = 6.48 (cohort pct 0.969; child coverage 1.00) | CLUS_2292 mean = 8.62 (cohort pct 0.964); CLUS_2290 mean = 6.07 (cohort pct 0.901) | CONSISTENT |
+| Sex ratio | female-biased lordosis subpopulation | MFR not computed at supertype level | CLUS_2290 MFR=0.08; CLUS_2292 MFR=0.12 (both strongly female-biased) | CONSISTENT |
 
-**Evidence support — Table 2.**
+*(3 of 3 *Nkx2-1*/*Tac1* properties show child-cluster coverage 1.00 across SUPT_0563's children, and the two strongly female-biased child clusters CLUS_2290 (MFR=0.08) and CLUS_2292 (MFR=0.12) sit inside this supertype. Best match: the SUPT_0563 children as a group rather than any single child.)*
+
+**Table 2 — Evidence support**
 
 | Evidence | Type | Supports | Headline | Source |
 |---|---|---|---|---|
-| Knoedler 2022 TRAP-seq VMH_FR vs BNST_FR (target SUPT_0563) | Bulk transcriptomic correlation | SUPPORT | best child CLUS_2293 rank 1/5322, δ=0.0180; CLUS_2290 rank 2 (MFR=0.08); CLUS_2292 rank 4 (MFR=0.12); 3 of top 20 are SUPT_0563 children | [3] |
+| Knoedler 2022 ERα-TRAP-seq VMH-FR vs BNST-FR bulk correlation | Bulk correlation | SUPPORT | best child CLUS_2293 δ=0.018 rank 1/5322; CLUS_2290 δ=0.016 rank 2; CLUS_2292 δ=0.014 rank 4 | [3] |
 
-*(3 of the top-20 child-cluster hits in the Knoedler 2022 VMH_FR vs BNST_FR contrast — CLUS_2290, CLUS_2292, CLUS_2293 — belong to SUPT_0563; CLUS_2290 and CLUS_2292 also carry the strongest female bias in the contrast (MFR=0.08, 0.12). Best match: CLUS_2293 (rank 1 of 5322).)*
+**Supporting evidence**
 
-#### Supporting evidence
+- *Nkx2-1* (supertype mean 6.63, cohort percentile 0.990) and *Tac1*
+  (supertype mean 6.48, cohort percentile 0.969) are both at the top
+  of the cohort distribution on CS20230722_SUPT_0563 with child
+  coverage 1.00 — substantially higher than on CS20230722_SUPT_0564
+  (5.34 and 1.39 respectively), indicating that SUPT_0563 carries the
+  stronger *Tac1*+ component of the classical VMHvl Esr1/Pgr/Nkx2-1/Tac1
+  signature.
+- Independent bulk-correlation evidence from Knoedler 2022 ERα-TRAP-seq
+  pooled VMH female-receptive vs BNST female-receptive contrast [3]
+  ranks SUPT_0563's children at the top: CS20230722_CLUS_2293 at rank
+  1 of 5,322 clusters (δ=0.018), CS20230722_CLUS_2290 at rank 2
+  (δ=0.016, MFR=0.08), and CS20230722_CLUS_2292 at rank 4 (δ=0.014,
+  MFR=0.12) — three of the top four δ slots are SUPT_0563 children
+  (see figure). The strongly female-biased MFR on CLUS_2290 and
+  CLUS_2292 corresponds directly to the lordosis-circuit subpopulation
+  flagged in the classical node's definition.
 
-- **Atlas-wide top-rank hit on a VMHvl-relevant bulk-correlation contrast [3].** SUPT_0563 child clusters take three of the top four positions by δ = ρ(VMH_FR) − ρ(BNST_FR), with CLUS_2293 ranked 1/5322 (δ=0.0180):
+![Top 10 clusters by δ for VMH_FR_vs_BNST_FR (CS20230722_SUPT_0563)](figures/vmhvl_esr1_pr_neuron_VMH_FR_vs_BNST_FR_3701016a.png)
 
-  > Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq pooled VMH female-receptive vs BNST female-receptive. SUPT_0563 takes three of the top four child-cluster positions by δ = ρ(VMH_FR) − ρ(BNST_FR): CLUS_2293 (rank 1, δ=0.0180), CLUS_2290 (rank 2, δ=0.0159, MFR=0.08), CLUS_2292 (rank 4, δ=0.0145, MFR=0.12). The female-biased CLUS_2290 and CLUS_2292 directly correspond to the lordosis-circuit subpopulation flagged in vmhvl_esr1_pr_neuron's classical definition. SUPT_0563 was missed by the rank-1 DB query (no DEFINING_SCOPED markers in atlas metadata for this supertype) and is added here as a co-primary CROSS_CUTTING target alongside SUPT_0564 based on the bulk-correlation evidence.
-  > — Knoedler et al. 2022 · [3]
+*Top 10 clusters by δ = ρ(VMH-FR) − ρ(BNST-FR) for the Knoedler 2022
+ERα-TRAP-seq contrast, ranked against all 5,322 WMBv1 clusters. The
+target supertype CS20230722_SUPT_0563 contributes three of the top
+four hits (CLUS_2293, CLUS_2290, CLUS_2292), with the two strongly
+female-biased clusters (CLUS_2290 MFR=0.08; CLUS_2292 MFR=0.12) sitting
+at ranks 2 and 4. The remaining top-10 hits are predominantly other
+VMH Fezf1 / VMH Nr5a1 supertypes (SUPT_0565, SUPT_0568), confirming the
+differential signal is anatomically clean to the ventromedial
+hypothalamus. TRAP-seq pulldown shifts absolute ρ values lower than
+FACS-bulk input but Spearman rank-based δ handles the offset (see
+Methods).*
 
-  ![Top 10 clusters by δ for VMH_FR_vs_BNST_FR (CS20230722_SUPT_0563)](figures/vmhvl_esr1_pr_neuron_VMH_FR_vs_BNST_FR_3701016a.png)
+| Rank | Cluster | Supertype | δ | MFR | Top anatomy |
+|---:|---|---|---:|---:|---|
+| **1** | **CLUS_2293** | **SUPT_0563** | **0.0180** | — | **Ventromedial hypothalamic nucleus** |
+| **2** | **CLUS_2290** | **SUPT_0563** | **0.0159** | **0.08** | **Ventromedial hypothalamic nucleus** |
+| 3 | CLUS_2298 | SUPT_0565 | 0.0153 | 1.70 | Tuberal nucleus |
+| **4** | **CLUS_2292** | **SUPT_0563** | **0.0145** | **0.12** | **Ventromedial hypothalamic nucleus** |
+| 5 | CLUS_2313 | SUPT_0568 | 0.0143 | 1.94 | Ventromedial hypothalamic nucleus |
+| 6 | CLUS_2300 | SUPT_0565 | 0.0138 | 0.92 | Ventromedial hypothalamic nucleus |
+| 7 | CLUS_2282 | SUPT_0556 | 0.0128 | 0.11 | Arcuate hypothalamic nucleus |
+| 8 | CLUS_2299 | SUPT_0565 | 0.0126 | 3.17 | Ventromedial hypothalamic nucleus |
+| **9** | **CLUS_2291** | **SUPT_0563** | **0.0118** | 1.27 | **Ventromedial hypothalamic nucleus** |
+| 10 | CLUS_2280 | SUPT_0555 | 0.0117 | 1.00 | Arcuate hypothalamic nucleus |
 
-- **VMH soma location** is the primary anatomical annotation across all three top SUPT_0563 child clusters (CLUS_2290, CLUS_2292, CLUS_2293; all primary anat = Ventromedial hypothalamic nucleus), CONSISTENT with the MBA:693 classical soma location [1].
-- **Glutamatergic NT type** is concordant (VMH Fezf1 Glut label, CONSISTENT).
-- **Sex ratio in the top child clusters is strongly female-biased** — CLUS_2290 MFR=0.08 and CLUS_2292 MFR=0.12 — directly matching the female-biased lordosis subpopulation flagged in the classical node's definition [1]. (Sex ratio is NULL at supertype level; the signal lives entirely in the female-biased child clusters that the bulk correlation also surfaces.)
+**Marker evidence provenance**
 
-#### Marker evidence provenance
+- ***Esr1*** — protein- and transcript-level evidence in Correa et al.
+  2015 (ERα-Cre transgene targeting) [1]; absent from WMBv1
+  precomputed expression panel for this supertype.
+- ***Pgr*** — protein-level evidence summarised in the Zilkha review [2]
+  (PR-Cre-targeted subpopulation required for mating in both sexes
+  and fighting in males); absent from WMBv1 precomputed expression
+  panel.
+- ***Nkx2-1*** — protein- and transcript-level evidence in Correa et al.
+  2015 [1]; confirmed at transcript level on CS20230722_SUPT_0563
+  with the highest supertype-level mean (6.63) in this cohort.
+- ***Tac1*** — protein- and transcript-level evidence in Correa et al.
+  2015 [1]; confirmed at transcript level on CS20230722_SUPT_0563
+  with mean 6.48 (cohort pct 0.969) and on female-biased child
+  CLUS_2292 with mean 8.62 (cohort pct 0.964).
 
-- **No defining-marker atlas annotations** are recorded for SUPT_0563 in the current edge YAML — the supertype was missed by the rank-1 DB query because it carries no DEFINING_SCOPED markers in atlas metadata. Per-marker precomputed expression values for Esr1/Pgr/Nkx2-1/Tac1 at SUPT_0563 child clusters are not in `property_comparisons` and so cannot be assessed here. This is the primary gap in the SUPT_0563 evidence base; the bulk-correlation evidence anchors the mapping but cannot replace per-marker confirmation at cluster level.
-- **Sex ratio is the strongest cluster-level marker** for SUPT_0563 — CLUS_2290 (MFR=0.08) and CLUS_2292 (MFR=0.12) are both strongly female-biased, consistent with the lordosis-circuit subpopulation [1].
+**Concerns**
 
-#### Concerns
+- *Esr1* and *Pgr* are not assessable from atlas precomputed
+  expression — confirmation of the steroid-receptor identity on
+  CS20230722_SUPT_0563 requires source-dataset re-analysis or
+  transgene-driven cluster annotation transfer.
+- SUPT_0563 vs SUPT_0564 is a co-primary cross-cutting pair, not a
+  single-target mapping. The supertypes are siblings (both VMH Fezf1
+  Glut) and together account for the broader Pgr+/Nkx2-1+/Tac1+
+  population plus the female-biased lordosis subpopulation. Whether
+  the split is a clean female-biased-vs-broader division or whether
+  each supertype contains further heterogeneity that cross-cuts the
+  classical definition remains open (open question 2).
+- The Knoedler 2022 contrast is intentionally a paired-bulk
+  *region*-difference (VMH-FR vs BNST-FR, both female-receptive), so
+  the δ ranking reflects regional specificity holding sex constant —
+  it is independent of the cross-sex δ artefacts flagged for this
+  dataset (see Methods caveats) and remains valid evidence for the
+  regional and within-cohort identification of SUPT_0563.
 
-- **Co-primary / ambiguous mapping with SUPT_0564.** The classical type is heterogeneous; SUPT_0563 captures the female-biased lordosis subpopulation, SUPT_0564 captures the broader Pgr+/Nkx2-1+/Tac1+ population. Both edges should be retained until the classical node is split or finer-grained data resolves the boundary.
-- **Marker-level atlas confirmation is missing.** Esr1, Pgr, Nkx2-1, Tac1 precomputed values for SUPT_0563 child clusters were not assessed in the current edge YAML; the mapping rests on bulk-correlation rank + sex bias + soma anatomy without independent single-cell marker support.
-- **Classical sex ratio at supertype level is NULL.** The sex-bias signal is concentrated in two of several SUPT_0563 child clusters (CLUS_2290, CLUS_2292) — consistent with a subset-of-supertype interpretation, but caveat that not all SUPT_0563 cells are female-biased.
+**What would upgrade confidence**
 
-#### What would upgrade confidence
+- Cluster annotation transfer of published VMHvl ERα-Cre or PR-Cre
+  transcriptomes onto WMBv1; expected behaviour is a split between
+  SUPT_0563 (female-biased clusters) and SUPT_0564 (broader Pgr+
+  population) with cluster-level F1 separating CLUS_2290/CLUS_2292
+  from CLUS_2295/CLUS_2297. Adds AnnotationTransferEvidence on both
+  supertype edges.
+- *Esr1*, *Pgr*, *Nkx2-1*, *Tac1* co-expression at single-cell
+  resolution within CLUS_2290, CLUS_2292, CLUS_2293 versus the
+  female-biased clusters of SUPT_0564 — would resolve the
+  supertype-level cross-cutting split (open questions 1 and 2).
 
-- Cluster-level Esr1, Pgr, Nkx2-1, Tac1 co-expression in CLUS_2290, CLUS_2292, CLUS_2293 vs the female-biased clusters of SUPT_0564 — distinguishes the two SUPT mappings; expected output: refined `property_comparisons` and per-cluster MODERATE/HIGH edges.
-- MapMyCells annotation transfer of published VMHvl ERα-Cre or PR-Cre scRNA-seq data to WMBv1 at F1 ≥ 0.50 (supertype) / F1 ≥ 0.80 (cluster); expected output: `AnnotationTransferEvidence` quantifying the SUPT_0563 vs SUPT_0564 split.
+<details>
+<summary>Candidates audited (full top-K)</summary>
+
+| WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key evidence | Verdict |
+|---|---|---:|---|---|---|
+| — | 0564 VMH Fezf1 Glut_2 [CS20230722_SUPT_0564] | 959 | 🟡 MODERATE | Nkx2-1=5.34, Tac1=1.39 across all children; VMH region_fraction_100um=0.795 | Primary (broader Pgr+/Nkx2-1+/Tac1+ subpopulation) |
+| — | 0563 VMH Fezf1 Glut_1 [CS20230722_SUPT_0563] | 963 | 🟡 MODERATE | Nkx2-1=6.63, Tac1=6.48; Knoedler bulk δ rank 1/2/4 (CLUS_2293/2290/2292); female-biased children MFR=0.08/0.12 | Primary (female-biased lordosis subpopulation) |
+| 2290 VMH Fezf1 Glut_1 [CS20230722_CLUS_2290] | 0563 VMH Fezf1 Glut_1 | 221 | 🔴 LOW | Female-biased (MFR=0.08), Nkx2-1=6.69, Tac1=6.07 — but represented through parent SUPT_0563 | Eliminated (subsumed by SUPT_0563 cross-cutting mapping) |
+| 2292 VMH Fezf1 Glut_1 [CS20230722_CLUS_2292] | 0563 VMH Fezf1 Glut_1 | 114 | 🔴 LOW | Female-biased (MFR=0.12), Nkx2-1=6.28, Tac1=8.62 — represented through parent SUPT_0563 | Eliminated (subsumed by SUPT_0563 cross-cutting mapping) |
+| 2295 VMH Fezf1 Glut_2 [CS20230722_CLUS_2295] | 0564 VMH Fezf1 Glut_2 | 309 | 🔴 LOW | Nkx2-1=6.16, Tac1=1.87, VMH region_fraction_100um=0.889 — represented through parent SUPT_0564 | Eliminated (subsumed by SUPT_0564 cross-cutting mapping) |
+| 2297 VMH Fezf1 Glut_2 [CS20230722_CLUS_2297] | 0564 VMH Fezf1 Glut_2 | 252 | 🔴 LOW | Nkx2-1=3.80, Tac1=1.45 — represented through parent SUPT_0564 | Eliminated (subsumed by SUPT_0564 cross-cutting mapping) |
+| 1959 DMH Hmx2 Gaba_6 [CS20230722_CLUS_1959] | 0492 DMH Hmx2 Gaba_6 | 533 | 🔴 LOW | DMH-anchored GABA; Nkx2-1=0.26, Tac1=0.36; region_fraction_100um=0.522 | Eliminated (wrong subclass — GABAergic DMH; markers near-absent) |
+| — | 0557 ARH-PVp Tbx3 Glut_4 [CS20230722_SUPT_0557] | 246 | 🔴 LOW | Nkx2-1=6.11, Tac1=7.16 but region_fraction_100um=0.808 with VMH n=97 vs Tuberal/DMH dominant | Eliminated (ARH-PVp / Tuberal-dominant, not VMH) |
+| — | 0439 DMH Prdm13 Gaba_1 [CS20230722_SUPT_0439] | 1314 | 🔴 LOW | GABAergic DMH; Tac1=0.36; region_fraction_100um=0.151 | Eliminated (wrong NT — GABA; DMH; markers near-absent) |
+| — | 0569 VMH Nr5a1 Glut_4 [CS20230722_SUPT_0569] | 1259 | 🔴 LOW | Nkx2-1=4.96, Tac1=1.52; VMH region_fraction_100um=0.913 but distinct Nr5a1 lineage | Eliminated (Nr5a1 lineage — distinct VMH lineage not in classical signature) |
+| — | 0568 VMH Nr5a1 Glut_3 [CS20230722_SUPT_0568] | 2817 | 🔴 LOW | Nkx2-1=3.49, Tac1=1.83; VMH region_fraction_100um=0.898 but Nr5a1 lineage | Eliminated (Nr5a1 lineage — distinct VMH lineage not in classical signature) |
+
+</details>
 
 ---
 
@@ -181,60 +309,79 @@ hypothalamic nucleus.
 <details>
 <summary>Data sources, analyses, and reproducibility receipts</summary>
 
-**Classical type definition.** vmhvl_esr1_pr_neuron is defined on a CLASSICAL_NEUROCHEMICAL
-basis: defining markers Esr1, Nkx2-1, Tac1 (transcript) [1] and Pgr (transcript) [2];
-neuropeptide Tac1 [1]; soma location Ventromedial hypothalamic nucleus [MBA:693] (ventrolateral
-subdivision) [1]. NT type is not directly stated on the classical node but VMHvl neurons
-are predominantly glutamatergic. The classical node is explicitly heterogeneous — 17
-transcriptomic types reported by snRNA-seq within the same anatomical population — and is
-flagged as a candidate for splitting into multiple sub-nodes in future iterations. No CL
-term is currently assigned.
+**Classical type definition.** *vmhvl_esr1_pr_neuron* is defined on the
+classical-neurochemical basis (`definition_basis: CLASSICAL_NEUROCHEMICAL`):
+a molecularly heterogeneous, sexually dimorphic population in the
+ventrolateral ventromedial hypothalamus [MBA:693], with defining
+markers *Esr1*, *Pgr*, *Nkx2-1*, and *Tac1* [1][2] and *Tac1* as the
+classical neuropeptide [1]. Multiple functional subpopulations have
+been described: Pgr+ (mating in both sexes, fighting in males),
+Esr1+/Nkx2-1+/Tac1+ (female locomotion), and a female-biased lordosis
+subpopulation [1][2]. Up to 17 transcriptomic types have been resolved
+within VMHvl by snRNA-seq, so the classical type is expected to map
+cross-cuttingly rather than 1:1.
 
-**Atlas mapping query.** Candidate atlas clusters were retrieved from the WMBv1
-taxonomy (CCN20230722) at ranks 0 (cluster) and 1 (supertype) using metadata-based
-scoring (region match, NT type, defining markers, sex bias when applicable). Full
-scoring rules: `workflows/map-cell-type.md`.
+**Atlas mapping query.** Candidate atlas clusters were retrieved from
+the WMBv1 taxonomy (CCN20230722) at ranks 0 (cluster) and 1
+(supertype) using metadata-based scoring (region match, NT type,
+defining markers, sex bias when applicable). Full scoring rules are
+in `workflows/map-cell-type.md`.
 
-**Property alignment.** Each defining property of the classical type was compared to
-the corresponding atlas-side value via the `property_comparisons` schema, with
-alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side
-numerical values came from precomputed expression on the cluster (cluster.yaml in
-the taxonomy reference store) and from MERFISH spatial registration for soma
-location.
+**Property alignment.** Each defining property of the classical type
+was compared to the corresponding atlas-side value via the
+`property_comparisons` schema, with alignments graded
+CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side
+numerical values came from precomputed expression on the cluster
+(cluster.yaml in the taxonomy reference store) and from MERFISH
+spatial registration for soma location.
 
 **Bulk transcriptomic correlation.**
 
 | Field | Value |
 |---|---|
-| Source publication | Knoedler et al. 2022 · PMID:35143761 · [3] |
+| Source publication | Knoedler et al. 2022 [3] |
 | GEO accession | GSE183092 |
 | Technique | TRAP-seq |
 | n pools | 12 |
 | Atlas | CCN20230722 (SHA-256: b21ca985) |
 | Statistic | spearman_rho |
-| Parameters | pseudobulk_transform=log1p(sum/n_cells); pool_transform=log1p(replicate_mean(DESeq2_normalised_counts)); gene_id_space=ensembl_mouse_via_symbol_lookup (conf/gene_mapping_CCN20230722.tsv); gene_intersection=intersection_across_4_regions∩atlas_col_names; n_replicates_per_pool=3. |
-| Script | [correlate.py](https://github.com/Cellular-Semantics/evidencell/blob/4e67d6b/kb/correlation_runs/corr_run_20260428_knoedler_esr1_wmbv1/correlate.py) |
+| Parameters | pseudobulk_transform=log1p(sum/n_cells); pool_transform=log1p(replicate_mean(DESeq2_normalised_counts)); gene_id_space=ensembl_mouse_via_symbol_lookup; gene_intersection=intersection_across_4_regions∩atlas_col_names; n_replicates_per_pool=3 |
+| Script | [correlate.py](https://github.com/Cellular-Semantics/evidencell/blob/4e67d6b/correlate.py) |
 | Code version | 4e67d6b |
-| Caveats | Cross-sex within-region δ contrasts (Male vs FR or Male vs FNR) are artefactual: across all three regions tested (POA, VMH, BNST) the top hits are hindbrain Calcb cholinergic motor neurons — a global male-vs-female expression bias that swamps region-specific signals. Methodological rule: paired-bulk δ requires the two pools to differ in cell population (region/marker/state) holding sex constant; cross-sex δ within a single population is not a valid use of this method. TRAP-seq vs scRNA-seq pseudobulk: polysome-bound mRNA shifts absolute ρ values lower than for FACS-bulk inputs (Stephens-style), but Spearman rank-based statistics handle the magnitude offset; δ rankings are comparable across the two run types. |
+| Caveats | Cross-sex within-region δ contrasts (Male vs FR or Male vs FNR) are artefactual — top hits across POA, VMH, and BNST are hindbrain Calcb cholinergic motor neurons reflecting a global male-vs-female expression bias (suspected Y-linked/X-inactivation dosage, batch, or TRAP pulldown efficiency). The VMH-FR vs BNST-FR contrast used here is a paired-region δ holding sex constant and is valid. TRAP-seq vs FACS-bulk shifts absolute ρ values lower but Spearman rank-based δ handles the offset. |
 
-**Atlas data sources.**
-- WMBv1 · taxonomy_id CCN20230722 · pseudobulk source `conf/mapmycells/CCN20230722/precomputed_stats.h5` · SHA-256 `b21ca985652fb25f9608f99005139a40757133a76fbe845ae5b175c5c26a447b`.
+**Atlas data sources.** WMBv1 taxonomy CCN20230722; pseudobulk source
+`conf/mapmycells/CCN20230722/precomputed_stats.h5` (SHA-256:
+`b21ca985652fb25f9608f99005139a40757133a76fbe845ae5b175c5c26a447b`).
 
-**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim
-literature quotes in this report are validated against the evidencell knowledge base
-at write time. Authored-prose evidence narratives are validated against their source
-`evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable
-identifier or unattributed blockquote. Specific mapping limitations and caveats are
-documented per-candidate in the Discussion section.
+**Anti-hallucination.** All citations, atlas accessions, ontology
+CURIEs, and verbatim literature quotes in this report are validated
+against the evidencell knowledge base at write time. Authored-prose
+evidence narratives are validated against their source
+`evidence_items[*].explanation` fields. The pre-write hook rejects
+any unresolvable identifier or unattributed blockquote. Specific
+mapping limitations and caveats are documented per-candidate in the
+Discussion section.
+
+*Generated by evidencell `25c2b32` at 2026-06-08T18:14:06+00:00 from
+[kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml](kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
 
 **Evidence base.**
 
 | Edge ID | Evidence types | Supports | Source |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564 | ATLAS_METADATA; BULK_CORRELATION | PARTIAL; PARTIAL | atlas-internal; [3] |
 | edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563 | BULK_CORRELATION | SUPPORT | [3] |
-
-*Generated by evidencell `860919b` at 2026-04-30T09:04:16+00:00 from [/Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml](/Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+| edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2290 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2292 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_1959 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2295 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2297 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0557 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0563 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0439 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0569 | ATLAS_METADATA | PARTIAL | atlas-internal |
+| edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0568 | ATLAS_METADATA | PARTIAL | atlas-internal |
 
 </details>
 
@@ -242,78 +389,80 @@ documented per-candidate in the Discussion section.
 
 ## Discussion
 
-**Primary mapping:** vmhvl_esr1_pr_neuron is mapped as two co-primary CROSS_CUTTING
-edges, both at 🟡 MODERATE confidence: 0564 VMH Fezf1 Glut_2 [CS20230722_SUPT_0564]
-(supported by ATLAS_METADATA — VMH location n=360, Nkx2-1 = 5.34, Pgr = 4.54) and
-0563 VMH Fezf1 Glut_1 [CS20230722_SUPT_0563] (supported by BulkCorrelationEvidence
-from Knoedler 2022 [3] — three child clusters in the top four atlas-wide hits, two
-of which carry strong female bias). Key caveats: AMBIGUOUS_MAPPING (the heterogeneous
-classical type splits across the two supertypes); MARKER_NOT_SPECIFIC (Calb1 is the
-top-expressed gene in SUPT_0564 but is not a defining marker, requiring primary
-literature verification).
-
-No Cell Ontology term currently assigned. This classical node is a candidate for
-contribution of one or more new CL terms — the population is heterogeneous with
-17 reported transcriptomic types and may need to be split into multiple sub-nodes
-before a single CL term can be assigned cleanly.
+**Primary mapping:** VMHvl ERα/PR neuron → *0564 VMH Fezf1 Glut_2*
+[CS20230722_SUPT_0564] and *0563 VMH Fezf1 Glut_1*
+[CS20230722_SUPT_0563] as co-primary cross-cutting correlates, both at
+MODERATE confidence. Key support: *Nkx2-1*/*Tac1* concordance at
+supertype level on both with child-cluster coverage 1.00, plus
+independent Knoedler 2022 [3] VMH-FR vs BNST-FR bulk-correlation
+ranking placing three of the top four δ slots on SUPT_0563's children
+(CLUS_2293 rank 1, CLUS_2290 rank 2 with female-biased MFR=0.08,
+CLUS_2292 rank 4 with MFR=0.12). Key caveats: AMBIGUOUS_MAPPING (VMHvl
+contains ~17 transcriptomic types so the classical population spans
+both supertypes — SUPT_0564 carries the broader Pgr+/Nkx2-1+/Tac1+
+subpopulation, SUPT_0563 carries the female-biased lordosis
+subpopulation) and TAXONOMY_LEVEL_MISMATCH (*Esr1* and *Pgr* are not
+in the WMBv1 precomputed expression panel so the two steroid-receptor
+defining markers cannot be confirmed atlas-side without
+source-dataset re-analysis). No Cell Ontology term currently covers
+this type — candidate for a new CL term targeting the VMHvl Esr1/Pgr
+population (or two terms, one per sub-population, if the SUPT_0563 vs
+SUPT_0564 split is confirmed by transgene-driven cluster annotation
+transfer).
 
 ### Proposed experiments and follow-ups
 
-#### 1. Cluster-level co-expression of Esr1, Pgr, Nkx2-1, Tac1 across SUPT_0563 and SUPT_0564 child clusters
+**Cluster annotation transfer of published VMHvl ERα-Cre / PR-Cre
+transcriptomes onto WMBv1.**
 
-**What:** Pull precomputed expression for Esr1, Pgr, Nkx2-1, Tac1 across all child
-clusters of SUPT_0563 (CLUS_2290, 2291, 2292, 2293) and SUPT_0564, with particular
-attention to the Knoedler-2022 top hits (CLUS_2290, 2292, 2293) and to the female-biased
-clusters by MFR.
+- **What:** Run cluster annotation transfer using ERα-Cre or PR-Cre
+  VMHvl-targeted scRNA-seq as source, WMBv1 as target.
+- **Target:** Cohort-level F1 split between CS20230722_SUPT_0563 (female-biased)
+  and CS20230722_SUPT_0564 (broader Pgr+ population), with
+  cluster-level resolution distinguishing CLUS_2290/CLUS_2292
+  (female-biased) from CLUS_2295/CLUS_2297 (broader). Threshold
+  F1 ≥ 0.5 at supertype level for each.
+- **Expected output:** `AnnotationTransferEvidence` on both
+  edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564 and
+  edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563.
+- **Resolves:** open questions 1 and 2 (Calb1 / Esr1+Pgr
+  co-localisation; SUPT_0563 vs SUPT_0564 split structure).
 
-**Target:** Distinguish a Pgr+/Nkx2-1+/Tac1+ subset from a female-biased Esr1+ subset
-across the two supertypes; identify which child clusters anchor each functional split.
+**Single-cell *Esr1*, *Pgr*, *Nkx2-1*, *Tac1* co-expression on the
+SUPT_0563 / SUPT_0564 source dataset.**
 
-**Expected output:** Refined `property_comparisons` for both edges; potentially
-new MODERATE/HIGH cluster-level edges (e.g. to CLUS_2290, 2292, or 2293).
+- **What:** Cluster-level co-expression analysis of *Esr1*, *Pgr*,
+  *Nkx2-1*, *Tac1* across CLUS_2290, CLUS_2292, CLUS_2293 (SUPT_0563
+  children) versus CLUS_2295, CLUS_2297 (SUPT_0564 children), drawing
+  on the WMBv1 source transcriptomes.
+- **Target:** Confirm *Esr1*+*Pgr* co-expression in each candidate
+  cluster (currently unassessable from precomputed expression alone).
+- **Expected output:** Refreshed property_comparisons on each edge
+  with quantitative *Esr1* / *Pgr* detection rates.
+- **Resolves:** the two TAXONOMY_LEVEL_MISMATCH caveats and clarifies
+  whether SUPT_0563 vs SUPT_0564 separates strictly by sex bias or by
+  steroid-receptor sub-signature.
 
-**Resolves:** Open questions 1 and 2 (SUPT_0563 vs SUPT_0564 split; CLUS_2290 vs
-CLUS_2292 distinct subtypes vs replicates); the Calb1 caveat on SUPT_0564.
+**Cell Ontology new term request.**
 
-#### 2. MapMyCells annotation transfer of external VMHvl ERα/PR scRNA-seq
-
-**What:** Run MapMyCells against WMBv1 using a published VMHvl ERα-Cre or PR-Cre
-sorted scRNA-seq dataset (e.g. Kim 2019 or comparable VMHvl-targeted snRNA-seq).
-
-**Target:** F1 ≥ 0.50 at supertype; F1 ≥ 0.80 at cluster level; expect F1 to split
-between SUPT_0563 (female-biased) and SUPT_0564 (broader Pgr+/Nkx2-1+).
-
-**Expected output:** `AnnotationTransferEvidence` entries on both edges,
-quantifying the proportion of cells assigned to each supertype.
-
-**Resolves:** Open question 1 (SUPT_0563 vs SUPT_0564 clean split or further
-heterogeneity); the missing per-marker confirmation on SUPT_0563.
-
-#### 3. Targeted literature search for primary VMHvl PR+ marker evidence
-
-**What:** Cite-traverse from [2] (review-level Pgr citation) to primary studies
-on Pgr expression and function in VMHvl neurons.
-
-**Target:** Replace the review-level [2] with a primary citation; resolve whether
-Pgr+ VMHvl neurons preferentially correspond to SUPT_0563 or SUPT_0564.
-
-**Expected output:** Updated `defining_markers[*].refs` on the classical node;
-potentially a new LITERATURE evidence item on whichever edge gains primary support.
-
-**Resolves:** The marker-evidence-provenance flag on Pgr (currently sourced only
-from a review).
+- **What:** Submit one or more CL new term requests targeting the
+  VMHvl Esr1/Pgr classical type (potentially split into a broader
+  Pgr+/Nkx2-1+/Tac1+ term and a female-biased lordosis subpopulation
+  term if the cluster annotation transfer split is confirmed).
+- **Expected output:** New CL term(s) assignable as the BROAD or
+  EXACT mapping for *vmhvl_esr1_pr_neuron*.
 
 ### Open questions
 
-1. **(SUPT_0563 edge)** Is SUPT_0563 vs SUPT_0564 a clean female-vs-broader split,
-   or do both supertypes contain heterogeneous sub-populations that cross-cut the
-   classical definition?
-2. **(SUPT_0563 edge)** Are CLUS_2290 and CLUS_2292 distinct functional subtypes
-   within SUPT_0563, or replicates of the same lordosis subpopulation?
-3. **(SUPT_0564 edge)** Does Calb1 (highest-expressed gene in SUPT_0564, mean = 8.0)
-   co-localise with Esr1/Pgr in VMHvl neurons, or does it mark a distinct
-   subpopulation within SUPT_0564 — potentially the SDN-POA calbindin neuron
-   contaminant?
+1. Does *Calb1* co-localise with *Esr1*/*Pgr* in VMHvl neurons, or does
+   it mark a distinct subpopulation within CS20230722_SUPT_0564? *Calb1*
+   has the highest mean expression on SUPT_0564 (8.0) but is not a
+   defining marker of the VMHvl Esr1/Pgr population.
+2. Is SUPT_0563 vs SUPT_0564 a clean female-vs-broader split, or do
+   both supertypes contain further heterogeneity that cross-cuts the
+   classical definition? Are CLUS_2290 and CLUS_2292 distinct
+   functional subtypes within SUPT_0563, or replicates of the same
+   lordosis subpopulation?
 
 ---
 
@@ -321,6 +470,387 @@ from a review).
 
 | # | Citation | PMID | Used for |
 |---|---|---|---|
-| [1] | Correa et al. 2015 | [PMID:25543145](https://pubmed.ncbi.nlm.nih.gov/25543145/) | Soma location (VMHvl); Esr1, Nkx2-1, Tac1 markers; Tac1 neuropeptide |
-| [2] | Zilkha et al. 2021 | [PMID:33910083](https://pubmed.ncbi.nlm.nih.gov/33910083/) | Pgr marker (review-level) |
-| [3] | Knoedler et al. 2022 | [PMID:35143761](https://pubmed.ncbi.nlm.nih.gov/35143761/) | Esr1+ TRAP-seq pooled VMH female-receptive vs BNST female-receptive bulk-correlation contrast against WMBv1 |
+| [1] | Correa et al. 2015 | [25543145](https://pubmed.ncbi.nlm.nih.gov/25543145) | Soma location, *Esr1*/*Nkx2-1*/*Tac1* markers, female-specific locomotion subpopulation |
+| [2] | Zilkha et al. 2021 | [33910083](https://pubmed.ncbi.nlm.nih.gov/33910083) | *Pgr* marker, sexually dimorphic mating/fighting subpopulation |
+| [3] | Knoedler et al. 2022 | 35143761 (not yet ingested into references.json) | ERα-TRAP-seq VMH-FR vs BNST-FR bulk-correlation evidence |
+
+---
+
+<!-- verdict-block-start: edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564 -->
+```yaml
+verdict:
+  confidence: MODERATE
+  confidence_score: 0.55
+  relationship: evidencell:CrossCuttingMatch
+  mapping_cardinality: "1:n"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:STRONGEST] CS20230722_SUPT_0564 (VMH Fezf1 Glut_2) shows
+    Nkx2-1=5.34 (cohort pct 0.887) and Tac1=1.39 (cohort pct 0.670)
+    with child-cluster coverage 1.00, and VMH [MBA:693] as primary
+    soma location (region_fraction_100um: 0.795). 2 of 4 defining
+    markers CONSISTENT at transcript level; Esr1 and Pgr are absent
+    from the atlas precomputed-expression panel for this supertype
+    and require source-dataset re-analysis. SUPT_0564 carries the
+    broader Pgr+/Nkx2-1+/Tac1+ subpopulation of the heterogeneous
+    classical type.
+  reconciliation_note: >
+    Co-primary cross-cutting target with
+    edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563. The VMHvl
+    Esr1/Pgr classical population is heterogeneous (up to 17
+    transcriptomic types described); SUPT_0564 captures the broader
+    Pgr+/Nkx2-1+/Tac1+ subpopulation and SUPT_0563 captures the
+    female-biased lordosis subpopulation by independent
+    bulk-correlation evidence from Knoedler 2022 (PMID:35143761).
+    Both edges should be retained until the classical node is split
+    or cluster annotation transfer resolves the structure.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        VMHvl contains up to 17 transcriptomic types and the
+        classical vmhvl_esr1_pr_neuron spans multiple functional
+        subtypes. CS20230722_SUPT_0564 is one of two co-primary
+        cross-cutting targets; CS20230722_SUPT_0563 captures the
+        female-biased lordosis subpopulation by the Knoedler 2022
+        VMH-FR vs BNST-FR contrast (CLUS_2290 MFR=0.08, CLUS_2292
+        MFR=0.12 at delta ranks 2 and 4 of 5322).
+    - caveat_type: MARKER_NOT_SPECIFIC
+      description: >
+        Calb1 has the highest mean expression on CS20230722_SUPT_0564
+        (mean=8.0) but is not a defining marker of
+        vmhvl_esr1_pr_neuron; Calb1 is the canonical marker of the
+        distinct SDN-POA calbindin neuron. Calb1 co-localisation
+        with Esr1/Pgr in VMHvl warrants primary literature
+        verification.
+    - caveat_type: TAXONOMY_LEVEL_MISMATCH
+      description: >
+        Esr1 and Pgr — two of the four defining markers — are absent
+        from the WMBv1 precomputed-expression panel for
+        CS20230722_SUPT_0564 and its children, so the
+        steroid-receptor identity that names the classical type
+        cannot be confirmed atlas-side. Cluster-level co-expression
+        check on the source transcriptomes is required.
+  proposed_experiments:
+    - >
+      Cluster annotation transfer of published VMHvl ERα-Cre or
+      PR-Cre transcriptomes onto WMBv1; target supertype-level F1
+      split between CS20230722_SUPT_0564 (broader Pgr+ population)
+      and CS20230722_SUPT_0563 (female-biased subpopulation), with
+      cluster-level resolution distinguishing CLUS_2295/CLUS_2297
+      from CLUS_2290/CLUS_2292. F1 >= 0.5 at supertype level. Adds
+      AnnotationTransferEvidence.
+    - >
+      Cluster-level Esr1, Pgr, Nkx2-1, Tac1 co-expression analysis
+      across CS20230722_SUPT_0564 children (CLUS_2295, CLUS_2297)
+      and CS20230722_SUPT_0563 children (CLUS_2290, CLUS_2292,
+      CLUS_2293) on the WMBv1 source dataset; confirms Esr1+Pgr
+      co-expression currently unassessable from atlas precomputed
+      expression.
+  unresolved_questions:
+    - >
+      Does Calb1 co-localise with Esr1/Pgr in VMHvl neurons, or
+      does it mark a distinct subpopulation within
+      CS20230722_SUPT_0564?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563 -->
+```yaml
+verdict:
+  confidence: MODERATE
+  confidence_score: 0.60
+  relationship: evidencell:CrossCuttingMatch
+  mapping_cardinality: "1:n"
+  mapping_justification: semapv:ManualMappingCuration
+  rationale: >
+    [tier:STRONGEST] CS20230722_SUPT_0563 (VMH Fezf1 Glut_1) shows
+    Nkx2-1=6.63 (cohort pct 0.990) and Tac1=6.48 (cohort pct 0.969)
+    with child-cluster coverage 1.00 — substantially higher than
+    CS20230722_SUPT_0564 — and VMH-FR vs BNST-FR bulk correlation
+    (corr_VMH_FR_vs_BNST_FR, Knoedler 2022 PMID:35143761) places
+    SUPT_0563 children at three of the top four delta slots: the
+    rank-1 hit in Knoedler 2022 VMH-FR vs BNST-FR bulk-correlation
+    (delta=0.018), CS20230722_CLUS_2290 rank 2 (delta=0.016,
+    MFR=0.08), CS20230722_CLUS_2292 rank 4 (delta=0.014, MFR=0.12). 2 of 4 defining markers CONSISTENT at
+    transcript level (Esr1/Pgr absent from atlas panel). SUPT_0563
+    carries the female-biased lordosis subpopulation.
+  reconciliation_note: >
+    Co-primary cross-cutting target with
+    edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564. SUPT_0563
+    was not retrieved in the rank-1 DB query (no DEFINING_SCOPED
+    markers in atlas metadata for this supertype) and is added on
+    the strength of the Knoedler 2022 bulk-correlation evidence
+    plus the supertype-level Nkx2-1/Tac1 transcript-level
+    concordance.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Co-primary with edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564.
+        The classical vmhvl_esr1_pr_neuron is a heterogeneous
+        population; CS20230722_SUPT_0563 captures the female-biased
+        lordosis subpopulation (CLUS_2290 MFR=0.08, CLUS_2292
+        MFR=0.12), CS20230722_SUPT_0564 captures the broader
+        Pgr+/Nkx2-1+/Tac1+ subpopulation. Both edges should be
+        retained until the classical node is split or
+        cluster-level annotation transfer resolves the structure.
+    - caveat_type: TAXONOMY_LEVEL_MISMATCH
+      description: >
+        Esr1 and Pgr are absent from the WMBv1 precomputed-expression
+        panel for CS20230722_SUPT_0563 and its children;
+        steroid-receptor identity requires source-dataset
+        re-analysis or transgene-driven cluster annotation
+        transfer.
+  proposed_experiments:
+    - >
+      Cluster-level Esr1, Pgr, Nkx2-1, Tac1 co-expression in
+      CS20230722_CLUS_2290, CS20230722_CLUS_2292, and the rank-1
+      bulk-correlation hit child cluster versus the female-biased
+      clusters of CS20230722_SUPT_0564 — distinguishes the two
+      co-primary cross-cutting targets.
+    - >
+      Cluster annotation transfer of published VMHvl ERα-Cre or
+      PR-Cre transcriptomes to WMBv1; expected F1 split between
+      CS20230722_SUPT_0563 (female-biased) and CS20230722_SUPT_0564
+      (broader Pgr+ population). Adds AnnotationTransferEvidence.
+  unresolved_questions:
+    - >
+      Is CS20230722_SUPT_0563 vs CS20230722_SUPT_0564 a clean
+      female-vs-broader split, or do both supertypes contain
+      heterogeneous sub-populations that cross-cut the classical
+      definition?
+    - >
+      Are CS20230722_CLUS_2290 and CS20230722_CLUS_2292 distinct
+      functional subtypes within CS20230722_SUPT_0563, or
+      replicates of the same lordosis subpopulation?
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2290 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.30
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_2290 is a SUPT_0563 child cluster
+    (Nkx2-1=6.69 cohort pct 0.989, Tac1=6.07 cohort pct 0.901,
+    region_fraction_100um: 0.817, MFR=0.08) and is among the top
+    bulk-correlation hits (delta rank 2 / 5322 in the Knoedler
+    2022 PMID:35143761 VMH-FR vs BNST-FR contrast). The
+    cluster-level signal is represented through the parent
+    supertype edge edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563
+    rather than as an independent cluster-level mapping target.
+  caveats:
+    - caveat_type: TAXONOMY_LEVEL_MISMATCH
+      description: >
+        CS20230722_CLUS_2290 represents the female-biased lordosis
+        signal that is the basis for the
+        edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563
+        cross-cutting mapping; treating it as a separate
+        cluster-level target would double-count the SUPT_0563
+        evidence.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2292 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.30
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_2292 is a SUPT_0563 child cluster
+    (Nkx2-1=6.28 cohort pct 0.949, Tac1=8.62 cohort pct 0.964,
+    region_fraction_100um: 1.000, MFR=0.12) and ranks at delta
+    rank 4 of 5322 in the Knoedler 2022 PMID:35143761 VMH-FR vs
+    BNST-FR contrast. The cluster-level signal is represented
+    through the parent supertype edge
+    edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563.
+  caveats:
+    - caveat_type: TAXONOMY_LEVEL_MISMATCH
+      description: >
+        CS20230722_CLUS_2292 is a child of CS20230722_SUPT_0563 and
+        contributes to the supertype-level cross-cutting mapping;
+        not treated as an independent cluster-level target.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_1959 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_1959 (DMH Hmx2 Gaba_6) is a
+    GABAergic dorsomedial-hypothalamus cluster with Nkx2-1=0.26
+    (cohort pct 0.423) and Tac1=0.36 (cohort pct 0.321) — both
+    defining markers near-absent — and region_fraction_100um:
+    0.522 with DMH [MBA:830] dominant over VMH [MBA:693].
+    Wrong subclass (DMH GABAergic) for the VMHvl glutamatergic
+    classical type.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        DMH-anchored GABAergic cluster; defining markers Nkx2-1 and
+        Tac1 are near-absent; wrong anatomical and NT context for
+        vmhvl_esr1_pr_neuron.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2295 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.30
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_2295 is a SUPT_0564 child cluster
+    (Nkx2-1=6.16 cohort pct 0.942, Tac1=1.87 cohort pct 0.752,
+    region_fraction_100um: 0.889). The cluster carries the
+    cleanest VMH region signal among SUPT_0564 children but its
+    mapping is represented through the parent supertype edge
+    edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564 rather than
+    as an independent cluster-level target.
+  caveats:
+    - caveat_type: TAXONOMY_LEVEL_MISMATCH
+      description: >
+        CS20230722_CLUS_2295 is a child of CS20230722_SUPT_0564 and
+        contributes to the supertype-level cross-cutting mapping;
+        not treated as an independent cluster-level target.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2297 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.25
+  rationale: >
+    [tier:CUT] CS20230722_CLUS_2297 is a SUPT_0564 child cluster
+    (Nkx2-1=3.80 cohort pct 0.763, Tac1=1.45 cohort pct 0.730,
+    region_fraction_100um: 0.737). Marker concordance is weaker
+    than its sibling CS20230722_CLUS_2295; the supertype-level
+    edge edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564 carries
+    the mapping.
+  caveats:
+    - caveat_type: TAXONOMY_LEVEL_MISMATCH
+      description: >
+        CS20230722_CLUS_2297 is a child of CS20230722_SUPT_0564;
+        not treated as an independent cluster-level target.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0557 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.20
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0557 (ARH-PVp Tbx3 Glut_4) carries
+    Nkx2-1=6.11 (cohort pct 0.969) and Tac1=7.16 (cohort pct
+    0.979) with child-cluster coverage 1.00 but
+    region_fraction_100um: 0.808 is dominated by Hypothalamus
+    catchall n=120 and Tuberal nucleus n=37 with VMH n=97 — the
+    supertype is ARH-PVp/Tuberal-leaning by name and metadata,
+    not VMHvl-specific. Wrong region context for the VMHvl
+    classical type.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        ARH-PVp Tbx3 supertype with Tuberal/Hypothalamus-catchall
+        anatomical distribution; not the VMHvl-specific signature
+        of vmhvl_esr1_pr_neuron.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0563 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.30
+  rationale: >
+    [tier:CUT] Duplicate fresh-emit edge to CS20230722_SUPT_0563
+    — the substantive supertype mapping is encoded on the legacy
+    edge edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563
+    (lowercase ID) which carries the populated bulk-correlation
+    evidence from corr_run_20260428_knoedler_esr1_wmbv1, the
+    co-primary cross-cutting designation, and the
+    property_comparisons. This uppercase-ID fresh-emit edge
+    carries only ATLAS_METADATA and a stub property_comparison
+    set; recommend curator removal to resolve the duplicate.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        Duplicate edge — same taxonomy_type CS20230722_SUPT_0563
+        is targeted by both
+        edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563 (legacy,
+        substantive) and this fresh-emit edge (impoverished).
+        Curator removal of one is recommended.
+  unresolved_questions:
+    - >
+      Curator removal of duplicate edge
+      edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0563 —
+      legacy/fresh-emit ID collision on taxonomy_type
+      CS20230722_SUPT_0563.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0439 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.05
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0439 (DMH Prdm13 Gaba_1) is a
+    GABAergic dorsomedial-hypothalamus supertype with
+    region_fraction_100um: 0.151 (DMH dominant) and Tac1=0.36
+    (cohort pct 0.309, near-absent). Wrong region and wrong NT
+    for the VMHvl glutamatergic classical type.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        DMH GABAergic supertype; Tac1 near-absent; minimal VMH
+        footprint (region_fraction_100um: 0.151).
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0569 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0569 (VMH Nr5a1 Glut_4) carries
+    Nkx2-1=4.96 (cohort pct 0.866) and Tac1=1.52 (cohort pct
+    0.680) with VMH region_fraction_100um: 0.913, but the
+    supertype belongs to the VMH Nr5a1 lineage (distinct from the
+    VMH Fezf1 lineage that contains SUPT_0563/SUPT_0564).
+    Nr5a1+ VMHdm/c populations are anatomically and functionally
+    distinct from the VMHvl Esr1/Pgr classical type.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        VMH Nr5a1 lineage — distinct VMH developmental lineage
+        from VMH Fezf1; not the canonical correlate of the
+        VMHvl Esr1/Pgr classical population.
+```
+<!-- verdict-block-end -->
+
+<!-- verdict-block-start: edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0568 -->
+```yaml
+verdict:
+  confidence: LOW
+  confidence_score: 0.15
+  rationale: >
+    [tier:CUT] CS20230722_SUPT_0568 (VMH Nr5a1 Glut_3) carries
+    Nkx2-1=3.49 (cohort pct 0.732) and Tac1=1.83 (cohort pct
+    0.722) with VMH region_fraction_100um: 0.898, but is part of
+    the VMH Nr5a1 lineage rather than the VMH Fezf1 lineage that
+    contains SUPT_0563/SUPT_0564. Nr5a1+ VMH populations sit
+    primarily in VMHdm/c and do not align with the VMHvl
+    Esr1/Pgr classical type.
+  caveats:
+    - caveat_type: AMBIGUOUS_MAPPING
+      description: >
+        VMH Nr5a1 lineage — distinct VMH developmental lineage
+        from VMH Fezf1; not the canonical correlate of the
+        VMHvl Esr1/Pgr classical population.
+```
+<!-- verdict-block-end -->

--- a/research/_drivers/refresh_region.py
+++ b/research/_drivers/refresh_region.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Per-region refresh driver: Stage A/B + refresh at ranks 0 and 1 + stale audit.
+
+For every curated classical node in a region's KB graphs:
+  - Stage A find-candidates at rank 0 and rank 1 (top-50)
+  - Stage B emit-stage-b at rank 0 and rank 1 (top-5) — idempotent on existing edges
+  - Stage B refresh-property-comparisons at rank 0 and rank 1 (top-K 50)
+  - Aggregates a per-region stale-audit markdown listing edges where the existing
+    taxonomy_type is no longer in current Stage A top-50.
+
+Usage:
+    python research/_drivers/refresh_region.py <region> [--date YYYYMMDD] [--dry-run]
+"""
+from __future__ import annotations
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+import yaml
+from datetime import date
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+
+def run(cmd: list[str]) -> tuple[int, str, str]:
+    p = subprocess.run(cmd, cwd=REPO, capture_output=True, text=True)
+    return p.returncode, p.stdout, p.stderr
+
+
+def parse_json_from_stdout(stdout: str) -> dict | None:
+    idx = stdout.find('{')
+    if idx < 0:
+        return None
+    try:
+        return json.loads(stdout[idx:])
+    except json.JSONDecodeError:
+        return None
+
+
+def collect_classical_nodes(region: str) -> list[tuple[pathlib.Path, str, str | None]]:
+    """Return [(graph_path, node_id, taxonomy_id)] for every curated classical node."""
+    out = []
+    for graph_path in sorted((REPO / 'kb' / 'graphs' / region).glob('*.yaml')):
+        try:
+            d = yaml.safe_load(graph_path.read_text())
+        except Exception as e:
+            print(f'  ERR parse {graph_path}: {e}', file=sys.stderr)
+            continue
+        if not isinstance(d, dict):
+            continue
+        # determine taxonomy_id from any atlas node
+        tax_id = None
+        for n in d.get('nodes', []) or []:
+            if isinstance(n, dict) and n.get('taxonomy_id'):
+                tax_id = n['taxonomy_id']
+                break
+        for n in d.get('nodes', []) or []:
+            if not isinstance(n, dict):
+                continue
+            db = n.get('definition_basis') or ''
+            if isinstance(db, str) and db.startswith('CLASSICAL'):
+                out.append((graph_path, n['id'], tax_id))
+    return out
+
+
+def per_node_refresh(graph_path: pathlib.Path, node_id: str, taxonomy_id: str, region: str, date_str: str):
+    base = REPO / 'research' / region / f'refresh_{date_str}_{node_id}'
+    base.mkdir(parents=True, exist_ok=True)
+    summary = {
+        'graph': str(graph_path.relative_to(REPO)),
+        'node_id': node_id,
+        'taxonomy_id': taxonomy_id,
+        'ranks': {},
+    }
+    for rank in (0, 1):
+        rk = {'stage_a': None, 'emit_b': None, 'refresh_pc': None}
+        # Stage A
+        disc_path = base / f'discovery_candidates_rank{rank}.json'
+        rc, out, err = run(['just', 'find-candidates', str(graph_path), node_id, taxonomy_id, str(rank), '50'])
+        if rc != 0:
+            rk['stage_a'] = {'error': err.strip()[:500] or out.strip()[:500]}
+        else:
+            # find-candidates prints info to stderr-ish then JSON to stdout; capture JSON portion
+            idx = out.find('{')
+            if idx < 0:
+                rk['stage_a'] = {'error': 'no JSON in stdout'}
+            else:
+                try:
+                    j = json.loads(out[idx:])
+                    disc_path.write_text(out[idx:])
+                    rk['stage_a'] = {'n_candidates': j.get('n_candidates'),
+                                     'top5': [c['node_id'] for c in j['candidates'][:5]]}
+                except Exception as e:
+                    rk['stage_a'] = {'error': f'json parse: {e}'}
+        # Stage B emit (only if Stage A succeeded)
+        if rk['stage_a'] and 'error' not in rk['stage_a']:
+            rc, out, err = run(['just', 'emit-stage-b', str(graph_path), node_id, taxonomy_id, str(rank), '5',
+                                '--discovery-json', str(disc_path)])
+            if rc != 0:
+                rk['emit_b'] = {'error': err.strip()[:500] or out.strip()[:500]}
+            else:
+                # parse human-readable summary
+                lines = (out + err).strip().splitlines()
+                rk['emit_b'] = {'last_lines': lines[-5:]}
+            # Refresh PC
+            rc, out, err = run(['just', 'refresh-property-comparisons', str(graph_path), node_id, taxonomy_id, str(rank), '--top-k', '50'])
+            if rc != 0:
+                rk['refresh_pc'] = {'error': err.strip()[:500] or out.strip()[:500]}
+            else:
+                j = parse_json_from_stdout(out)
+                if j is None:
+                    rk['refresh_pc'] = {'error': 'no JSON', 'tail': out[-200:]}
+                else:
+                    rk['refresh_pc'] = {
+                        'edges_refreshed': j.get('edges_refreshed'),
+                        'edges_skipped_taxtype_not_in_topk': j.get('edges_skipped_taxtype_not_in_topk'),
+                        'skipped_details': j.get('skipped_details', []),
+                        'refreshed_details': [
+                            {'edge_id': r.get('edge_id'), 'taxonomy_type': r.get('taxonomy_type')}
+                            for r in j.get('refreshed_details', [])
+                        ],
+                    }
+        summary['ranks'][f'rank{rank}'] = rk
+    (base / 'refresh_summary.json').write_text(json.dumps(summary, indent=2))
+    return summary
+
+
+def _rank_of_taxtype(tt: str) -> int | None:
+    """Map a taxonomy_type accession to its rank: CLUS_*→0, SUPT_*→1, SUBC_*→2, CLAS_*→3."""
+    if not isinstance(tt, str):
+        return None
+    u = tt.upper()
+    if '_CLUS_' in u: return 0
+    if '_SUPT_' in u: return 1
+    if '_SUBC_' in u: return 2
+    if '_CLAS_' in u: return 3
+    return None
+
+
+def stale_audit_md(region: str, date_str: str, all_summaries: list[dict]) -> str:
+    lines = [f'# Stale-location audit — {region} — {date_str}', '',
+             'Edges whose `taxonomy_type` is NOT in current Stage A top-50 at the rank that matches the edge target\'s level.',
+             '(Rank-mismatch skips — e.g. supertype edge skipped at rank-0 cluster refresh — are filtered out; those are not stale.)',
+             'These need curator review — current proximity-aware scoring placed the cluster/supertype outside the candidate pool.',
+             '', '## Stale edges', '']
+    any_stale = False
+    for s in all_summaries:
+        node = s['node_id']
+        graph = s['graph']
+        for rank_key, rk in (s.get('ranks') or {}).items():
+            target_rank = int(rank_key.replace('rank', ''))
+            rpc = (rk or {}).get('refresh_pc') or {}
+            for d in rpc.get('skipped_details', []) or []:
+                tt = d.get('taxonomy_type', '')
+                tt_rank = _rank_of_taxtype(tt)
+                if tt_rank is None or tt_rank != target_rank:
+                    continue  # rank-mismatch — not a stale signal
+                any_stale = True
+                lines.append(f'### {node} (rank{target_rank}) — `{d.get("edge_id")}`')
+                lines.append('')
+                lines.append(f'- **Graph**: `{graph}`')
+                lines.append(f'- **taxonomy_type**: `{tt}`')
+                reason = d.get('skip_reason') or 'taxonomy_type not in current Stage A top-50 at matching rank'
+                lines.append(f'- **Skip reason**: {reason}')
+                extras = {k: v for k, v in d.items() if k not in ('edge_id', 'taxonomy_type', 'skip_reason')}
+                if extras:
+                    lines.append(f'- **Extras**: `{json.dumps(extras)[:300]}`')
+                lines.append('')
+    if not any_stale:
+        lines.append('_None — all existing edges land within current top-50 at their respective ranks._')
+    lines.append('')
+    lines.append('## Refresh summary')
+    lines.append('')
+    lines.append('| Node | Rank0 refreshed / skipped | Rank1 refreshed / skipped |')
+    lines.append('|---|---|---|')
+    for s in all_summaries:
+        node = s['node_id']
+        cells = []
+        for rk_key in ('rank0', 'rank1'):
+            rk = (s.get('ranks') or {}).get(rk_key) or {}
+            rpc = rk.get('refresh_pc') or {}
+            r = rpc.get('edges_refreshed')
+            k = rpc.get('edges_skipped_taxtype_not_in_topk')
+            err = rpc.get('error')
+            if err:
+                cells.append(f'ERR: {err[:80]}')
+            else:
+                cells.append(f'{r} / {k}')
+        lines.append(f'| `{node}` | {cells[0]} | {cells[1]} |')
+    lines.append('')
+    return '\n'.join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('region')
+    ap.add_argument('--date', default=date.today().strftime('%Y%m%d'))
+    args = ap.parse_args()
+
+    region = args.region
+    nodes = collect_classical_nodes(region)
+    if not nodes:
+        print(f'No curated classical nodes for region {region}')
+        return 1
+    print(f'Region {region}: {len(nodes)} (graph, node) pairs')
+    all_summaries = []
+    for i, (gp, nid, tax) in enumerate(nodes, 1):
+        if not tax:
+            print(f'  [{i}/{len(nodes)}] {nid} in {gp.name}: SKIP no taxonomy_id')
+            all_summaries.append({'graph': str(gp.relative_to(REPO)), 'node_id': nid,
+                                  'taxonomy_id': None, 'ranks': {},
+                                  'skipped_reason': 'no taxonomy_id discoverable'})
+            continue
+        print(f'  [{i}/{len(nodes)}] {nid} in {gp.name} ({tax})', flush=True)
+        s = per_node_refresh(gp, nid, tax, region, args.date)
+        all_summaries.append(s)
+        # print 1-line summary
+        rank0 = (s['ranks'].get('rank0') or {}).get('refresh_pc') or {}
+        rank1 = (s['ranks'].get('rank1') or {}).get('refresh_pc') or {}
+        print(f'    rank0 refreshed={rank0.get("edges_refreshed")}/skipped={rank0.get("edges_skipped_taxtype_not_in_topk")}; '
+              f'rank1 refreshed={rank1.get("edges_refreshed")}/skipped={rank1.get("edges_skipped_taxtype_not_in_topk")}')
+    out_dir = REPO / 'research' / region
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / f'refresh_{args.date}_stale_audit.md').write_text(stale_audit_md(region, args.date, all_summaries))
+    (out_dir / f'refresh_{args.date}_summary.json').write_text(json.dumps(all_summaries, indent=2))
+    print(f'\nWrote: research/{region}/refresh_{args.date}_stale_audit.md')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/research/sexually_dimorphic/refresh_20260608_arc_aromatase_neuron/discovery_candidates_rank0.json
+++ b/research/sexually_dimorphic/refresh_20260608_arc_aromatase_neuron/discovery_candidates_rank0.json
@@ -1,0 +1,1559 @@
+{
+  "classical_node_id": "arc_aromatase_neuron",
+  "classical_node_name": "Arcuate aromatase neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 0,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_CLUS_5303",
+      "label": "5303 VLMC NN_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUPT_1190",
+      "male_female_ratio": 0.12,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.317,
+        "region_fraction_100um": 0.692,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1569",
+      "label": "1569 ARH-PVi Six6 Dopa-Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0427",
+      "male_female_ratio": 0.96,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.526,
+        "region_fraction_100um": 0.789,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1570",
+      "label": "1570 ARH-PVi Six6 Dopa-Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0427",
+      "male_female_ratio": 0.85,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.545,
+        "region_fraction_100um": 0.779,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1571",
+      "label": "1571 ARH-PVi Six6 Dopa-Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0427",
+      "male_female_ratio": 5.25,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.338,
+        "region_fraction_100um": 0.69,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1683",
+      "label": "1683 SBPV-PVa Six6 Satb2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0453",
+      "male_female_ratio": 1.86,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.346,
+        "region_fraction_100um": 0.506,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1687",
+      "label": "1687 SBPV-PVa Six6 Satb2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0453",
+      "male_female_ratio": 0.96,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.37,
+        "region_fraction_100um": 0.596,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1788",
+      "label": "1788 DMH-LHA Gsx1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0470",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.244,
+        "region_fraction_100um": 0.528,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1810",
+      "label": "1810 DMH-LHA Gsx1 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Chol",
+      "parent_id": "CS20230722_SUPT_0472",
+      "male_female_ratio": 1.27,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.649,
+        "region_fraction_100um": 0.805,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1838",
+      "label": "1838 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0478",
+      "male_female_ratio": 0.92,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.826,
+        "region_fraction_100um": 0.972,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1837",
+      "label": "1837 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0478",
+      "male_female_ratio": 0.82,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.885,
+        "region_fraction_100um": 0.948,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1840",
+      "label": "1840 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0478",
+      "male_female_ratio": 1.7,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.547,
+        "region_fraction_100um": 0.765,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1849",
+      "label": "1849 TU-ARH Otp Six6 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0479",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.4,
+        "region_fraction_100um": 0.667,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1841",
+      "label": "1841 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0478",
+      "male_female_ratio": 1.5,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.636,
+        "region_fraction_100um": 0.788,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1842",
+      "label": "1842 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0478",
+      "male_female_ratio": 1.17,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.858,
+        "region_fraction_100um": 0.972,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1857",
+      "label": "1857 TU-ARH Otp Six6 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0480",
+      "male_female_ratio": 1.08,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.273,
+        "region_fraction_100um": 0.682,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1863",
+      "label": "1863 TMd-DMH Foxd2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0481",
+      "male_female_ratio": 1.5,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.182,
+        "region_fraction_100um": 0.545,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1936",
+      "label": "1936 DMH Hmx2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0488",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.244,
+        "region_fraction_100um": 0.61,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1961",
+      "label": "1961 ARH-PVp Tbx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0493",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.701,
+        "region_fraction_100um": 0.88,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1962",
+      "label": "1962 ARH-PVp Tbx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0493",
+      "male_female_ratio": 0.89,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.847,
+        "region_fraction_100um": 0.976,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1963",
+      "label": "1963 ARH-PVp Tbx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0493",
+      "male_female_ratio": 1.7,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.762,
+        "region_fraction_100um": 0.952,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1964",
+      "label": "1964 ARH-PVp Tbx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0493",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.494,
+        "region_fraction_100um": 0.753,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1965",
+      "label": "1965 ARH-PVp Tbx3 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0494",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.292,
+        "region_fraction_100um": 0.5,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1968",
+      "label": "1968 ARH-PVp Tbx3 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0495",
+      "male_female_ratio": 2.33,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.649,
+        "region_fraction_100um": 0.881,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1969",
+      "label": "1969 ARH-PVp Tbx3 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0495",
+      "male_female_ratio": 1.27,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.608,
+        "region_fraction_100um": 0.959,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1970",
+      "label": "1970 ARH-PVp Tbx3 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0495",
+      "male_female_ratio": 1.38,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.568,
+        "region_fraction_100um": 0.875,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1971",
+      "label": "1971 ARH-PVp Tbx3 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0495",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.804,
+        "region_fraction_100um": 0.921,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2274",
+      "label": "2274 ARH-PVp Tbx3 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0554",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.702,
+        "region_fraction_100um": 0.845,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2276",
+      "label": "2276 ARH-PVp Tbx3 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0554",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.649,
+        "region_fraction_100um": 0.84,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2275",
+      "label": "2275 ARH-PVp Tbx3 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0554",
+      "male_female_ratio": 0.47,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.333,
+        "region_fraction_100um": 0.5,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2278",
+      "label": "2278 ARH-PVp Tbx3 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut-GABA",
+      "parent_id": "CS20230722_SUPT_0555",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.532,
+        "region_fraction_100um": 0.761,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2277",
+      "label": "2277 ARH-PVp Tbx3 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0554",
+      "male_female_ratio": 0.82,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.821,
+        "region_fraction_100um": 0.929,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2279",
+      "label": "2279 ARH-PVp Tbx3 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut-GABA",
+      "parent_id": "CS20230722_SUPT_0555",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.588,
+        "region_fraction_100um": 0.855,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2281",
+      "label": "2281 ARH-PVp Tbx3 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0556",
+      "male_female_ratio": 32.33,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.799,
+        "region_fraction_100um": 0.937,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2280",
+      "label": "2280 ARH-PVp Tbx3 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0555",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.753,
+        "region_fraction_100um": 0.928,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2282",
+      "label": "2282 ARH-PVp Tbx3 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0556",
+      "male_female_ratio": 0.11,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.758,
+        "region_fraction_100um": 0.888,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2301",
+      "label": "2301 VMH Nr5a1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0566",
+      "male_female_ratio": 0.96,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.167,
+        "region_fraction_100um": 0.5,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_5246",
+      "label": "5246 Tanycyte NN_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUPT_1173",
+      "male_female_ratio": 2.45,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.159,
+        "region_fraction_100um": 0.435,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1573",
+      "label": "1573 TMv-PMv Tbx3 Hist-Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Hist",
+      "parent_id": "CS20230722_SUPT_0429",
+      "male_female_ratio": 0.85,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.143,
+        "region_fraction_100um": 0.125,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1575",
+      "label": "1575 TMv-PMv Tbx3 Hist-Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Hist",
+      "parent_id": "CS20230722_SUPT_0429",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.057,
+        "region_fraction_100um": 0.151,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1578",
+      "label": "1578 TMv-PMv Tbx3 Hist-Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0430",
+      "male_female_ratio": 1.27,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.097,
+        "region_fraction_100um": 0.185,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1624",
+      "label": "1624 DMH Prdm13 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0440",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.038,
+        "region_fraction_100um": 0.308,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1686",
+      "label": "1686 SBPV-PVa Six6 Satb2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0453",
+      "male_female_ratio": 1.7,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.18,
+        "region_fraction_100um": 0.28,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1697",
+      "label": "1697 SBPV-PVa Six6 Satb2 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0455",
+      "male_female_ratio": 3.0,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.108,
+        "region_fraction_100um": 0.238,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1789",
+      "label": "1789 DMH-LHA Gsx1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0470",
+      "male_female_ratio": 1.27,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.227,
+        "region_fraction_100um": 0.36,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1790",
+      "label": "1790 DMH-LHA Gsx1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0470",
+      "male_female_ratio": 1.5,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.141,
+        "region_fraction_100um": 0.352,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1791",
+      "label": "1791 DMH-LHA Gsx1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0470",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.081,
+        "region_fraction_100um": 0.29,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1839",
+      "label": "1839 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0478",
+      "male_female_ratio": 1.94,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.095,
+        "region_fraction_100um": 0.243,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1843",
+      "label": "1843 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0478",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.208,
+        "region_fraction_100um": 0.312,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1847",
+      "label": "1847 TU-ARH Otp Six6 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0479",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.014,
+        "region_fraction_100um": 0.11,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1848",
+      "label": "1848 TU-ARH Otp Six6 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0479",
+      "male_female_ratio": 1.08,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.061,
+        "region_fraction_100um": 0.161,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_arc_aromatase_neuron/discovery_candidates_rank1.json
+++ b/research/sexually_dimorphic/refresh_20260608_arc_aromatase_neuron/discovery_candidates_rank1.json
@@ -1,0 +1,1509 @@
+{
+  "classical_node_id": "arc_aromatase_neuron",
+  "classical_node_name": "Arcuate aromatase neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 1,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_SUPT_1190",
+      "label": "1190 VLMC NN_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_330",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.317,
+        "region_fraction_100um": 0.692,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_1173",
+      "label": "1173 Tanycyte NN_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_322",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.342,
+        "region_fraction_100um": 0.732,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_1174",
+      "label": "1174 Tanycyte NN_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_322",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.508,
+        "region_fraction_100um": 0.743,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0427",
+      "label": "0427 ARH-PVi Six6 Dopa-Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_091",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.427,
+        "region_fraction_100um": 0.741,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0495",
+      "label": "0495 ARH-PVp Tbx3 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_108",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.665,
+        "region_fraction_100um": 0.917,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0493",
+      "label": "0493 ARH-PVp Tbx3 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_108",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.719,
+        "region_fraction_100um": 0.897,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0478",
+      "label": "0478 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_104",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.694,
+        "region_fraction_100um": 0.822,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0472",
+      "label": "0472 DMH-LHA Gsx1 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_102",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.649,
+        "region_fraction_100um": 0.805,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0556",
+      "label": "0556 ARH-PVp Tbx3 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.709,
+        "region_fraction_100um": 0.862,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0555",
+      "label": "0555 ARH-PVp Tbx3 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.614,
+        "region_fraction_100um": 0.844,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0554",
+      "label": "0554 ARH-PVp Tbx3 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.674,
+        "region_fraction_100um": 0.835,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0455",
+      "label": "0455 SBPV-PVa Six6 Satb2 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_099",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.098,
+        "region_fraction_100um": 0.214,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0453",
+      "label": "0453 SBPV-PVa Six6 Satb2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_099",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.171,
+        "region_fraction_100um": 0.287,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0440",
+      "label": "0440 DMH Prdm13 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_095",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.012,
+        "region_fraction_100um": 0.141,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0430",
+      "label": "0430 TMv-PMv Tbx3 Hist-Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_092",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.075,
+        "region_fraction_100um": 0.145,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0488",
+      "label": "0488 DMH Hmx2 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.074,
+        "region_fraction_100um": 0.121,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0494",
+      "label": "0494 ARH-PVp Tbx3 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_108",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.155,
+        "region_fraction_100um": 0.268,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0479",
+      "label": "0479 TU-ARH Otp Six6 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_104",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.089,
+        "region_fraction_100um": 0.204,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0481",
+      "label": "0481 TMd-DMH Foxd2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_105",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.051,
+        "region_fraction_100um": 0.22,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0480",
+      "label": "0480 TU-ARH Otp Six6 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_104",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.082,
+        "region_fraction_100um": 0.148,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0470",
+      "label": "0470 DMH-LHA Gsx1 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_102",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.111,
+        "region_fraction_100um": 0.257,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0569",
+      "label": "0569 VMH Nr5a1 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_129",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.045,
+        "region_fraction_100um": 0.163,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0568",
+      "label": "0568 VMH Nr5a1 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_129",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.06,
+        "region_fraction_100um": 0.139,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0558",
+      "label": "0558 ARH-PVp Tbx3 Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.109,
+        "region_fraction_100um": 0.173,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0557",
+      "label": "0557 ARH-PVp Tbx3 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.108,
+        "region_fraction_100um": 0.225,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0553",
+      "label": "0553 DMH Hmx2 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_125",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.096,
+        "region_fraction_100um": 0.192,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0561",
+      "label": "0561 DMH-LHA Vgll2 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_127",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.059,
+        "region_fraction_100um": 0.159,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0545",
+      "label": "0545 DMH Nkx2-4 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_123",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.061,
+        "region_fraction_100um": 0.202,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_1172",
+      "label": "1172 Tanycyte NN_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_322",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.035,
+        "region_fraction_100um": 0.046,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0443",
+      "label": "0443 PVHd-SBPV Six3 Prox1 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_097",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.003,
+        "region_fraction_100um": 0.005,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0439",
+      "label": "0439 DMH Prdm13 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_095",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.004,
+        "region_fraction_100um": 0.022,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0429",
+      "label": "0429 TMv-PMv Tbx3 Hist-Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_092",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.014,
+        "region_fraction_100um": 0.039,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0428",
+      "label": "0428 ARH-PVi Six6 Dopa-Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_091",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.053,
+        "region_fraction_100um": 0.05,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0487",
+      "label": "0487 DMH Hmx2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.008,
+        "region_fraction_100um": 0.037,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0492",
+      "label": "0492 DMH Hmx2 Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.043,
+        "region_fraction_100um": 0.086,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0491",
+      "label": "0491 DMH Hmx2 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.018,
+        "region_fraction_100um": 0.039,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0605",
+      "label": "0605 PMv-TMv Pitx2 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_136",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.06,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0643",
+      "label": "0643 PVT-PT Ntrk1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_149",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.004,
+        "region_fraction_100um": 0.004,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0628",
+      "label": "0628 HY Gnrh1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_142",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.058,
+        "region_fraction_100um": 0.05,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0567",
+      "label": "0567 VMH Nr5a1 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_129",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.041,
+        "region_fraction_100um": 0.091,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0566",
+      "label": "0566 VMH Nr5a1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_129",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.04,
+        "region_fraction_100um": 0.087,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0565",
+      "label": "0565 VMH Fezf1 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_128",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.011,
+        "region_fraction_100um": 0.021,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0564",
+      "label": "0564 VMH Fezf1 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_128",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.023,
+        "region_fraction_100um": 0.058,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0570",
+      "label": "0570 VMH Nr5a1 Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_129",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.023,
+        "region_fraction_100um": 0.085,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0552",
+      "label": "0552 DMH Hmx2 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_125",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.005,
+        "region_fraction_100um": 0.054,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0551",
+      "label": "0551 MPN-MPO-PVpo Hmx2 Glut_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_124",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.008,
+        "region_fraction_100um": 0.022,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0588",
+      "label": "0588 PVH-SO-PVa Otp Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_133",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.036,
+        "region_fraction_100um": 0.037,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0607",
+      "label": "0607 PMv-TMv Pitx2 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_136",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.08,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0571",
+      "label": "0571 VMH Nr5a1 Glut_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_129",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.021,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0563",
+      "label": "0563 VMH Fezf1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_128",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:223"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.028,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_arc_aromatase_neuron/prior_summary_preserved.md
+++ b/research/sexually_dimorphic/refresh_20260608_arc_aromatase_neuron/prior_summary_preserved.md
@@ -1,0 +1,238 @@
+# Arcuate aromatase neuron — WMBv1 Mapping Report
+*draft · 2026-04-25 · Source: `kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
+
+**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+
+---
+
+## Introduction
+
+### Classical type
+
+**Arcuate aromatase neuron** is defined by neurochemical criteria: Cyp19a1 (aromatase)
+expression in a sexually dimorphic, male-biased cluster located in the arcuate hypothalamic
+nucleus, adjacent to kisspeptin neurons. The population is part of a broader aromatase
+neuronal network spanning hypothalamus and amygdala (~6,000 neurons at birth). Functionally,
+male arcuate aromatase neurons convert testosterone to estrogen and regulate kisspeptin
+neuron activity. Evidence derives from a single primary source (Wartenberg et al. 2021 [1]);
+no CL term is currently assigned and the type is a candidate for a new term. NT type and
+negative markers are not reported.
+
+| Property | Value | References |
+|---|---|---|
+| Soma location | Arcuate hypothalamic nucleus [MBA:223] (adjacent to kisspeptin neurons, per source) | [1] |
+| Defining markers | Cyp19a1 (aromatase, transcript) | [1] |
+
+<details>
+<summary>Literature support — expand for verbatim quotes</summary>
+
+**[1] Wartenberg et al. 2021 · PMID:34561233 — Neuronal Markers and Molecular Characteristics**
+
+> We identified an aromatase neuronal network comprising ~6000 neurons in the hypothalamus and amygdala. By birth, this network has become sexually dimorphic in a cluster of aromatase neurons in the arcuate nucleus adjacent to kisspeptin neurons. We demonstrate that male arcuate aromatase neurons convert testosterone to estrogen to regulate kisspeptin neuron activity.
+> — Wartenberg et al. 2021, Neuronal Markers and Molecular Characteristics · [1] <!-- quote_key: 237626479_5aec04ab -->
+
+</details>
+
+---
+
+## Results
+
+**Primary finding (null result).** A complete scan of WMBv1 (CCN20230722) confirmed that
+no supertype or cluster located in Arcuate hypothalamic nucleus [MBA:223] carries Cyp19a1
+as a defining marker. All Cyp19a1-expressing clusters identified by the DB scan reside in
+preoptic area (POA) and periventricular zones, not in MBA:223. The best available atlas
+match — 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] — is in the periventricular
+preoptic zone (PVpo n=64; MPN n=37; AVPV n=16) with **no MBA:223 cells**, and is proposed
+only because its child cluster CLUS_1907 carries Cyp19a1 as a defining marker (supertype
+mean Cyp19a1=1.15). The arc_aromatase_neuron edge is therefore classified UNCERTAIN, and
+the apparent transcriptomic signal is anatomically discordant with the classical type's
+defining ARH location.
+
+### Mapping candidates
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
+|---|---|---|---|---|---|---|
+| — | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] | (self) | 178 | ⚪ UNCERTAIN | Cyp19a1 APPROXIMATE; location DISCORDANT | Eliminated |
+1 edge total. Relationship type: UNCERTAIN.
+
+### Property alignment — primary candidate (SUPT_0486)
+
+**Table 1 — Property comparison.**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Arcuate hypothalamic nucleus [MBA:223] | MBA:133 PVpo n=64; MBA:515 MPN n=37; MBA:272 AVPV n=16 — no MBA:223 cells | not assessed | DISCORDANT |
+| Cyp19a1 expression | POSITIVE (transcript, primary defining marker) | precomputed mean_expression=1.15; child CLUS_1907 has Cyp19a1 as defining marker | not assessed | APPROXIMATE |
+| Sex ratio | Male-biased (not quantitatively documented in classical source) | not available | not assessed | NOT_ASSESSED |
+
+**Table 2 — Evidence support.**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas DB scan for Cyp19a1 in ARH (MBA:223) | Atlas metadata | WEAK | No MBA:223 supertype carries Cyp19a1 as defining marker; SUPT_0486 best available (mean=1.15) but in PVpo-VMPO-MPN | atlas-internal |
+
+*(Child-cluster breakdown not assessed — see proposed experiments. CLUS_1907 is flagged
+in atlas metadata as carrying Cyp19a1 as a defining marker, but its MERFISH spatial
+distribution within SUPT_0486's preoptic/periventricular footprint has not been verified
+against MBA:223.)*
+
+---
+
+
+
+### Eliminated candidates
+
+**Shared disqualifying signal:** the only edge on this classical node is UNCERTAIN, and
+the disqualifying property is **anatomical location**. Cyp19a1 expression is detectable
+at supertype level in SUPT_0486 (mean=1.15) and at child-cluster level in CLUS_1907
+(defining marker), but the supertype's MERFISH soma distribution places its cells in
+MBA:133 (PVpo, n=64), MBA:515 (MPN, n=37), and MBA:272 (AVPV, n=16) with **zero cells in
+MBA:223 (ARH)**. The defining ARH location of arc_aromatase_neuron is therefore not
+recovered by any Cyp19a1-positive WMBv1 supertype.
+
+### 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] · ⚪ UNCERTAIN
+
+**Disqualifying evidence**
+
+- **Location DISCORDANT — distant region.** Classical type is in Arcuate hypothalamic
+  nucleus [MBA:223]; SUPT_0486 cells are distributed across the periventricular preoptic
+  zone (MBA:133 PVpo, MBA:515 MPN, MBA:272 AVPV) with no cells recorded in MBA:223. POA
+  and ARH are anatomically distinct hypothalamic nuclei separated by intervening
+  periventricular and tuberal zones. *(distant region — stronger counter-evidence;
+  classical type may still be a member of this T-type's broader aromatase network but
+  not the ARH population specifically)*
+- **Cyp19a1 alignment is APPROXIMATE only.** SUPT_0486 supertype mean Cyp19a1 = 1.15 is
+  the best Cyp19a1 signal available, and CLUS_1907 carries Cyp19a1 as a defining marker;
+  but a full DB scan confirmed **no ARH supertype expresses Cyp19a1 as a defining
+  marker**. The match is therefore the least-bad transcriptomic candidate rather than a
+  positive identification of the ARH aromatase population.
+- **MERFISH registration uncertainty.** The classical type is defined in MBA:223 but the
+  best transcriptomic match sits in periventricular preoptic territory. Possible
+  explanations include MERFISH registration artefacts at the ARH/periventricular boundary
+  or a pan-hypothalamic aromatase transcriptomic identity that is not segregated by
+  anatomical zone in WMBv1 — neither is established by current evidence.
+- **Single-source classical definition.** The ARH location assignment for
+  arc_aromatase_neuron rests entirely on Wartenberg et al. 2021 [1]. ARH-region
+  alternative supertypes SUPT_0427 and SUPT_0428 (ARH-PVi Six6 Dopa-Gaba) have not had
+  Cyp19a1 expression assessed and remain possible — though unconfirmed — candidates.
+
+**Marker evidence provenance**
+
+- **Cyp19a1** — classical evidence is transcript-level (Wartenberg 2021 reports an
+  aromatase neuronal network in hypothalamus and amygdala, sexually dimorphic in ARH
+  adjacent to kisspeptin neurons) [1]. Atlas signal is also transcript-level (10x
+  Chromium precomputed mean = 1.15 at SUPT_0486; CLUS_1907 carries Cyp19a1 as a defining
+  marker). The atlas captures Cyp19a1+ cells, but they are spatially located in the
+  preoptic / periventricular zone — not the arcuate nucleus. There is no atlas
+  annotation/expression discrepancy in the usual sense (the gene is detected and the
+  metadata flags it as defining for CLUS_1907) — the discrepancy is between the
+  classical type's ARH location and the atlas Cyp19a1+ cells' POA/periventricular
+  location.
+- **Single-citation marker provenance.** Cyp19a1 as a defining marker for
+  arc_aromatase_neuron rests on Wartenberg 2021 [1] alone. A targeted literature search
+  for additional primary studies of arcuate Cyp19a1+ neurons (e.g. Cyp19a1-Cre lineage
+  tracing, ISH co-localisation with kisspeptin) would strengthen the classical
+  definition independently of the atlas mapping problem.
+
+**What would upgrade — or definitively eliminate — confidence**
+
+- **Query Cyp19a1 expression in ARH-located supertypes** (SUPT_0427, SUPT_0428, and
+  neighbouring ARH supertypes) from the precomputed HDF5 stats. If any ARH supertype
+  carries non-zero Cyp19a1, it becomes a stronger candidate than SUPT_0486 despite a
+  weaker marker signal, because it would resolve the location DISCORDANT verdict. If all
+  ARH supertypes are confirmed Cyp19a1-negative, SUPT_0486 remains the only available
+  match and the UNCERTAIN classification is locked in by atlas-level absence of ARH
+  Cyp19a1+ cells.
+- **CLUS_1907 spatial localisation.** Confirm whether CLUS_1907 cells are exclusively
+  POA/periventricular or include any MBA:223 representation. If exclusively POA, this
+  strengthens the location DISCORDANT verdict.
+- **Targeted cite-traverse** for "arcuate aromatase Cyp19a1 mouse" beyond Wartenberg 2021
+  to confirm the ARH location of the classical type with independent primary evidence.
+
+---
+
+### Methods
+
+<details>
+<summary>Data sources, analyses, and reproducibility receipts</summary>
+
+**Classical type definition.** See classical type table in Introduction; defining_basis on the classical node and per-property literature support are listed there. The KB-side definition lives at the source graph file linked in the reproducibility footer.
+
+**Atlas mapping query.** Candidate atlas clusters were retrieved from CCN20230722 at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias). Full scoring rules: `workflows/map-cell-type.md`.
+
+**Property alignment.** Each defining property was compared to the corresponding atlas-side value via the `property_comparisons` schema; alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
+
+
+
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote.
+
+*Generated by evidencell `0c97cfa` from [`kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`](../../kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+
+</details>
+
+---
+
+## Discussion
+
+**Primary mapping:** → SUPT_0486 (preoptic — wrong region; null result) at UNCERTAIN confidence. Key support: no support — ATLAS_METADATA confirms Cyp19a1 = 0.0 across all ARH supertypes (SUPT_0427 Cyp19a1=0.0; child clusters CLUS_1569, 1570, 1571 all = 0.0). Key caveats: `MARKER_NOT_SPECIFIC` (Cyp19a1 absent from atlas at the expected location); the arcuate aromatase population is not resolvable from WMBv1 metadata.
+
+No Cell Ontology term currently assigned for this classical type.
+
+### Proposed experiments and follow-ups
+
+### 1. Targeted Cyp19a1 expression query in ARH-located WMBv1 supertypes
+
+**What:** Query the precomputed HDF5 expression stats for Cyp19a1 across all WMBv1
+supertypes whose MERFISH soma distribution includes Arcuate hypothalamic nucleus
+[MBA:223] — including SUPT_0427 and SUPT_0428 (ARH-PVi Six6 Dopa-Gaba supertypes) and
+neighbouring ARH supertypes.
+
+**Target:** Identify any ARH supertype with Cyp19a1 mean expression ≥ 0.5 (consistent
+with detectable subset expression).
+
+**Expected output:** `MarkerAnalysisEvidence` for any ARH supertype with non-zero
+Cyp19a1; or, if all ARH supertypes return Cyp19a1 ≈ 0, a negative `MarkerAnalysisEvidence`
+that locks in the UNCERTAIN classification by establishing atlas-level absence of ARH
+Cyp19a1+ cells.
+
+**Resolves:** Open question 1.
+
+### 2. Spatial localisation of CLUS_1907
+
+**What:** Inspect the MERFISH spatial distribution of CLUS_1907 (the SUPT_0486 child
+cluster carrying Cyp19a1 as a defining marker) and determine whether any cells are
+located in MBA:223 (ARH) or whether the cluster is exclusively in POA/periventricular
+zones.
+
+**Target:** A definitive MBA-region breakdown of CLUS_1907 cells.
+
+**Expected output:** Updated location field on the SUPT_0486 / CLUS_1907 edge, supporting
+either retention of the DISCORDANT verdict (CLUS_1907 entirely outside MBA:223) or
+re-assessment if any MBA:223 cells are present.
+
+**Resolves:** Open question 2.
+
+---
+
+### Open questions
+
+1. Do SUPT_0427 or SUPT_0428 (ARH Dopa-Gaba supertypes), or any other ARH-located
+   supertype, show Cyp19a1 expression in the precomputed HDF5 stats?
+2. Is CLUS_1907 located exclusively in POA/periventricular zones in MERFISH data, or
+   are any cells assigned to MBA:223?
+
+---
+
+### Evidence base
+
+| Edge ID | Evidence type | Supports |
+|---|---|---|
+| edge_arc_aromatase_neuron_to_cs20230722_supt_0486 | ATLAS_METADATA | WEAK — SUPT_0486 best available Cyp19a1 signal (mean=1.15; CLUS_1907 defining) but anatomically in PVpo-VMPO-MPN with 0 cells in MBA:223; full DB scan confirms no ARH supertype carries Cyp19a1 as a defining marker |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | Wartenberg et al. 2021 | [PMID:34561233](https://pubmed.ncbi.nlm.nih.gov/34561233/) | Soma location (ARH adjacent to kisspeptin neurons), Cyp19a1 / aromatase as defining marker, sexually dimorphic male-biased ARH aromatase cluster, testosterone-to-estrogen conversion |

--- a/research/sexually_dimorphic/refresh_20260608_arc_aromatase_neuron/refresh_summary.json
+++ b/research/sexually_dimorphic/refresh_20260608_arc_aromatase_neuron/refresh_summary.json
@@ -1,0 +1,127 @@
+{
+  "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+  "node_id": "arc_aromatase_neuron",
+  "taxonomy_id": "CCN20230722",
+  "ranks": {
+    "rank0": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_CLUS_5303",
+          "CS20230722_CLUS_1569",
+          "CS20230722_CLUS_1570",
+          "CS20230722_CLUS_1571",
+          "CS20230722_CLUS_1683"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml arc_aromatase_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_arc_aromatase_neuron/discovery_candidates_rank0.json",
+          "  emit-stage-b: wrote 5 edge(s) + 5 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 5,
+        "edges_skipped_taxtype_not_in_topk": 1,
+        "skipped_details": [
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_cs20230722_supt_0486",
+            "taxonomy_type": "CS20230722_SUPT_0486"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_5303",
+            "taxonomy_type": "CS20230722_CLUS_5303"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1569",
+            "taxonomy_type": "CS20230722_CLUS_1569"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1570",
+            "taxonomy_type": "CS20230722_CLUS_1570"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1571",
+            "taxonomy_type": "CS20230722_CLUS_1571"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1683",
+            "taxonomy_type": "CS20230722_CLUS_1683"
+          }
+        ]
+      }
+    },
+    "rank1": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_SUPT_1190",
+          "CS20230722_SUPT_1173",
+          "CS20230722_SUPT_1174",
+          "CS20230722_SUPT_0427",
+          "CS20230722_SUPT_0495"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml arc_aromatase_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_arc_aromatase_neuron/discovery_candidates_rank1.json",
+          "  emit-stage-b: wrote 5 edge(s) + 5 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 5,
+        "edges_skipped_taxtype_not_in_topk": 6,
+        "skipped_details": [
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_cs20230722_supt_0486",
+            "taxonomy_type": "CS20230722_SUPT_0486"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_5303",
+            "taxonomy_type": "CS20230722_CLUS_5303"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1569",
+            "taxonomy_type": "CS20230722_CLUS_1569"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1570",
+            "taxonomy_type": "CS20230722_CLUS_1570"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1571",
+            "taxonomy_type": "CS20230722_CLUS_1571"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1683",
+            "taxonomy_type": "CS20230722_CLUS_1683"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_SUPT_1190",
+            "taxonomy_type": "CS20230722_SUPT_1190"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_SUPT_1173",
+            "taxonomy_type": "CS20230722_SUPT_1173"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_SUPT_1174",
+            "taxonomy_type": "CS20230722_SUPT_1174"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_SUPT_0427",
+            "taxonomy_type": "CS20230722_SUPT_0427"
+          },
+          {
+            "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_SUPT_0495",
+            "taxonomy_type": "CS20230722_SUPT_0495"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/research/sexually_dimorphic/refresh_20260608_avpv_kiss1_neuron/discovery_candidates_rank0.json
+++ b/research/sexually_dimorphic/refresh_20260608_avpv_kiss1_neuron/discovery_candidates_rank0.json
@@ -1,0 +1,1837 @@
+{
+  "classical_node_id": "avpv_kiss1_neuron",
+  "classical_node_name": "AVPV/PeN kisspeptin neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 0,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_CLUS_1301",
+      "label": "1301 MEA-BST Lhx6 Nfib Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0360",
+      "male_female_ratio": 0.1,
+      "criteria_applied": [
+        "sex_bias=female"
+      ],
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Th",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.026,
+        "region_fraction_100um": 0.051,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1876",
+      "label": "1876 PVpo-VMPO-MPN Hmx2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0482",
+      "male_female_ratio": 1.17,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Th",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.517,
+        "region_fraction_100um": 0.629,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1891",
+      "label": "1891 PVpo-VMPO-MPN Hmx2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0483",
+      "male_female_ratio": 0.1,
+      "criteria_applied": [
+        "sex_bias=female"
+      ],
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.059,
+        "region_fraction_100um": 0.074,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1895",
+      "label": "1895 PVpo-VMPO-MPN Hmx2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0483",
+      "male_female_ratio": 0.06,
+      "criteria_applied": [
+        "sex_bias=female"
+      ],
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.01,
+        "region_fraction_100um": 0.01,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1507",
+      "label": "1507 PVR Six3 Sox3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0411",
+      "male_female_ratio": 1.04,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.391,
+        "region_fraction_100um": 0.669,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1531",
+      "label": "1531 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0419",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.062,
+        "region_fraction_100um": 0.212,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1533",
+      "label": "1533 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0419",
+      "male_female_ratio": 1.63,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.354,
+        "region_fraction_100um": 0.667,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1534",
+      "label": "1534 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0419",
+      "male_female_ratio": 1.17,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.396,
+        "region_fraction_100um": 0.706,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1536",
+      "label": "1536 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0419",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.113,
+        "region_fraction_100um": 0.242,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1862",
+      "label": "1862 TMd-DMH Foxd2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0481",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.488,
+        "region_fraction_100um": 0.585,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1888",
+      "label": "1888 PVpo-VMPO-MPN Hmx2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0483",
+      "male_female_ratio": 5.67,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.18,
+        "region_fraction_100um": 0.231,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1909",
+      "label": "1909 PVpo-VMPO-MPN Hmx2 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0484",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.107,
+        "region_fraction_100um": 0.107,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1967",
+      "label": "1967 ARH-PVp Tbx3 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0494",
+      "male_female_ratio": 0.72,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.655,
+        "region_fraction_100um": 0.707,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_0871",
+      "label": "0871 NDB-SI-MA-STRv Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0245",
+      "male_female_ratio": 0.61,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Th",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.045,
+        "region_fraction_100um": 0.095,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1309",
+      "label": "1309 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0361",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.074,
+        "region_fraction_100um": 0.074,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1788",
+      "label": "1788 DMH-LHA Gsx1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0470",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Th",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.008,
+        "region_fraction_100um": 0.057,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1828",
+      "label": "1828 PVHd-DMH Lhx6 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0475",
+      "male_female_ratio": 1.04,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Th",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.062,
+        "region_fraction_100um": 0.062,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1838",
+      "label": "1838 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0478",
+      "male_female_ratio": 0.92,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.005,
+        "region_fraction_100um": 0.026,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1851",
+      "label": "1851 TU-ARH Otp Six6 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0479",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Th",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.012,
+        "region_fraction_100um": 0.012,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1889",
+      "label": "1889 PVpo-VMPO-MPN Hmx2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0483",
+      "male_female_ratio": 1.7,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.061,
+        "region_fraction_100um": 0.096,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1912",
+      "label": "1912 PVpo-VMPO-MPN Hmx2 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0486",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Th",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.027,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1961",
+      "label": "1961 ARH-PVp Tbx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0493",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.003,
+        "region_fraction_100um": 0.065,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1279",
+      "label": "1279 MEA-BST Lhx6 Nr2e1 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0355",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.014,
+        "region_fraction_100um": 0.032,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_5246",
+      "label": "5246 Tanycyte NN_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUPT_1173",
+      "male_female_ratio": 2.45,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.049,
+        "region_fraction_100um": 0.148,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_0874",
+      "label": "0874 NDB-SI-MA-STRv Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0245",
+      "male_female_ratio": 0.64,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.028,
+        "region_fraction_100um": 0.101,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_0880",
+      "label": "0880 NDB-SI-MA-STRv Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0246",
+      "male_female_ratio": 0.75,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.059,
+        "region_fraction_100um": 0.135,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_0885",
+      "label": "0885 NDB-SI-MA-STRv Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0246",
+      "male_female_ratio": 0.61,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.06,
+        "region_fraction_100um": 0.18,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_0896",
+      "label": "0896 NDB-SI-MA-STRv Lhx8 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0248",
+      "male_female_ratio": 0.61,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.057,
+        "region_fraction_100um": 0.13,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1305",
+      "label": "1305 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0361",
+      "male_female_ratio": 6.14,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.35,
+        "region_fraction_100um": 0.35,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1433",
+      "label": "1433 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0397",
+      "male_female_ratio": 0.89,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.014,
+        "region_fraction_100um": 0.148,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1440",
+      "label": "1440 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.07,
+        "region_fraction_100um": 0.214,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1441",
+      "label": "1441 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 0.89,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.073,
+        "region_fraction_100um": 0.279,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1442",
+      "label": "1442 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 1.5,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.062,
+        "region_fraction_100um": 0.118,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1443",
+      "label": "1443 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 1.63,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.04,
+        "region_fraction_100um": 0.14,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1444",
+      "label": "1444 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 1.63,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.111,
+        "region_fraction_100um": 0.333,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1445",
+      "label": "1445 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.233,
+        "region_fraction_100um": 0.432,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1503",
+      "label": "1503 PVR Six3 Sox3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0411",
+      "male_female_ratio": 0.92,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.171,
+        "region_fraction_100um": 0.292,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1505",
+      "label": "1505 PVR Six3 Sox3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0411",
+      "male_female_ratio": 0.85,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.132,
+        "region_fraction_100um": 0.17,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1519",
+      "label": "1519 PVR Six3 Sox3 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0414",
+      "male_female_ratio": 0.92,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.02,
+        "region_fraction_100um": 0.107,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1515",
+      "label": "1515 PVR Six3 Sox3 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0414",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.127,
+        "region_fraction_100um": 0.215,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1520",
+      "label": "1520 PVR Six3 Sox3 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0415",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.121,
+        "region_fraction_100um": 0.19,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1521",
+      "label": "1521 PVR Six3 Sox3 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0415",
+      "male_female_ratio": 0.59,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.292,
+        "region_fraction_100um": 0.347,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1522",
+      "label": "1522 PVR Six3 Sox3 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0415",
+      "male_female_ratio": 0.89,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.106,
+        "region_fraction_100um": 0.216,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1523",
+      "label": "1523 PVR Six3 Sox3 Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0416",
+      "male_female_ratio": 0.52,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.053,
+        "region_fraction_100um": 0.119,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1525",
+      "label": "1525 PVR Six3 Sox3 Gaba_7",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0417",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.259,
+        "region_fraction_100um": 0.345,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1526",
+      "label": "1526 PVR Six3 Sox3 Gaba_7",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0417",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.3,
+        "region_fraction_100um": 0.381,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1527",
+      "label": "1527 PVR Six3 Sox3 Gaba_8",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0418",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.222,
+        "region_fraction_100um": 0.333,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1528",
+      "label": "1528 PVR Six3 Sox3 Gaba_8",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0418",
+      "male_female_ratio": 1.04,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.115,
+        "region_fraction_100um": 0.2,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1529",
+      "label": "1529 PVR Six3 Sox3 Gaba_8",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0418",
+      "male_female_ratio": 1.17,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.034,
+        "region_fraction_100um": 0.121,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1530",
+      "label": "1530 PVR Six3 Sox3 Gaba_8",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0418",
+      "male_female_ratio": 0.75,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.105,
+        "region_fraction_100um": 0.105,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_avpv_kiss1_neuron/discovery_candidates_rank1.json
+++ b/research/sexually_dimorphic/refresh_20260608_avpv_kiss1_neuron/discovery_candidates_rank1.json
@@ -1,0 +1,1637 @@
+{
+  "classical_node_id": "avpv_kiss1_neuron",
+  "classical_node_name": "AVPV/PeN kisspeptin neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 1,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_SUPT_0411",
+      "label": "0411 PVR Six3 Sox3 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.324,
+        "region_fraction_100um": 0.55,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0494",
+      "label": "0494 ARH-PVp Tbx3 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_108",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.433,
+        "region_fraction_100um": 0.557,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0550",
+      "label": "0550 MPN-MPO-PVpo Hmx2 Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_124",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.612,
+        "region_fraction_100um": 0.733,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0249",
+      "label": "0249 NDB-SI-MA-STRv Lhx8 Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Th",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.009,
+        "region_fraction_100um": 0.019,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0486",
+      "label": "0486 PVpo-VMPO-MPN Hmx2 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.043,
+        "region_fraction_100um": 0.061,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_1172",
+      "label": "1172 Tanycyte NN_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_322",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.098,
+        "region_fraction_100um": 0.243,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0246",
+      "label": "0246 NDB-SI-MA-STRv Lhx8 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.035,
+        "region_fraction_100um": 0.117,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0419",
+      "label": "0419 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.171,
+        "region_fraction_100um": 0.348,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0418",
+      "label": "0418 PVR Six3 Sox3 Gaba_8",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.085,
+        "region_fraction_100um": 0.169,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0417",
+      "label": "0417 PVR Six3 Sox3 Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.224,
+        "region_fraction_100um": 0.292,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0416",
+      "label": "0416 PVR Six3 Sox3 Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.053,
+        "region_fraction_100um": 0.119,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0415",
+      "label": "0415 PVR Six3 Sox3 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.181,
+        "region_fraction_100um": 0.269,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0495",
+      "label": "0495 ARH-PVp Tbx3 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_108",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.018,
+        "region_fraction_100um": 0.115,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0485",
+      "label": "0485 PVpo-VMPO-MPN Hmx2 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.339,
+        "region_fraction_100um": 0.372,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0482",
+      "label": "0482 PVpo-VMPO-MPN Hmx2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.121,
+        "region_fraction_100um": 0.197,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0481",
+      "label": "0481 TMd-DMH Foxd2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_105",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.071,
+        "region_fraction_100um": 0.218,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0398",
+      "label": "0398 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.073,
+        "region_fraction_100um": 0.183,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_1200",
+      "label": "1200 NK cells NN_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_338",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.001,
+        "region_fraction_100um": 0.001,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0261",
+      "label": "0261 PAL-STR Gaba-Chol_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_058",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.006,
+        "region_fraction_100um": 0.022,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0248",
+      "label": "0248 NDB-SI-MA-STRv Lhx8 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.017,
+        "region_fraction_100um": 0.073,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0245",
+      "label": "0245 NDB-SI-MA-STRv Lhx8 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.016,
+        "region_fraction_100um": 0.043,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0251",
+      "label": "0251 NDB-SI-MA-STRv Lhx8 Gaba_8",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.012,
+        "region_fraction_100um": 0.044,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0250",
+      "label": "0250 NDB-SI-MA-STRv Lhx8 Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.005,
+        "region_fraction_100um": 0.008,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0244",
+      "label": "0244 NDB-SI-MA-STRv Lhx8 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.016,
+        "region_fraction_100um": 0.039,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0414",
+      "label": "0414 PVR Six3 Sox3 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.029,
+        "region_fraction_100um": 0.085,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0412",
+      "label": "0412 PVR Six3 Sox3 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.02,
+        "region_fraction_100um": 0.028,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0406",
+      "label": "0406 MPO-ADP Lhx8 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.004,
+        "region_fraction_100um": 0.015,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0400",
+      "label": "0400 SI-MPO-LPO Lhx8 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.022,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0458",
+      "label": "0458 AHN Onecut3 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_100",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.026,
+        "region_fraction_100um": 0.046,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0424",
+      "label": "0424 BST-MPN Six3 Nrgn Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.012,
+        "region_fraction_100um": 0.023,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0423",
+      "label": "0423 BST-MPN Six3 Nrgn Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.012,
+        "region_fraction_100um": 0.018,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0430",
+      "label": "0430 TMv-PMv Tbx3 Hist-Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_092",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.013,
+        "region_fraction_100um": 0.05,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0493",
+      "label": "0493 ARH-PVp Tbx3 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_108",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.002,
+        "region_fraction_100um": 0.071,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0478",
+      "label": "0478 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_104",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.006,
+        "region_fraction_100um": 0.023,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0484",
+      "label": "0484 PVpo-VMPO-MPN Hmx2 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.047,
+        "region_fraction_100um": 0.046,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0483",
+      "label": "0483 PVpo-VMPO-MPN Hmx2 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.027,
+        "region_fraction_100um": 0.036,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0470",
+      "label": "0470 DMH-LHA Gsx1 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_102",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.014,
+        "region_fraction_100um": 0.032,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0355",
+      "label": "0355 MEA-BST Lhx6 Nr2e1 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_075",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.016,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0361",
+      "label": "0361 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.037,
+        "region_fraction_100um": 0.038,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0360",
+      "label": "0360 MEA-BST Lhx6 Nfib Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.018,
+        "region_fraction_100um": 0.035,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0399",
+      "label": "0399 SI-MPO-LPO Lhx8 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.04,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0397",
+      "label": "0397 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.009,
+        "region_fraction_100um": 0.044,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0518",
+      "label": "0518 MS-SF Bsx Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_115",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.018,
+        "region_fraction_100um": 0.029,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0552",
+      "label": "0552 DMH Hmx2 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_125",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.005,
+        "region_fraction_100um": 0.021,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0236",
+      "label": "0236 STR Lhx8 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_055",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Th",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_evidence": "DESCENDANT_ONLY"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0256",
+      "label": "0256 NDB-SI-MA-STRv Lhx8 Gaba_13",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.019,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0403",
+      "label": "0403 MPO-ADP Lhx8 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.014,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0402",
+      "label": "0402 MPO-ADP Lhx8 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.014,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0440",
+      "label": "0440 DMH Prdm13 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_095",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.024,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0479",
+      "label": "0479 TU-ARH Otp Six6 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_104",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:272,MBA:126",
+              "nt_type=GABAergic / dopaminergic (TH co-expression)",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.028,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_avpv_kiss1_neuron/prior_summary_preserved.md
+++ b/research/sexually_dimorphic/refresh_20260608_avpv_kiss1_neuron/prior_summary_preserved.md
@@ -1,0 +1,136 @@
+# AVPV/PeN kisspeptin neuron — WMBv1 Mapping Report
+*2026-04-25 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
+
+---
+
+## Classical type
+
+| Property | Value | References |
+|---|---|---|
+| CL term | hypothalamus kisspeptin neuron (CL:4023123) | |
+| Soma location | anteroventral periventricular nucleus (AVPV) [MBA:272]; periventricular nucleus (PeN) [MBA:341] | [1] [2] [3] [1] [2] [3] |
+| NT | GABAergic / dopaminergic (TH co-expression) | [3] |
+| Markers | Kiss1+, Th+, Esr1+ | [1] [2] [3] [4] [5] |
+| Neuropeptides | Kiss1 | [6] |
+
+---
+
+## Cell Ontology mapping
+
+AVPV/PeN kisspeptin neuron is a **broad match** to **hypothalamus kisspeptin neuron (CL:4023123)** in the Cell Ontology — i.e. **hypothalamus kisspeptin neuron (CL:4023123)** is the closest existing CL term (an ancestor) but does not fully cover this type. A new child term is a candidate for submission to CL.
+
+*Mapping notes:* CL:4023123 covers all hypothalamic kisspeptin neurons. The AVPV/PeN (RP3V) population is Kiss1-only (not obligately KNDy), so the more specific CL:4023128 (RP3V KNDy neuron) is inappropriate as it requires NKB and dynorphin co-expression. A dedicated CL term for the AVPV/RP3V Kiss1 non-KNDy subpopulation does not yet exist — potential CL contribution.
+
+---
+
+## Mapping candidates
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
+|---|---|---|---|---|---|
+| — | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] |  | 178 |  |  |
+| — | 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_CLUS_1915] | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 | 5 |  |  |
+
+All edges: `evidencell:PartialOverlapMatch`
+
+---
+
+## 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 · 
+
+*`CS20230722_SUPT_0486` · 178 cells (10x)*
+
+**Supporting evidence:**
+
+- SUPT_0486 (PVpo-VMPO-MPN Hmx2 Gaba_5) is the highest-scoring supertype for AVPV-region preoptic GABAergic neurons. Precomputed expression confirms Esr1=7.72 (defining marker for both classical node and supertype), Th=2.72, and Kiss1=0.62. The supertype contains n=16 cells labeled AVPV (MBA:272). Child cluster CLUS_1915 (dopaminergic designation, male_female_ratio=0.02) is the strongest sub-resolution candidate for the female-biased AVPV Kiss1/TH population. PARTIAL_OVERLAP because SUPT_0486 spans a broader preoptic zone than the AVPV/PeN. [Atlas metadata]
+
+**Concerns:**
+
+- **nt_type** (APPROXIMATE): A=GABAergic / dopaminergic (Th co-expression) / B=GABAergic (Gaba_5 label). GABAergic concordant; dopaminergic component present at supertype level (Th=2.72) but diluted. Resolved at cluster level by CLUS_1915 (nt_type=Dopa).
+
+- **location_MBA272** (APPROXIMATE): A=MBA:272 (AVPV) / B=MBA:272 (AVPV) n=16; MBA:133 PVpo n=64; MBA:515 MPN n=37. Direct AVPV location match (n=16); supertype spans broader preoptic zone.
+- **marker_Kiss1** (APPROXIMATE): A=POSITIVE (transcript, defining marker) / B=precomputed mean_expression=0.62. Present but low-moderate at supertype level; consistent with subset expression.
+- **marker_Th** (APPROXIMATE): A=POSITIVE (protein, co-expressed with Kiss1) / B=precomputed mean_expression=2.72. 
+- SUPT_0486 spans PVpo-VMPO-MPN and contains multiple preoptic cell types. avpv_kiss1_neuron, avpv_th_neuron, and mpoa_esr1_neuron all map to SUPT_0486, reflecting the heterogeneity of this preoptic GABAergic supertype. AVPV Kiss1 neurons are a subset.
+- Supertype-level sex ratio not directly available. Female-biased sex ratio signal is concentrated in child cluster CLUS_1915 (male_female_ratio=0.02). A cluster-level edge to CLUS_1915 would provide more specific mapping.
+
+**What would upgrade confidence:**
+
+- *Unresolved:* Which cluster(s) within SUPT_0486 carry peak Kiss1+Th+Esr1 co-expression consistent with AVPV Kiss1/TH identity?
+
+- *Unresolved:* Do PeN (MBA:341) Kiss1 neurons map to SUPT_0486 or a different supertype?
+
+- *Proposed:* Inspect child clusters of SUPT_0486 for Kiss1, Th, Esr1 co-expression at cluster level to identify the AVPV Kiss1/TH candidate cluster.
+
+- *Proposed:* MapMyCells annotation transfer of published AVPV Kiss1 scRNA-seq data to WMBv1.
+
+
+---
+
+## 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 · 
+
+*`CS20230722_CLUS_1915` · 5 cells (10x) · supertype: 0486 PVpo-VMPO-MPN Hmx2 Gaba_5*
+
+**Supporting evidence:**
+
+- CLUS_1915 (1915 PVpo-VMPO-MPN Hmx2 Gaba_5) is the child cluster of SUPT_0486 with the highest co-expression of Kiss1 (2.51), Th (6.6), and Esr1 (9.55) — all three classical defining markers. It is the most strongly female-biased cluster in the supertype (male_female_ratio=0.02), directly concordant with the FEMALE_BIASED sex_bias of avpv_kiss1_neuron. Kiss1 and Slc18a2 are cluster-level DEFINING markers. nt_type=Dopa confirmed in cluster.yaml. MBA:272 (AVPV) cells explicitly present. CLUS_1915 was not ranked in the top-30 DB results because its Kiss1/Th/Esr1 profile appears only in precomputed_expression, not in the defining_markers metadata columns. It was identified through child_cluster_expression analysis of the SUPT_0486 parent. [Atlas metadata]
+- Stephens 2024 (PMID:37934722) bulk Kiss1+ neurons sorted from RP3V vs ARC. Differential δ = ρ_RP3V − ρ_ARC ranks CLUS_1915 first of 5,322 atlas clusters, with δ=0.090 (ρ_RP3V=0.388, ρ_ARC=0.298). All other top-20 hits are also preoptic/periventricular hypothalamic GABAergic clusters — the differential signal is strongly anatomically clean. Independent quantitative confirmation of the existing ATLAS_METADATA-based mapping; the Kiss1+ pool transcriptomic profile tracks CLUS_1915 specifically more than any other cluster in the atlas. [Bulk correlation] [7]
+
+**Concerns:**
+
+- **location_MBA272** (APPROXIMATE): A=MBA:272 (AVPV) / B=MBA:272 (AVPV) n=1; MBA:133 PVpo n=1; MBA:1097 Hypothalamus n=3. AVPV cells present but cluster is very small (n=5 total) and primary soma annotation resolves to the broad Hypothalamus catchall (MBA:1097). MERFISH spatial resolution insufficient to resolve AVPV vs adjacent PVpo/PeN at this cell count.
+
+- CLUS_1915 contains only n=3–5 total cells in the WMBv1 atlas. The sex ratio (MFR=0.02) and expression values are reliable in direction but have limited statistical power. Confidence is capped at MODERATE pending annotation transfer evidence or larger-dataset replication.
+- CLUS_1915 is a sub-resolution split of SUPT_0486. The cluster-level Kiss1+Th+Dopa phenotype is the most specific available match for avpv_kiss1_neuron; however, avpv_th_neuron maps to the same cluster (both types substantially overlap in the classical literature — most AVPV Kiss1 cells co-express Th).
+
+**What would upgrade confidence:**
+
+- *Unresolved:* Do avpv_kiss1_neuron and avpv_th_neuron represent separable populations within CLUS_1915, or is CLUS_1915 the atlas correlate of both?
+
+- *Proposed:* MapMyCells annotation transfer of published AVPV Kiss1-Cre or Kiss1-Cre/Rosa-tdTom scRNA-seq data to WMBv1; confirm F1 score against CLUS_1915.
+
+
+---
+
+## Proposed experiments
+
+### 1 — Other
+
+- Inspect child clusters of SUPT_0486 for Kiss1, Th, Esr1 co-expression at cluster level to identify the AVPV Kiss1/TH candidate cluster.
+*Resolves: edge_avpv_kiss1_neuron_to_cs20230722_supt_0486*
+
+### 2 — MapMyCells / annotation transfer
+
+- MapMyCells annotation transfer of published AVPV Kiss1 scRNA-seq data to WMBv1.
+- MapMyCells annotation transfer of published AVPV Kiss1-Cre or Kiss1-Cre/Rosa-tdTom scRNA-seq data to WMBv1; confirm F1 score against CLUS_1915.
+*Resolves: edge_avpv_kiss1_neuron_to_cs20230722_supt_0486, edge_avpv_kiss1_neuron_to_cs20230722_clus_1915*
+
+---
+
+## Open questions
+
+1. Which cluster(s) within SUPT_0486 carry peak Kiss1+Th+Esr1 co-expression consistent with AVPV Kiss1/TH identity?
+2. Do PeN (MBA:341) Kiss1 neurons map to SUPT_0486 or a different supertype?
+3. Do avpv_kiss1_neuron and avpv_th_neuron represent separable populations within CLUS_1915, or is CLUS_1915 the atlas correlate of both?
+
+---
+
+## Evidence base
+
+| Edge | Evidence types | Supports |
+|---|---|---|
+| edge_avpv_kiss1_neuron_to_cs20230722_supt_0486 | Atlas metadata | PARTIAL |
+| edge_avpv_kiss1_neuron_to_cs20230722_clus_1915 | Atlas metadata | SUPPORT |
+| edge_avpv_kiss1_neuron_to_cs20230722_clus_1915 | Bulk correlation [7] | SUPPORT |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | Nejad et al. 2017 · PMID:29201072 | [29201072](https://pubmed.ncbi.nlm.nih.gov/29201072/) | soma location |
+| [2] | Adachi et al. 2007 · PMID:17213691 | [17213691](https://pubmed.ncbi.nlm.nih.gov/17213691/) | soma location |
+| [3] | Stephens et al. 2017 · PMID:28660243 | [28660243](https://pubmed.ncbi.nlm.nih.gov/28660243/) | soma location |
+| [4] | Kauffman et al. 2007 · PMID:17699664 | [17699664](https://pubmed.ncbi.nlm.nih.gov/17699664/) | Th marker |
+| [5] | Wartenberg et al. 2021 · PMID:34561233 | [34561233](https://pubmed.ncbi.nlm.nih.gov/34561233/) | Esr1 marker |
+| [6] | Frazão et al. 2013 · PMID:23407940 | [23407940](https://pubmed.ncbi.nlm.nih.gov/23407940/) | Kiss1 neuropeptide |
+| [7] | Stephens et al. 2024 · PMID:37934722 | [37934722](https://pubmed.ncbi.nlm.nih.gov/37934722/) | Stephens 2024 (PMID:37934722) bulk Kiss1+ neurons sorted from RP3V vs ARC. Diffe |

--- a/research/sexually_dimorphic/refresh_20260608_avpv_kiss1_neuron/refresh_summary.json
+++ b/research/sexually_dimorphic/refresh_20260608_avpv_kiss1_neuron/refresh_summary.json
@@ -1,0 +1,157 @@
+{
+  "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+  "node_id": "avpv_kiss1_neuron",
+  "taxonomy_id": "CCN20230722",
+  "ranks": {
+    "rank0": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_CLUS_1301",
+          "CS20230722_CLUS_1876",
+          "CS20230722_CLUS_1891",
+          "CS20230722_CLUS_1895",
+          "CS20230722_CLUS_1507"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml avpv_kiss1_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_avpv_kiss1_neuron/discovery_candidates_rank0.json",
+          "  emit-stage-b: skipped 5 existing edge(s): edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1301, edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1876, edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1891, edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1895, edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1507",
+          "  emit-stage-b: nothing to write (all edges already present)."
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 5,
+        "edges_skipped_taxtype_not_in_topk": 7,
+        "skipped_details": [
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_cs20230722_supt_0486",
+            "taxonomy_type": "CS20230722_SUPT_0486"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_cs20230722_clus_1915",
+            "taxonomy_type": "CS20230722_CLUS_1915"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0411",
+            "taxonomy_type": "CS20230722_SUPT_0411"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0494",
+            "taxonomy_type": "CS20230722_SUPT_0494"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0550",
+            "taxonomy_type": "CS20230722_SUPT_0550"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0249",
+            "taxonomy_type": "CS20230722_SUPT_0249"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0486",
+            "taxonomy_type": "CS20230722_SUPT_0486"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1301",
+            "taxonomy_type": "CS20230722_CLUS_1301"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1876",
+            "taxonomy_type": "CS20230722_CLUS_1876"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1891",
+            "taxonomy_type": "CS20230722_CLUS_1891"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1895",
+            "taxonomy_type": "CS20230722_CLUS_1895"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1507",
+            "taxonomy_type": "CS20230722_CLUS_1507"
+          }
+        ]
+      }
+    },
+    "rank1": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_SUPT_0411",
+          "CS20230722_SUPT_0494",
+          "CS20230722_SUPT_0550",
+          "CS20230722_SUPT_0249",
+          "CS20230722_SUPT_0486"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml avpv_kiss1_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_avpv_kiss1_neuron/discovery_candidates_rank1.json",
+          "  emit-stage-b: skipped 5 existing edge(s): edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0411, edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0494, edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0550, edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0249, edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0486",
+          "  emit-stage-b: nothing to write (all edges already present)."
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 6,
+        "edges_skipped_taxtype_not_in_topk": 6,
+        "skipped_details": [
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_cs20230722_clus_1915",
+            "taxonomy_type": "CS20230722_CLUS_1915"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1301",
+            "taxonomy_type": "CS20230722_CLUS_1301"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1876",
+            "taxonomy_type": "CS20230722_CLUS_1876"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1891",
+            "taxonomy_type": "CS20230722_CLUS_1891"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1895",
+            "taxonomy_type": "CS20230722_CLUS_1895"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1507",
+            "taxonomy_type": "CS20230722_CLUS_1507"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_cs20230722_supt_0486",
+            "taxonomy_type": "CS20230722_SUPT_0486"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0411",
+            "taxonomy_type": "CS20230722_SUPT_0411"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0494",
+            "taxonomy_type": "CS20230722_SUPT_0494"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0550",
+            "taxonomy_type": "CS20230722_SUPT_0550"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0249",
+            "taxonomy_type": "CS20230722_SUPT_0249"
+          },
+          {
+            "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0486",
+            "taxonomy_type": "CS20230722_SUPT_0486"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/research/sexually_dimorphic/refresh_20260608_avpv_th_neuron/discovery_candidates_rank0.json
+++ b/research/sexually_dimorphic/refresh_20260608_avpv_th_neuron/discovery_candidates_rank0.json
@@ -1,0 +1,372 @@
+{
+  "classical_node_id": "avpv_th_neuron",
+  "classical_node_name": "AVPV tyrosine hydroxylase (TH) neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 0,
+  "n_candidates": 10,
+  "candidates": [
+    {
+      "node_id": "CS20230722_CLUS_1915",
+      "label": "1915 PVpo-VMPO-MPN Hmx2 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0486",
+      "male_female_ratio": 0.02,
+      "criteria_applied": [
+        "sex_bias=female"
+      ],
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 1,
+        "cohort_size": 10,
+        "next_best_score": 2,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 10,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Kiss1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.029,
+        "region_fraction_100um": 0.071,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1469",
+      "label": "1469 MPO-ADP Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0404",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 2,
+        "cohort_size": 10,
+        "next_best_score": 2,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 10,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Th",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.021,
+        "region_fraction_100um": 0.053,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_5246",
+      "label": "5246 Tanycyte NN_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUPT_1173",
+      "male_female_ratio": 2.45,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 3,
+        "cohort_size": 10,
+        "next_best_score": 2,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 10,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.049,
+        "region_fraction_100um": 0.148,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1910",
+      "label": "1910 PVpo-VMPO-MPN Hmx2 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0485",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 4,
+        "cohort_size": 10,
+        "next_best_score": 2,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 10,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.208,
+        "region_fraction_100um": 0.26,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_5211",
+      "label": "5211 Astro-NT NN_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUPT_1159",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 5,
+        "cohort_size": 10,
+        "next_best_score": 2,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 10,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.03,
+        "region_fraction_100um": 0.035,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1535",
+      "label": "1535 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0419",
+      "male_female_ratio": 0.92,
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 6,
+        "cohort_size": 10,
+        "next_best_score": 2,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 10,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Th",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.022,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1904",
+      "label": "1904 PVpo-VMPO-MPN Hmx2 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0484",
+      "male_female_ratio": 1.5,
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 7,
+        "cohort_size": 10,
+        "next_best_score": 2,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 10,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.05,
+        "region_fraction_100um": 0.05,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1907",
+      "label": "1907 PVpo-VMPO-MPN Hmx2 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0484",
+      "male_female_ratio": 2.7,
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 8,
+        "cohort_size": 10,
+        "next_best_score": 2,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 10,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.059,
+        "region_fraction_100um": 0.054,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1940",
+      "label": "1940 DMH Hmx2 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0489",
+      "male_female_ratio": 1.86,
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 9,
+        "cohort_size": 10,
+        "next_best_score": 2,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 10,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.034,
+        "region_fraction_100um": 0.034,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_5316",
+      "label": "5316 DC NN_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUPT_1197",
+      "male_female_ratio": 1.5,
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 10,
+        "cohort_size": 10,
+        "next_best_score": 2,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 10,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.018,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_avpv_th_neuron/discovery_candidates_rank1.json
+++ b/research/sexually_dimorphic/refresh_20260608_avpv_th_neuron/discovery_candidates_rank1.json
@@ -1,0 +1,385 @@
+{
+  "classical_node_id": "avpv_th_neuron",
+  "classical_node_name": "AVPV tyrosine hydroxylase (TH) neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 1,
+  "n_candidates": 12,
+  "candidates": [
+    {
+      "node_id": "CS20230722_SUPT_0550",
+      "label": "0550 MPN-MPO-PVpo Hmx2 Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_124",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 1,
+        "cohort_size": 12,
+        "next_best_score": 2,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 12,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.612,
+        "region_fraction_100um": 0.733,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_1172",
+      "label": "1172 Tanycyte NN_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_322",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 2,
+        "cohort_size": 12,
+        "next_best_score": 2,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 12,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.098,
+        "region_fraction_100um": 0.243,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0419",
+      "label": "0419 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 3,
+        "cohort_size": 12,
+        "next_best_score": 2,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 12,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.171,
+        "region_fraction_100um": 0.348,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0485",
+      "label": "0485 PVpo-VMPO-MPN Hmx2 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 4,
+        "cohort_size": 12,
+        "next_best_score": 2,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 12,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.339,
+        "region_fraction_100um": 0.372,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0400",
+      "label": "0400 SI-MPO-LPO Lhx8 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 5,
+        "cohort_size": 12,
+        "next_best_score": 2,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 12,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.022,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0486",
+      "label": "0486 PVpo-VMPO-MPN Hmx2 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 6,
+        "cohort_size": 12,
+        "next_best_score": 2,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 12,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.043,
+        "region_fraction_100um": 0.061,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0484",
+      "label": "0484 PVpo-VMPO-MPN Hmx2 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 7,
+        "cohort_size": 12,
+        "next_best_score": 2,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 12,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.047,
+        "region_fraction_100um": 0.046,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0518",
+      "label": "0518 MS-SF Bsx Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_115",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 8,
+        "cohort_size": 12,
+        "next_best_score": 2,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 12,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.018,
+        "region_fraction_100um": 0.029,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_1197",
+      "label": "1197 DC NN_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_337",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 9,
+        "cohort_size": 12,
+        "next_best_score": 2,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 12,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_evidence": "DESCENDANT_ONLY"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_1159",
+      "label": "1159 Astro-NT NN_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_318",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 10,
+        "cohort_size": 12,
+        "next_best_score": 2,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 12,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_evidence": "DESCENDANT_ONLY"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0404",
+      "label": "0404 MPO-ADP Lhx8 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 11,
+        "cohort_size": 12,
+        "next_best_score": 2,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 12,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_evidence": "DESCENDANT_ONLY"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0489",
+      "label": "0489 DMH Hmx2 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 12,
+        "cohort_size": 12,
+        "next_best_score": 2,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 12,
+            "filters": [
+              "region=MBA:272",
+              "nt_type=dopaminergic",
+              "sex_bias=female"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_evidence": "DESCENDANT_ONLY"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_avpv_th_neuron/prior_summary_preserved.md
+++ b/research/sexually_dimorphic/refresh_20260608_avpv_th_neuron/prior_summary_preserved.md
@@ -1,0 +1,111 @@
+# AVPV tyrosine hydroxylase (TH) neuron — WMBv1 Mapping Report
+*2026-04-25 · Source: `/Users/do12/Documents/GitHub/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
+
+---
+
+## Classical type
+
+| Property | Value | References |
+|---|---|---|
+| CL term | — | |
+| Soma location | anteroventral periventricular nucleus (AVPV) [MBA:272] | [1] [2] [3] |
+| NT | dopaminergic | [3] |
+| Markers | Th+, Kiss1+ | [1] [4] [2] [3] [5] |
+
+---
+
+## Mapping candidates
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Verdict |
+|---|---|---|---|---|---|
+| — | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] |  | 178 |  |  |
+| — | 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_CLUS_1915] | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 | 5 |  |  |
+
+All edges: `evidencell:PartialOverlapMatch`
+
+---
+
+## 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 · 
+
+*`CS20230722_SUPT_0486` · 178 cells (10x)*
+
+**Supporting evidence:**
+
+- SUPT_0486 is the top-ranked rank-1 candidate for avpv_th_neuron. Child cluster CLUS_1915 (nt_type=Dopa, male_female_ratio=0.02) is the most extremely female-biased cluster in the candidate set, directly concordant with the female-biased AVPV TH population (2-4x more TH+ neurons in females). Th=2.72, Esr1=7.72, Kiss1=0.62 at supertype level. Three independent signals (Th expression, AVPV location, female sex ratio in child cluster) converge on SUPT_0486/CLUS_1915. [Atlas metadata]
+
+**Concerns:**
+
+- **nt_type** (APPROXIMATE): A=dopaminergic (A14 group) / B=GABAergic (Gaba_5 label); child CLUS_1915 nt_type=Dopa. Dopaminergic identity resolved at cluster level; supertype label reflects majority.
+- **location_MBA272** (APPROXIMATE): A=MBA:272 (AVPV) / B=MBA:272 (AVPV) n=16; MBA:133 PVpo n=64; MBA:515 MPN n=37. Direct AVPV cells present (n=16); supertype also spans broader preoptic zone.
+- **marker_Th** (APPROXIMATE): A=POSITIVE (protein, primary defining marker) / B=precomputed mean_expression=2.72. 
+- **marker_Kiss1** (APPROXIMATE): A=POSITIVE (transcript, co-expressed with Th in AVPV) / B=precomputed mean_expression=0.62. 
+- SUPT_0486 carries a Gaba_5 label at supertype level while the classical AVPV TH neuron is dopaminergic. Dopaminergic identity is resolved only at cluster level (CLUS_1915, Dopa designation).
+- avpv_th_neuron and avpv_kiss1_neuron both map to SUPT_0486 — these two classical types substantially overlap (most AVPV/PeN Kiss1 cells co-express Th). Cluster-level resolution needed to determine whether they are separable within SUPT_0486.
+
+**What would upgrade confidence:**
+
+- *Unresolved:* Does CLUS_1915 specifically correspond to AVPV A14 TH neurons? Confirm by cluster-level Kiss1/Th/Esr1 co-expression profiling.
+
+- *Proposed:* MapMyCells annotation transfer of AVPV TH-lineage (Th-Cre or Kiss1-Cre) scRNA-seq data to WMBv1 for F1-based confirmation.
+
+
+---
+
+## 1915 PVpo-VMPO-MPN Hmx2 Gaba_5 · 
+
+*`CS20230722_CLUS_1915` · 5 cells (10x) · supertype: 0486 PVpo-VMPO-MPN Hmx2 Gaba_5*
+
+**Supporting evidence:**
+
+- CLUS_1915 is the top-ranked rank-0 candidate (DB score=6) for avpv_th_neuron. Th=6.6 (highest in the SUPT_0486 lineage), Kiss1=2.51 (only cluster with Kiss1 substantially above background), MFR=0.02 (extreme female bias), nt_type=Dopa confirmed, MBA:272 (AVPV) cells present. Slc18a2 (VMAT2, vesicular monoamine transporter) is a DEFINING cluster marker, providing independent dopaminergic identity support. Three convergent signals: Th expression, female sex ratio, and dopaminergic NT type. [Atlas metadata]
+
+**Concerns:**
+
+- **location_MBA272** (APPROXIMATE): A=MBA:272 (AVPV) / B=MBA:272 (AVPV) n=1; MBA:133 PVpo n=1; MBA:1097 Hypothalamus n=3. AVPV cells present; cluster too small to resolve sub-regional anatomy precisely.
+- CLUS_1915 has only n=3–5 total cells. All metrics are directionally correct but have limited statistical power. Confidence capped at MODERATE.
+- avpv_th_neuron and avpv_kiss1_neuron both map to CLUS_1915 — the two classical types are substantially overlapping (most AVPV Kiss1 cells co-express Th). These may be the same cell population described from different entry points in the classical literature.
+
+**What would upgrade confidence:**
+
+- *Unresolved:* Is CLUS_1915 specifically the A14 TH/Kiss1 cluster, or does it also include TH+ AVPV neurons that are Kiss1-negative?
+
+- *Proposed:* MapMyCells annotation transfer of Th-Cre AVPV scRNA-seq data for F1-based confirmation at cluster level.
+
+
+---
+
+## Proposed experiments
+
+### 1 — MapMyCells / annotation transfer
+
+- MapMyCells annotation transfer of AVPV TH-lineage (Th-Cre or Kiss1-Cre) scRNA-seq data to WMBv1 for F1-based confirmation.
+- MapMyCells annotation transfer of Th-Cre AVPV scRNA-seq data for F1-based confirmation at cluster level.
+*Resolves: edge_avpv_th_neuron_to_cs20230722_supt_0486, edge_avpv_th_neuron_to_cs20230722_clus_1915*
+
+---
+
+## Open questions
+
+1. Does CLUS_1915 specifically correspond to AVPV A14 TH neurons? Confirm by cluster-level Kiss1/Th/Esr1 co-expression profiling.
+2. Is CLUS_1915 specifically the A14 TH/Kiss1 cluster, or does it also include TH+ AVPV neurons that are Kiss1-negative?
+
+---
+
+## Evidence base
+
+| Edge | Evidence types | Supports |
+|---|---|---|
+| edge_avpv_th_neuron_to_cs20230722_supt_0486 | Atlas metadata | SUPPORT |
+| edge_avpv_th_neuron_to_cs20230722_clus_1915 | Atlas metadata | SUPPORT |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | https://doi.org/10.1007/s12031-012-9923-1 | — | soma location |
+| [2] | He et al. 2013 · PMID:25206587 | [25206587](https://pubmed.ncbi.nlm.nih.gov/25206587/) | soma location |
+| [3] | Stephens et al. 2017 · PMID:28660243 | [28660243](https://pubmed.ncbi.nlm.nih.gov/28660243/) | soma location |
+| [4] | Zilkha et al. 2021 · PMID:33910083 | [33910083](https://pubmed.ncbi.nlm.nih.gov/33910083/) | Th marker |
+| [5] | Kauffman et al. 2007 · PMID:17699664 | [17699664](https://pubmed.ncbi.nlm.nih.gov/17699664/) | Kiss1 marker |

--- a/research/sexually_dimorphic/refresh_20260608_avpv_th_neuron/refresh_summary.json
+++ b/research/sexually_dimorphic/refresh_20260608_avpv_th_neuron/refresh_summary.json
@@ -1,0 +1,135 @@
+{
+  "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+  "node_id": "avpv_th_neuron",
+  "taxonomy_id": "CCN20230722",
+  "ranks": {
+    "rank0": {
+      "stage_a": {
+        "n_candidates": 10,
+        "top5": [
+          "CS20230722_CLUS_1915",
+          "CS20230722_CLUS_1469",
+          "CS20230722_CLUS_5246",
+          "CS20230722_CLUS_1910",
+          "CS20230722_CLUS_5211"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml avpv_th_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_avpv_th_neuron/discovery_candidates_rank0.json",
+          "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 6,
+        "edges_skipped_taxtype_not_in_topk": 1,
+        "skipped_details": [
+          {
+            "edge_id": "edge_avpv_th_neuron_to_cs20230722_supt_0486",
+            "taxonomy_type": "CS20230722_SUPT_0486"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_avpv_th_neuron_to_cs20230722_clus_1915",
+            "taxonomy_type": "CS20230722_CLUS_1915"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_1915",
+            "taxonomy_type": "CS20230722_CLUS_1915"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_1469",
+            "taxonomy_type": "CS20230722_CLUS_1469"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_5246",
+            "taxonomy_type": "CS20230722_CLUS_5246"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_1910",
+            "taxonomy_type": "CS20230722_CLUS_1910"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_5211",
+            "taxonomy_type": "CS20230722_CLUS_5211"
+          }
+        ]
+      }
+    },
+    "rank1": {
+      "stage_a": {
+        "n_candidates": 12,
+        "top5": [
+          "CS20230722_SUPT_0550",
+          "CS20230722_SUPT_1172",
+          "CS20230722_SUPT_0419",
+          "CS20230722_SUPT_0485",
+          "CS20230722_SUPT_0400"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml avpv_th_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_avpv_th_neuron/discovery_candidates_rank1.json",
+          "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 6,
+        "edges_skipped_taxtype_not_in_topk": 6,
+        "skipped_details": [
+          {
+            "edge_id": "edge_avpv_th_neuron_to_cs20230722_clus_1915",
+            "taxonomy_type": "CS20230722_CLUS_1915"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_1915",
+            "taxonomy_type": "CS20230722_CLUS_1915"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_1469",
+            "taxonomy_type": "CS20230722_CLUS_1469"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_5246",
+            "taxonomy_type": "CS20230722_CLUS_5246"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_1910",
+            "taxonomy_type": "CS20230722_CLUS_1910"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_5211",
+            "taxonomy_type": "CS20230722_CLUS_5211"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_avpv_th_neuron_to_cs20230722_supt_0486",
+            "taxonomy_type": "CS20230722_SUPT_0486"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_SUPT_0550",
+            "taxonomy_type": "CS20230722_SUPT_0550"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_SUPT_1172",
+            "taxonomy_type": "CS20230722_SUPT_1172"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_SUPT_0419",
+            "taxonomy_type": "CS20230722_SUPT_0419"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_SUPT_0485",
+            "taxonomy_type": "CS20230722_SUPT_0485"
+          },
+          {
+            "edge_id": "edge_avpv_th_neuron_to_CS20230722_SUPT_0400",
+            "taxonomy_type": "CS20230722_SUPT_0400"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/research/sexually_dimorphic/refresh_20260608_bnst_crf_neuron/discovery_candidates_rank0.json
+++ b/research/sexually_dimorphic/refresh_20260608_bnst_crf_neuron/discovery_candidates_rank0.json
@@ -1,0 +1,2507 @@
+{
+  "classical_node_id": "bnst_crf_neuron",
+  "classical_node_name": "BNST (anterolateral) corticotropin-releasing factor (CRF) neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 0,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_CLUS_1409",
+      "label": "1409 CEA-BST Rai14 Pdyn Crh Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0393",
+      "male_female_ratio": 0.92,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 3.57,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.517
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.506,
+        "region_fraction_100um": 0.794,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1410",
+      "label": "1410 CEA-BST Rai14 Pdyn Crh Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0393",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 7.57,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.855
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.649,
+        "region_fraction_100um": 0.851,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1475",
+      "label": "1475 MPO-ADP Lhx8 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0405",
+      "male_female_ratio": 0.61,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 0.68,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.167
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.545,
+        "region_fraction_100um": 0.864,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1476",
+      "label": "1476 MPO-ADP Lhx8 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0405",
+      "male_female_ratio": 0.45,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 1.29,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.291
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.453,
+        "region_fraction_100um": 0.669,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1499",
+      "label": "1499 BST Tac2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0410",
+      "male_female_ratio": 0.72,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 3.49,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.504
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.613,
+        "region_fraction_100um": 0.762,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1500",
+      "label": "1500 BST Tac2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0410",
+      "male_female_ratio": 0.82,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 0.57,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.146
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.473,
+        "region_fraction_100um": 0.6,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1501",
+      "label": "1501 BST Tac2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0410",
+      "male_female_ratio": 0.39,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 6.58,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.754
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.734,
+        "region_fraction_100um": 0.778,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1235",
+      "label": "1235 MEA-BST Sox6 Gaba_10",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0346",
+      "male_female_ratio": 3.17,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 2.25,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.407
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.379,
+        "region_fraction_100um": 0.517,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1455",
+      "label": "1455 SI-MPO-LPO Lhx8 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0400",
+      "male_female_ratio": 0.67,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.0,
+            "reliable": false,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.0
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.033,
+        "region_fraction_100um": 0.074,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1474",
+      "label": "1474 MPO-ADP Lhx8 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0405",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.0,
+            "reliable": false,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.0
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.053,
+        "region_fraction_100um": 0.053,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2121",
+      "label": "2121 ADP-MPO Trp73 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0528",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.0,
+            "reliable": false,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.0
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.042,
+        "region_fraction_100um": 0.074,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_0900",
+      "label": "0900 NDB-SI-MA-STRv Lhx8 Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0249",
+      "male_female_ratio": 1.38,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 0.88,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.202
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.163,
+        "region_fraction_100um": 0.212,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_0901",
+      "label": "0901 NDB-SI-MA-STRv Lhx8 Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0249",
+      "male_female_ratio": 1.04,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 0.92,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.216
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.279,
+        "region_fraction_100um": 0.364,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_0969",
+      "label": "0969 STR D2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0274",
+      "male_female_ratio": 0.96,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 5.96,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.699
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.304,
+        "region_fraction_100um": 0.304,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_0984",
+      "label": "0984 STR D2 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0278",
+      "male_female_ratio": 0.92,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 7.29,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.826
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.156,
+        "region_fraction_100um": 0.364,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1313",
+      "label": "1313 MEA-BST Lhx6 Nfib Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0362",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 8.01,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.902
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.402,
+        "region_fraction_100um": 0.5,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1316",
+      "label": "1316 CEA-BST Gal Avp Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0363",
+      "male_female_ratio": 0.96,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.74,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.179
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.405,
+        "region_fraction_100um": 0.505,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1328",
+      "label": "1328 CEA-BST Six3 Cyp26b1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0367",
+      "male_female_ratio": 1.08,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 6.15,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.72
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.482,
+        "region_fraction_100um": 0.667,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1329",
+      "label": "1329 CEA-BST Six3 Cyp26b1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0367",
+      "male_female_ratio": 0.79,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 5.9,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.693
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.421,
+        "region_fraction_100um": 0.586,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1330",
+      "label": "1330 CEA-BST Six3 Cyp26b1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0367",
+      "male_female_ratio": 2.12,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 6.12,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.715
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.449,
+        "region_fraction_100um": 0.592,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1360",
+      "label": "1360 CEA-AAA-BST Six3 Sp9 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0375",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 6.21,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.725
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.537,
+        "region_fraction_100um": 0.644,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1362",
+      "label": "1362 CEA-AAA-BST Six3 Sp9 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0375",
+      "male_female_ratio": 1.08,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 6.37,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.738
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.567,
+        "region_fraction_100um": 0.833,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1373",
+      "label": "1373 ACB-BST-FS D1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0381",
+      "male_female_ratio": 0.82,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 1.57,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.348
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.673,
+        "region_fraction_100um": 0.75,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1374",
+      "label": "1374 ACB-BST-FS D1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0381",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.96,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.229
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.697,
+        "region_fraction_100um": 0.828,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1375",
+      "label": "1375 ACB-BST-FS D1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0381",
+      "male_female_ratio": 1.5,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 3.07,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.47
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.31,
+        "region_fraction_100um": 0.617,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1377",
+      "label": "1377 ACB-BST-FS D1 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0382",
+      "male_female_ratio": 0.45,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 0.91,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.213
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.16,
+        "region_fraction_100um": 0.233,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1370",
+      "label": "1370 CEA-AAA-BST Six3 Sp9 Gaba_7",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0379",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 2.0,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.39
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.372,
+        "region_fraction_100um": 0.519,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1382",
+      "label": "1382 ACB-BST-FS D1 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut-GABA",
+      "parent_id": "CS20230722_SUPT_0383",
+      "male_female_ratio": 0.82,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 2.77,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.439
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.563,
+        "region_fraction_100um": 0.731,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1383",
+      "label": "1383 ACB-BST-FS D1 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0383",
+      "male_female_ratio": 2.33,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.68,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.167
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.795,
+        "region_fraction_100um": 0.951,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1380",
+      "label": "1380 ACB-BST-FS D1 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0383",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 3.78,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.538
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.46,
+        "region_fraction_100um": 0.94,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1381",
+      "label": "1381 ACB-BST-FS D1 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut-GABA",
+      "parent_id": "CS20230722_SUPT_0383",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.18,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.024
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.623,
+        "region_fraction_100um": 0.905,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1391",
+      "label": "1391 CEA-BST Ebf1 Pdyn Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0386",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 2.89,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.452
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.289,
+        "region_fraction_100um": 0.353,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1403",
+      "label": "1403 CEA-BST Ebf1 Pdyn Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0389",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 1.13,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.265
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.108,
+        "region_fraction_100um": 0.167,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1406",
+      "label": "1406 CEA-BST Ebf1 Pdyn Gaba_8",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0391",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 1.16,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.267
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.238,
+        "region_fraction_100um": 0.365,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1407",
+      "label": "1407 CEA-BST Rai14 Pdyn Crh Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0392",
+      "male_female_ratio": 1.08,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 2.88,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.45
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.37,
+        "region_fraction_100um": 0.504,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1414",
+      "label": "1414 BST-SI-AAA Six3 Slc22a3 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0395",
+      "male_female_ratio": 0.82,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 1.62,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.356
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.5,
+        "region_fraction_100um": 0.69,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1429",
+      "label": "1429 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0397",
+      "male_female_ratio": 1.38,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 5.46,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.655
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.06,
+        "region_fraction_100um": 0.173,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1431",
+      "label": "1431 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0397",
+      "male_female_ratio": 1.04,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 2.1,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.4
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.145,
+        "region_fraction_100um": 0.255,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1434",
+      "label": "1434 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0397",
+      "male_female_ratio": 0.85,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 6.93,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.795
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.126,
+        "region_fraction_100um": 0.345,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1436",
+      "label": "1436 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0397",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 2.17,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.402
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.16,
+        "region_fraction_100um": 0.24,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1438",
+      "label": "1438 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0397",
+      "male_female_ratio": 0.82,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 6.82,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.78
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.208,
+        "region_fraction_100um": 0.321,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1472",
+      "label": "1472 MPO-ADP Lhx8 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0405",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 1.07,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.25
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.2,
+        "region_fraction_100um": 0.5,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1483",
+      "label": "1483 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0407",
+      "male_female_ratio": 0.96,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 4.74,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.605
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.446,
+        "region_fraction_100um": 0.597,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1493",
+      "label": "1493 BST Tac2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0409",
+      "male_female_ratio": 2.12,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 6.84,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.782
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.217,
+        "region_fraction_100um": 0.583,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1498",
+      "label": "1498 BST Tac2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0409",
+      "male_female_ratio": 1.08,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 4.89,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.616
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.338,
+        "region_fraction_100um": 0.456,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1560",
+      "label": "1560 BST-MPN Six3 Nrgn Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0425",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 2.0,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.39
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.455,
+        "region_fraction_100um": 0.529,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1989",
+      "label": "1989 BST-po Iigp1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0501",
+      "male_female_ratio": 0.64,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.29,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.057
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.347,
+        "region_fraction_100um": 0.554,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1993",
+      "label": "1993 TRS-BAC Sln Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0503",
+      "male_female_ratio": 0.33,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 3.76,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.537
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.51,
+        "region_fraction_100um": 0.583,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1197",
+      "label": "1197 MEA-BST Sox6 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0338",
+      "male_female_ratio": 0.82,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.9,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.211
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.424,
+        "region_fraction_100um": 0.545,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1226",
+      "label": "1226 MEA-BST Sox6 Gaba_7",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0343",
+      "male_female_ratio": 2.12,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 8.03,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.906
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.772,
+        "region_fraction_100um": 0.901,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_bnst_crf_neuron/discovery_candidates_rank1.json
+++ b/research/sexually_dimorphic/refresh_20260608_bnst_crf_neuron/discovery_candidates_rank1.json
@@ -1,0 +1,2282 @@
+{
+  "classical_node_id": "bnst_crf_neuron",
+  "classical_node_name": "BNST (anterolateral) corticotropin-releasing factor (CRF) neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 1,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_SUPT_0410",
+      "label": "0410 BST Tac2 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_088",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 3.4,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.492
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.482,
+        "region_fraction_100um": 0.569,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0393",
+      "label": "0393 CEA-BST Rai14 Pdyn Crh Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_083",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 5.57,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.737
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.628,
+        "region_fraction_100um": 0.846,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0343",
+      "label": "0343 MEA-BST Sox6 Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_073",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 7.28,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.894
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.423,
+        "region_fraction_100um": 0.548,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0379",
+      "label": "0379 CEA-AAA-BST Six3 Sp9 Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_080",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 2.0,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.352
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.372,
+        "region_fraction_100um": 0.519,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0383",
+      "label": "0383 ACB-BST-FS D1 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_081",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 1.86,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.309
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.587,
+        "region_fraction_100um": 0.812,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0381",
+      "label": "0381 ACB-BST-FS D1 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_081",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 1.87,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.318
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.382,
+        "region_fraction_100um": 0.651,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0367",
+      "label": "0367 CEA-BST Six3 Cyp26b1 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_079",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 6.5,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.831
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.431,
+        "region_fraction_100um": 0.577,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0375",
+      "label": "0375 CEA-AAA-BST Six3 Sp9 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_080",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 6.06,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.775
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.433,
+        "region_fraction_100um": 0.544,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0363",
+      "label": "0363 CEA-BST Gal Avp Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_077",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.74,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.14
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.422,
+        "region_fraction_100um": 0.5,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0348",
+      "label": "0348 MEA-BST Lhx6 Sp9 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_074",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 7.33,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.903
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.504,
+        "region_fraction_100um": 0.652,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0353",
+      "label": "0353 MEA-BST Lhx6 Sp9 Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_074",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 5.43,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.72
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.383,
+        "region_fraction_100um": 0.511,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0397",
+      "label": "0397 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crh",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "-Calb1",
+            "val": 4.44,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.597
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.067,
+        "region_fraction_100um": 0.13,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0501",
+      "label": "0501 BST-po Iigp1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_110",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.29,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.047
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.347,
+        "region_fraction_100um": 0.554,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0249",
+      "label": "0249 NDB-SI-MA-STRv Lhx8 Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.89,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.182
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.109,
+        "region_fraction_100um": 0.145,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0252",
+      "label": "0252 NDB-SI-MA-STRv Lhx8 Gaba_9",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.31,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.059
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.093,
+        "region_fraction_100um": 0.118,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0238",
+      "label": "0238 Sst Chodl Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_056",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 6.69,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.847
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.125,
+        "region_fraction_100um": 0.212,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0237",
+      "label": "0237 STR Lhx8 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_055",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 3.23,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.466
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.115,
+        "region_fraction_100um": 0.204,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0276",
+      "label": "0276 STR D2 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_062",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 6.54,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.843
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.053,
+        "region_fraction_100um": 0.12,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0167",
+      "label": "0167 OB-STR-CTX Inh IMN_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_045",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.06,
+            "reliable": false,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.0
+              }
+            ]
+          }
+        ],
+        "region_evidence": "DESCENDANT_ONLY"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0154",
+      "label": "0154 OB-in Frmd7 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_041",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.09,
+            "reliable": false,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.004
+              }
+            ]
+          }
+        ],
+        "region_evidence": "DESCENDANT_ONLY"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0416",
+      "label": "0416 PVR Six3 Sox3 Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.63,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.136
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.076,
+        "region_fraction_100um": 0.172,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0420",
+      "label": "0420 BST-MPN Six3 Nrgn Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 6.53,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.839
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.041,
+        "region_fraction_100um": 0.119,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0409",
+      "label": "0409 BST Tac2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_088",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 5.36,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.708
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.185,
+        "region_fraction_100um": 0.32,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0408",
+      "label": "0408 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_087",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 6.23,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.805
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.07,
+        "region_fraction_100um": 0.169,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0407",
+      "label": "0407 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_087",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 5.03,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.674
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.136,
+        "region_fraction_100um": 0.244,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0406",
+      "label": "0406 MPO-ADP Lhx8 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 1.5,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.275
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.152,
+        "region_fraction_100um": 0.361,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0405",
+      "label": "0405 MPO-ADP Lhx8 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 0.84,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.161
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.283,
+        "region_fraction_100um": 0.475,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0404",
+      "label": "0404 MPO-ADP Lhx8 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 1.98,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.343
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.144,
+        "region_fraction_100um": 0.266,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0403",
+      "label": "0403 MPO-ADP Lhx8 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 1.49,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.267
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.021,
+        "region_fraction_100um": 0.11,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0426",
+      "label": "0426 BST-MPN Six3 Nrgn Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 4.69,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.631
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.046,
+        "region_fraction_100um": 0.132,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0425",
+      "label": "0425 BST-MPN Six3 Nrgn Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 3.87,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.542
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.241,
+        "region_fraction_100um": 0.361,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0421",
+      "label": "0421 BST-MPN Six3 Nrgn Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 4.86,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.648
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.165,
+        "region_fraction_100um": 0.279,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0483",
+      "label": "0483 PVpo-VMPO-MPN Hmx2 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 3.68,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.525
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.073,
+        "region_fraction_100um": 0.133,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0308",
+      "label": "0308 LSX Nkx2-1 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_069",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 2.19,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.377
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.085,
+        "region_fraction_100um": 0.182,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0303",
+      "label": "0303 LSX Otx2 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_068",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 5.57,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.737
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.057,
+        "region_fraction_100um": 0.132,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0301",
+      "label": "0301 LSX Otx2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_068",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 4.72,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.64
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.055,
+        "region_fraction_100um": 0.212,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0387",
+      "label": "0387 CEA-BST Ebf1 Pdyn Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_082",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 4.72,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.64
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.235,
+        "region_fraction_100um": 0.325,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0386",
+      "label": "0386 CEA-BST Ebf1 Pdyn Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_082",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 2.53,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.411
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.183,
+        "region_fraction_100um": 0.214,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0385",
+      "label": "0385 CEA-BST Ebf1 Pdyn Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_082",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 1.07,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.216
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.126,
+        "region_fraction_100um": 0.144,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0384",
+      "label": "0384 CEA-BST Ebf1 Pdyn Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_082",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 7.21,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.881
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.227,
+        "region_fraction_100um": 0.296,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0382",
+      "label": "0382 ACB-BST-FS D1 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_081",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 1.79,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.305
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.1,
+        "region_fraction_100um": 0.213,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0369",
+      "label": "0369 CEA-BST Six3 Cyp26b1 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_079",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 5.08,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.686
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.275,
+        "region_fraction_100um": 0.307,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0368",
+      "label": "0368 CEA-BST Six3 Cyp26b1 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_079",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 5.05,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.678
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.155,
+        "region_fraction_100um": 0.161,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0374",
+      "label": "0374 CEA-AAA-BST Six3 Sp9 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_080",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 2.83,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.419
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.059,
+        "region_fraction_100um": 0.101,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0373",
+      "label": "0373 CEA-AAA-BST Six3 Sp9 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_080",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 3.1,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.453
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.122,
+        "region_fraction_100um": 0.151,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0359",
+      "label": "0359 MEA-BST Lhx6 Nfib Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 5.43,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.72
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.112,
+        "region_fraction_100um": 0.126,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0357",
+      "label": "0357 MEA-BST Lhx6 Nfib Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 7.16,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.877
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.286,
+        "region_fraction_100um": 0.446,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0361",
+      "label": "0361 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 8.17,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.945
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.267,
+        "region_fraction_100um": 0.378,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0347",
+      "label": "0347 MEA-BST Lhx6 Sp9 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_074",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 6.35,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.809
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.152,
+        "region_fraction_100um": 0.197,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0346",
+      "label": "0346 MEA-BST Sox6 Gaba_10",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_073",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:351,MBA:351,MBA:351"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "-Calb1",
+            "val": 1.55,
+            "reliable": true,
+            "raw_tier": -1,
+            "applied_score": -1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.284
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.128,
+        "region_fraction_100um": 0.195,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_bnst_crf_neuron/prior_summary_preserved.md
+++ b/research/sexually_dimorphic/refresh_20260608_bnst_crf_neuron/prior_summary_preserved.md
@@ -1,0 +1,319 @@
+# BNST (anterolateral) corticotropin-releasing factor (CRF) neuron — WMBv1 Mapping Report
+*draft · 2026-04-25 · Source: `kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
+
+**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+
+---
+
+## Introduction
+
+### Classical type
+
+**BNST (anterolateral) corticotropin-releasing factor (CRF) neuron** is defined by
+neurochemical criteria: Crh expression as both a defining marker and the released
+neuropeptide; Calb1 absence (distinguishing dlBNST CRF neurons from the Calb1+
+principal nucleus of BNST); and a female-biased sexual dimorphism — anterolateral
+BST CRF+ neurons are larger and more numerous in females. Somas concentrate in
+three sub-nuclei of the bed nucleus of the stria terminalis: dlBNST, ovBNST, and
+alBNST. Functional electrophysiology classifies these as Type II dlBNST neurons.
+
+CL term: **corticotropin-releasing neuron (CL:4072021)** — mapping is BROAD; a
+BNST-specific child term is a candidate for new CL contribution.
+
+| Property | Value | References |
+|---|---|---|
+| Soma location | Bed nuclei of the stria terminalis [MBA:174] (dorsolateral / oval / anterolateral subnuclei) | [1], [2] |
+| Defining markers | Crh | — |
+| Negative markers | Calb1 | — |
+| Neuropeptides | Crh (corticotropin-releasing factor) | [1], [2] |
+| CL term | CL:4072021 (corticotropin-releasing neuron) — BROAD | |
+
+<details>
+<summary>Literature support — expand for verbatim quotes</summary>
+
+**[1] Frontiers in Neural Circuits 2025 — Sexually Dimorphic Brain Regions and Structures**
+
+> The BNST modulates pain sensitivity by releasing corticotropin-releasing factor (CRF) from neurons in the anterolateral subdivision (Ide et al., 2013). Female mice have larger CRF neurons in the anterolateral BNST than male mice (Uchida et al., 2019). Dopaminergic projection from the periaqueductal gray (PAG) to the BNST, which preferentially targets the dorsal part, including the anterolateral subdivision (Gungor et al., 2016), drives pain-related behaviors differently between male and female mice (Yu et al., 2021b).
+> — Frontiers in Neural Circuits 2025, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 279874350_b2b4adba -->
+
+**[2] Ide et al. 2013 · PMID:23554470 — Sexually Dimorphic Brain Regions and Structures**
+
+> Pain is a complex experience composed of sensory and affective components. Although the neural systems of the sensory component of pain have been studied extensively, those of its affective component remain to be determined. In the present study, we examined the effects of corticotropin-releasing factor (CRF) and neuropeptide Y (NPY) injected into the dorsolateral bed nucleus of the stria terminalis (dlBNST) on pain-induced aversion and nociceptive behaviors in rats to examine the roles of these peptides in affective and sensory components of pain, respectively. In vivo microdialysis showed that formalin-evoked pain enhanced the release of CRF in this brain region. Using a conditioned place aversion (CPA) test, we found that intra-dlBNST injection of a CRF1 or CRF2 receptor antagonist suppressed pain-induced aversion. Intra-dlBNST CRF injection induced CPA even in the absence of pain stimulation. On the other hand, intra-dlBNST NPY injection suppressed pain-induced aversion. Coadministration of NPY inhibited CRF-induced CPA. This inhibitory effect of NPY was blocked by coadministration of a Y1 or Y5 receptor antagonist. Furthermore, whole-cell patch-clamp electrophysiology in dlBNST slices revealed that CRF increased neuronal excitability specifically in type II dlBNST neurons, whereas NPY decreased it in these neurons. Excitatory effects of CRF on type II dlBNST neurons were suppressed by NPY. These results have uncovered some of the neuronal mechanisms underlying the affective component of pain by showing opposing roles of intra-dlBNST CRF and NPY in pain-induced aversion and opposing actions of these peptides on neuronal excitability converging on the same target, type II neurons, within the dlBNST.
+> — Ide et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 14550592_292dccea -->
+
+</details>
+
+---
+
+## Results
+
+### Mapping candidates
+
+Two mapping edges are recorded for bnst_crf_neuron: an alternative supertype-level
+edge to SUPT_0358 supported by Knoedler 2022 Esr1+ TRAP-seq bulk-correlation
+evidence (LOW confidence — Esr1+ is a proxy, not a direct Crh signal), and the
+existing supertype-level edge to SUPT_0393 (the sole rank-1 candidate carrying
+Crh as a DEFINING_SCOPED atlas marker, eliminated at supertype resolution by
+Calb1 discordance). Both are speculative or eliminated at supertype resolution
+and require child-cluster analysis.
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
+|---|---|---|---|---|---|---|
+| 1 | 0358 MEA-BST Lhx6 Nfib Gaba_2 [CS20230722_SUPT_0358] | (self) | 666 | 🔴 LOW | NT CONSISTENT; Crh NOT_ASSESSED (Esr1+ proxy); location APPROXIMATE | Speculative |
+| — | 0393 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_SUPT_0393] | (self) | 231 | ⚪ UNCERTAIN | Crh CONSISTENT; Calb1 DISCORDANT | Eliminated (negative_Calb1) |
+2 edges total. Relationship type: PARTIAL_OVERLAP (both edges).
+
+### Property alignment — primary candidate (SUPT_0358)
+
+**Table 1 — Property comparison.**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Bed nuclei of the stria terminalis [MBA:174] (dlBNST / ovBNST / alBNST) | Multiple child clusters; spans BST and MEA | CLUS_1290 primary soma = BST proper | APPROXIMATE |
+| NT type | GABAergic (CRF+ BST neurons predominantly GABAergic) | GABAergic (Lhx6 Nfib Gaba_2) | not assessed | CONSISTENT |
+| Crh expression | POSITIVE (defining marker) | NOT_ASSESSED — Knoedler sorted on Esr1, not Crh | not assessed | NOT_ASSESSED |
+| Sex ratio | sexually dimorphic (anterolateral BST CRF+ neurons larger in females) | not available | child cluster MFRs span 0.82 to 99.0; CLUS_1293 MFR=99 (male-biased) | APPROXIMATE |
+
+**Table 2 — Evidence support.**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Knoedler 2022 Esr1+ TRAP-seq BNST-FR vs VMH-FR | Bulk transcriptomic correlation | PARTIAL | best_child_cluster=CLUS_1295 (rank 4, δ=0.0161); 4 SUPT_0358 child clusters in top 10 | [3] |
+
+*(Of the 4 SUPT_0358 child clusters in the Knoedler top-10 BNST-specific signal,
+CLUS_1290 maps to BST proper while CLUS_1293 carries an extreme male-biased
+MFR=99 — divergent from the female-biased classical type. Best match by BNST
+specificity: CLUS_1295. Direct Crh expression at child-cluster level has not
+been assessed.)*
+
+---
+
+
+
+### 0358 MEA-BST Lhx6 Nfib Gaba_2 [CS20230722_SUPT_0358] · 🔴 LOW
+
+### Supporting evidence
+
+- **GABAergic identity is concordant.** Supertype label Lhx6 Nfib Gaba_2 directly
+  aligns with the GABAergic phenotype expected for BST CRF+ neurons (CONSISTENT).
+- **BST anatomical signal is captured at child-cluster level.** Property
+  comparison records CLUS_1290 with primary soma in BST proper, providing direct
+  anatomical anchoring within an otherwise mixed BST/MEA supertype (APPROXIMATE
+  at supertype level due to MEA contribution).
+- **Knoedler 2022 Esr1+ TRAP-seq bulk-correlation signal [3].**
+  > Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq pooled BNST female-receptive vs VMH female-receptive identifies SUPT_0358 (MEA-BST Lhx6 Nfib Gaba_2) as a top BNST-specific signal. Multiple child clusters appear in top 10 by δ(BNST_FR − VMH_FR): CLUS_1295 (rank 4), CLUS_1291 (rank 5), CLUS_1290 (rank 9, primary soma BST proper), CLUS_1293 (rank 10, MFR=99 — extreme male bias). CRITICAL CAVEAT: Knoedler sorted on Esr1+, not Crh+. This evidence supports SUPT_0358 as the BST-localised Esr1+ supertype; CRF+/Crh+ co-localisation within this supertype must be confirmed by direct evidence (ISH, scRNA-seq for Crh) before accepting SUPT_0358 as a bnst_crf_neuron mapping target. Confidence held at LOW pending that confirmation.
+  > — Knoedler et al. 2022 · [3]
+
+### Marker evidence provenance
+
+- **Crh** — classical node carries Crh as a defining marker without a primary
+  citation on the marker entry itself; literature support comes via the
+  neuropeptide field [1], [2], both of which establish Crh release and peptide
+  function in dlBNST. At target side, SUPT_0358 has no DEFINING marker for Crh
+  in atlas metadata, and the Knoedler sort was on Esr1+ rather than Crh+. The
+  mapping therefore relies on an Esr1+ proxy with no direct Crh quantification
+  at supertype or child-cluster level — a substantial provenance gap. *(note:
+  targeted ISH or scRNA-seq for Crh+/Esr1+ overlap in BST would resolve whether
+  the BNST-Esr1+ transcriptomic signature is a valid proxy for the CRF+
+  population.)*
+- **Calb1 (negative marker)** — classical node lists Calb1 as a negative marker
+  without a primary citation on the marker entry. Calb1 expression at SUPT_0358
+  has not been quantified in this edge's property_comparisons; this remains an
+  assessment gap that should be checked against precomputed expression to rule
+  out a Calb1+ contamination similar to that seen in SUPT_0393.
+
+### Concerns
+
+- **Crh expression is NOT_ASSESSED at supertype/cluster level.** The Knoedler
+  evidence is pooled Esr1+ TRAP-seq — Crh+/Esr1+ co-localisation in BST is not
+  established by this run. Without direct Crh quantification, SUPT_0358 cannot
+  be confirmed as the CRF+ correlate.
+- **Location APPROXIMATE — supertype spans BST and MEA.** SUPT_0358 includes
+  medial amygdala (MEA) cells alongside BST. *(adjacent region — MEA and BST
+  are part of the extended amygdala continuum, so this is weak counter-evidence
+  at supertype resolution; cluster-level resolution shows CLUS_1290 is in BST
+  proper.)*
+- **Sex ratio APPROXIMATE with conflicting child-cluster signal.** Child cluster
+  MFRs span 0.82 to 99.0; CLUS_1293 (rank 10 in the Knoedler signal) carries
+  MFR = 99 — extreme male bias, opposite the female-biased dimorphism that
+  defines bnst_crf_neuron. This indicates SUPT_0358 aggregates sex-divergent
+  subpopulations and the CRF+ female-biased subset is unlikely to encompass
+  the entire supertype.
+- **No DEFINING Crh marker in atlas metadata (NO_DISCRIMINATING_MARKER caveat).**
+  The mapping rests entirely on bulk-correlation co-localisation evidence
+  (Esr1+ proxy). Direct Crh expression measurement at cluster level is the
+  prerequisite for any confidence upgrade.
+- **Ambiguous mapping vs SUPT_0393 (AMBIGUOUS_MAPPING caveat).** SUPT_0358 and
+  SUPT_0393 may both capture parts of the heterogeneous BNST-CRF population —
+  SUPT_0393 via direct Crh expression (Calb1-confounded), SUPT_0358 via Esr1+
+  proxy (Crh-unverified). Curator review is required to determine which (or
+  both) should be retained.
+
+### What would upgrade confidence
+
+- **ISH or MERFISH co-staining for Crh, Esr1, Calb1 in BST** to identify the
+  cluster boundary between SUPT_0358 (Esr1+) and SUPT_0393 (Crh+). Expected
+  output: `MarkerAnalysisEvidence` resolving the Crh+/Esr1+/Calb1− triple-
+  overlap fraction within SUPT_0358 child clusters.
+- **MapMyCells annotation transfer of published BNST scRNA-seq with Crh+ subset
+  annotations** to WMBv1 at cluster resolution. Target: F1 ≥ 0.50 for Crh+
+  subset cells against either SUPT_0358 or SUPT_0393 (split expected).
+  Expected output: `AnnotationTransferEvidence` on both edges.
+- **Targeted child-cluster query for Crh and Calb1 precomputed expression**
+  across SUPT_0358 child clusters (CLUS_1290, CLUS_1291, CLUS_1293, CLUS_1295)
+  to identify any Crh-high, Calb1-low, female-biased child cluster as a more
+  specific candidate.
+- **Targeted literature search** for primary citations supporting Calb1
+  negativity in dlBNST CRF neurons (currently unsourced on the classical node)
+  would strengthen the negative-marker assertion that is currently driving the
+  SUPT_0393 elimination.
+
+---
+
+### Eliminated candidates
+
+### 0393 CEA-BST Rai14 Pdyn Crh Gaba_2 [CS20230722_SUPT_0393] · ⚪ UNCERTAIN
+
+The single shared disqualifying signal is **Calb1 DISCORDANT** at supertype
+level (precomputed mean = 5.57 despite Calb1 being a NEGATIVE marker for the
+classical type).
+
+**Disqualifying evidence:**
+
+- **Calb1 = 5.57 at supertype level (DISCORDANT, primary driver of UNCERTAIN
+  confidence).** Calb1 is explicitly absent in dlBNST CRF neurons but shows
+  substantial supertype-level expression. SUPT_0393 likely aggregates both
+  Calb1− CRF neurons and Calb1+ BNST neurons. *(strong counter-evidence in a
+  marker sense — the negative-marker discordance disqualifies the supertype
+  as a whole; a child cluster with low Calb1 and high Crh would be a more
+  specific mapping candidate and may support upgrade to LOW or MODERATE.)*
+- **Sub-nucleus identity unresolvable (MERFISH_REGISTRATION_UNCERTAINTY
+  caveat).** The classical type is defined at sub-nucleus resolution (dlBNST,
+  ovBNST, alBNST). WMBv1 MERFISH annotation uses the parent BNST term
+  [MBA:351] without sub-nucleus assignment. This caveat applies to any BST
+  candidate, not only SUPT_0393.
+
+**Otherwise-supportive properties (PARTIAL atlas-metadata evidence, all
+overruled by the Calb1 discordance):**
+
+- Crh = 7.96 (DEFINING_SCOPED, CONSISTENT) — SUPT_0393 is the only rank-1
+  candidate with BST location, Crh marker, and GABAergic NT.
+- Location = BNST [MBA:351] n = 140 (CONSISTENT).
+- NT = GABAergic, Gad2 DEFINING (CONSISTENT).
+
+A Calb1-low child cluster of SUPT_0393 may rescue this candidate.
+
+---
+
+### Methods
+
+<details>
+<summary>Data sources, analyses, and reproducibility receipts</summary>
+
+**Classical type definition.** See classical type table in Introduction; defining_basis on the classical node and per-property literature support are listed there. The KB-side definition lives at the source graph file linked in the reproducibility footer.
+
+**Atlas mapping query.** Candidate atlas clusters were retrieved from CCN20230722 at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias). Full scoring rules: `workflows/map-cell-type.md`.
+
+**Property alignment.** Each defining property was compared to the corresponding atlas-side value via the `property_comparisons` schema; alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
+
+**Bulk transcriptomic correlation.** Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq BNST female-receptive vs VMH female-receptive. SUPT_0358 child clusters at top of δ ranking. Run record: [`kb/correlation_runs/20260428_knoedler_esr1_wmbv1/manifest.yaml`](../../kb/correlation_runs/20260428_knoedler_esr1_wmbv1/manifest.yaml). Script: [`correlate.py`](https://github.com/Cellular-Semantics/evidencell/blob/4e67d6b/kb/correlation_runs/20260428_knoedler_esr1_wmbv1/correlate.py)
+
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote.
+
+*Generated by evidencell `0c97cfa` from [`kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`](../../kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+
+</details>
+
+---
+
+## Discussion
+
+**Primary mapping:** → 0358 MEA-BST Lhx6 Nfib Gaba_2 [CS20230722_SUPT_0358] at LOW confidence. Key support: BULK_CORRELATION (Knoedler 2022 [3]) — Esr1+ proxy for the CRF+ subpopulation. Key caveats: Knoedler is Esr1-only; co-localisation with Crh requires direct evidence. Alternative existing edge to SUPT_0393 at UNCERTAIN..
+
+No Cell Ontology term currently assigned for this classical type.
+
+### Proposed experiments and follow-ups
+
+### 1. ISH or MERFISH co-staining for Crh, Esr1, Calb1 in BST
+
+**What:** Triple-stain ISH or MERFISH of BST in male and female mice for Crh,
+Esr1, and Calb1 to define the cluster boundary between SUPT_0358 (Esr1+) and
+SUPT_0393 (Crh+ with Calb1+ admixture) and to identify the Crh+ Calb1−
+anterolateral BST subset.
+
+**Target:** Quantify Crh+/Esr1+ overlap fraction in BST; identify a Crh+
+Calb1− Esr1+ female-biased subset.
+
+**Expected output:** `MarkerAnalysisEvidence` on both edges.
+
+**Resolves:** Open questions 1 and 2 (which supertype is the better mapping
+target).
+
+### 2. Annotation transfer of BNST scRNA-seq with Crh+ subset annotations
+
+**What:** MapMyCells annotation transfer of published BNST scRNA-seq with Crh+
+subset annotations against WMBv1 at cluster resolution.
+
+**Target:** F1 split between SUPT_0358 and SUPT_0393 — diagnostic for which
+supertype carries the Crh+ female-biased dimorphic population.
+
+**Expected output:** `AnnotationTransferEvidence` on both edges. Atlas: WMBv1.
+Tool: MapMyCells. Output format: per-cluster F1 matrix, fed back as
+`AnnotationTransferEvidence` YAML.
+
+**Resolves:** Open questions 1 and 2; addresses the Crh NOT_ASSESSED gap on
+SUPT_0358.
+
+### 3. Child-cluster precomputed expression query for SUPT_0393 and SUPT_0358
+
+**What:** Query precomputed Calb1 and Crh expression across child clusters of
+SUPT_0393 to identify any Calb1-low, Crh-high cluster as a more specific
+mapping candidate. Apply the same query to SUPT_0358 child clusters
+(CLUS_1290, CLUS_1291, CLUS_1293, CLUS_1295) for direct Crh assessment.
+
+**Target:** Identify a Crh-high, Calb1-low child cluster (in either supertype)
+that could be promoted to a primary cluster-level mapping.
+
+**Expected output:** Per-child-cluster Crh and Calb1 means recorded on the
+edges; potentially a new cluster-level `MappingEdge` if a clean child cluster
+is identified.
+
+**Resolves:** SUPT_0393 Calb1 DISCORDANT rescue path; SUPT_0358 Crh
+NOT_ASSESSED gap; refinement of female-biased vs male-biased child-cluster
+heterogeneity within SUPT_0358.
+
+---
+
+### Open questions
+
+1. What fraction of SUPT_0358 cells co-express Esr1 and Crh? ISH or scRNA-seq
+   for Crh+/Esr1+ overlap in BST would resolve this. *(Appears on the SUPT_0358
+   edge.)*
+2. Is SUPT_0393 (high Crh, Calb1-confounded) or SUPT_0358 (Esr1+ proxy,
+   Crh-unverified) the better mapping for the sexually dimorphic anterolateral
+   BST CRF+ population — or do they capture distinct subsets? *(Appears on the
+   SUPT_0358 edge as the AMBIGUOUS_MAPPING caveat.)*
+3. Do individual clusters under SUPT_0393 segregate into Calb1-high and
+   Calb1-low populations? A Calb1-low, Crh-high child cluster would support
+   confidence upgrade. *(Appears on the SUPT_0393 edge.)*
+4. Does SUPT_0393 show a female-biased sex ratio consistent with
+   bnst_crf_neuron? *(Appears on the SUPT_0393 edge.)*
+
+---
+
+### Evidence base
+
+| Edge ID | Evidence type | Supports |
+|---|---|---|
+| edge_bnst_crf_neuron_to_cs20230722_supt_0358 | BULK_CORRELATION ([3] Knoedler 2022) | PARTIAL — best_child_cluster=CLUS_1295 (rank 4, δ=0.0161); 4 SUPT_0358 child clusters in top 10 of BNST-FR vs VMH-FR; Esr1+ proxy, Crh unverified |
+| edge_bnst_crf_neuron_to_cs20230722_supt_0393 | ATLAS_METADATA | PARTIAL — Crh=7.96 (DEFINING_SCOPED), BST [MBA:351] n=140, Gad2 DEFINING; Calb1=5.57 DISCORDANT vs negative-marker requirement |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | Frontiers in Neural Circuits 2025 | [DOI:10.3389/fncir.2025.1593443](https://doi.org/10.3389/fncir.2025.1593443) | Soma location; CRF neuropeptide; female-biased dimorphism in anterolateral BNST |
+| [2] | Ide et al. 2013 | [PMID:23554470](https://pubmed.ncbi.nlm.nih.gov/23554470/) | Soma location (dlBNST); CRF neuropeptide; Type II ephys classification within dlBNST |
+| [3] | Knoedler et al. 2022 | [PMID:35143761](https://pubmed.ncbi.nlm.nih.gov/35143761/) | Knoedler 2022 Esr1+ TRAP-seq pooled BNST female-receptive vs VMH female-receptive — bulk-correlation BNST-specific signal identifying SUPT_0358 |

--- a/research/sexually_dimorphic/refresh_20260608_bnst_crf_neuron/refresh_summary.json
+++ b/research/sexually_dimorphic/refresh_20260608_bnst_crf_neuron/refresh_summary.json
@@ -1,0 +1,135 @@
+{
+  "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+  "node_id": "bnst_crf_neuron",
+  "taxonomy_id": "CCN20230722",
+  "ranks": {
+    "rank0": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_CLUS_1409",
+          "CS20230722_CLUS_1410",
+          "CS20230722_CLUS_1475",
+          "CS20230722_CLUS_1476",
+          "CS20230722_CLUS_1499"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml bnst_crf_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_bnst_crf_neuron/discovery_candidates_rank0.json",
+          "  emit-stage-b: wrote 5 edge(s) + 5 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 5,
+        "edges_skipped_taxtype_not_in_topk": 2,
+        "skipped_details": [
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_cs20230722_supt_0393",
+            "taxonomy_type": "CS20230722_SUPT_0393"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_cs20230722_supt_0358",
+            "taxonomy_type": "CS20230722_SUPT_0358"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1409",
+            "taxonomy_type": "CS20230722_CLUS_1409"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1410",
+            "taxonomy_type": "CS20230722_CLUS_1410"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1475",
+            "taxonomy_type": "CS20230722_CLUS_1475"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1476",
+            "taxonomy_type": "CS20230722_CLUS_1476"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1499",
+            "taxonomy_type": "CS20230722_CLUS_1499"
+          }
+        ]
+      }
+    },
+    "rank1": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_SUPT_0410",
+          "CS20230722_SUPT_0393",
+          "CS20230722_SUPT_0343",
+          "CS20230722_SUPT_0379",
+          "CS20230722_SUPT_0383"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml bnst_crf_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_bnst_crf_neuron/discovery_candidates_rank1.json",
+          "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 6,
+        "edges_skipped_taxtype_not_in_topk": 6,
+        "skipped_details": [
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_cs20230722_supt_0358",
+            "taxonomy_type": "CS20230722_SUPT_0358"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1409",
+            "taxonomy_type": "CS20230722_CLUS_1409"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1410",
+            "taxonomy_type": "CS20230722_CLUS_1410"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1475",
+            "taxonomy_type": "CS20230722_CLUS_1475"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1476",
+            "taxonomy_type": "CS20230722_CLUS_1476"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1499",
+            "taxonomy_type": "CS20230722_CLUS_1499"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_cs20230722_supt_0393",
+            "taxonomy_type": "CS20230722_SUPT_0393"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_SUPT_0410",
+            "taxonomy_type": "CS20230722_SUPT_0410"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_SUPT_0393",
+            "taxonomy_type": "CS20230722_SUPT_0393"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_SUPT_0343",
+            "taxonomy_type": "CS20230722_SUPT_0343"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_SUPT_0379",
+            "taxonomy_type": "CS20230722_SUPT_0379"
+          },
+          {
+            "edge_id": "edge_bnst_crf_neuron_to_CS20230722_SUPT_0383",
+            "taxonomy_type": "CS20230722_SUPT_0383"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/research/sexually_dimorphic/refresh_20260608_mpoa_esr1_neuron/discovery_candidates_rank0.json
+++ b/research/sexually_dimorphic/refresh_20260608_mpoa_esr1_neuron/discovery_candidates_rank0.json
@@ -1,0 +1,1748 @@
+{
+  "classical_node_id": "mpoa_esr1_neuron",
+  "classical_node_name": "MPOA estrogen receptor 1 (Esr1) neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 0,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_CLUS_1466",
+      "label": "1466 MPO-ADP Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0404",
+      "male_female_ratio": 0.82,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.301,
+        "region_fraction_100um": 0.529,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1536",
+      "label": "1536 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0419",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.468,
+        "region_fraction_100um": 0.694,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1885",
+      "label": "1885 PVpo-VMPO-MPN Hmx2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0482",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.5,
+        "region_fraction_100um": 0.75,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1887",
+      "label": "1887 PVpo-VMPO-MPN Hmx2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0482",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.315,
+        "region_fraction_100um": 0.612,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2118",
+      "label": "2118 ADP-MPO Trp73 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0527",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.582,
+        "region_fraction_100um": 0.818,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_0926",
+      "label": "0926 PAL-STR Gaba-Chol_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Chol",
+      "parent_id": "CS20230722_SUPT_0259",
+      "male_female_ratio": 0.75,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Ar",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.062,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1303",
+      "label": "1303 MEA-BST Lhx6 Nfib Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0360",
+      "male_female_ratio": 9.0,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.091,
+        "region_fraction_100um": 0.545,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1307",
+      "label": "1307 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0361",
+      "male_female_ratio": 0.54,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.029,
+        "region_fraction_100um": 0.171,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1309",
+      "label": "1309 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0361",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.096,
+        "region_fraction_100um": 0.25,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1432",
+      "label": "1432 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0397",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.284,
+        "region_fraction_100um": 0.629,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1433",
+      "label": "1433 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0397",
+      "male_female_ratio": 0.89,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.362,
+        "region_fraction_100um": 0.725,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1437",
+      "label": "1437 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0397",
+      "male_female_ratio": 1.38,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.2,
+        "region_fraction_100um": 0.457,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1440",
+      "label": "1440 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.342,
+        "region_fraction_100um": 0.556,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1441",
+      "label": "1441 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 0.89,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.293,
+        "region_fraction_100um": 0.535,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1442",
+      "label": "1442 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 1.5,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.375,
+        "region_fraction_100um": 0.647,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1443",
+      "label": "1443 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 1.63,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.34,
+        "region_fraction_100um": 0.64,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1444",
+      "label": "1444 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 1.63,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.481,
+        "region_fraction_100um": 0.778,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1445",
+      "label": "1445 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.192,
+        "region_fraction_100um": 0.568,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1448",
+      "label": "1448 SI-MPO-LPO Lhx8 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0399",
+      "male_female_ratio": 1.04,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.31,
+        "region_fraction_100um": 0.513,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1449",
+      "label": "1449 SI-MPO-LPO Lhx8 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0399",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.224,
+        "region_fraction_100um": 0.507,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1452",
+      "label": "1452 SI-MPO-LPO Lhx8 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut-GABA",
+      "parent_id": "CS20230722_SUPT_0400",
+      "male_female_ratio": 0.85,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.406,
+        "region_fraction_100um": 0.781,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1453",
+      "label": "1453 SI-MPO-LPO Lhx8 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0400",
+      "male_female_ratio": 2.57,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.288,
+        "region_fraction_100um": 0.561,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1454",
+      "label": "1454 SI-MPO-LPO Lhx8 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0400",
+      "male_female_ratio": 1.38,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.412,
+        "region_fraction_100um": 0.706,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1456",
+      "label": "1456 SI-MPO-LPO Lhx8 Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0401",
+      "male_female_ratio": 2.7,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.312,
+        "region_fraction_100um": 0.812,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1459",
+      "label": "1459 MPO-ADP Lhx8 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0402",
+      "male_female_ratio": 1.38,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.415,
+        "region_fraction_100um": 0.604,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1460",
+      "label": "1460 MPO-ADP Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0403",
+      "male_female_ratio": 1.86,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.51,
+        "region_fraction_100um": 0.76,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1464",
+      "label": "1464 MPO-ADP Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0403",
+      "male_female_ratio": 1.17,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.321,
+        "region_fraction_100um": 0.65,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1465",
+      "label": "1465 MPO-ADP Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0403",
+      "male_female_ratio": 1.38,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.816,
+        "region_fraction_100um": 0.98,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1470",
+      "label": "1470 MPO-ADP Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0404",
+      "male_female_ratio": 2.03,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.37,
+        "region_fraction_100um": 0.659,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1472",
+      "label": "1472 MPO-ADP Lhx8 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0405",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.3,
+        "region_fraction_100um": 0.5,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1474",
+      "label": "1474 MPO-ADP Lhx8 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0405",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.289,
+        "region_fraction_100um": 0.684,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1475",
+      "label": "1475 MPO-ADP Lhx8 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0405",
+      "male_female_ratio": 0.61,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.036,
+        "region_fraction_100um": 0.245,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1476",
+      "label": "1476 MPO-ADP Lhx8 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0405",
+      "male_female_ratio": 0.45,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.08,
+        "region_fraction_100um": 0.291,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1478",
+      "label": "1478 MPO-ADP Lhx8 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0405",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.257,
+        "region_fraction_100um": 0.705,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1487",
+      "label": "1487 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0407",
+      "male_female_ratio": 1.7,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.265,
+        "region_fraction_100um": 0.595,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1480",
+      "label": "1480 MPO-ADP Lhx8 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0406",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.407,
+        "region_fraction_100um": 0.519,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1497",
+      "label": "1497 BST Tac2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0409",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.133,
+        "region_fraction_100um": 0.257,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1498",
+      "label": "1498 BST Tac2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0409",
+      "male_female_ratio": 1.08,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.216,
+        "region_fraction_100um": 0.369,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1500",
+      "label": "1500 BST Tac2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0410",
+      "male_female_ratio": 0.82,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.081,
+        "region_fraction_100um": 0.187,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1515",
+      "label": "1515 PVR Six3 Sox3 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0414",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.253,
+        "region_fraction_100um": 0.582,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1517",
+      "label": "1517 PVR Six3 Sox3 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0414",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.248,
+        "region_fraction_100um": 0.53,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1531",
+      "label": "1531 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0419",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.062,
+        "region_fraction_100um": 0.212,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1532",
+      "label": "1532 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0419",
+      "male_female_ratio": 1.08,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.25,
+        "region_fraction_100um": 0.7,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1533",
+      "label": "1533 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0419",
+      "male_female_ratio": 1.63,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.167,
+        "region_fraction_100um": 0.604,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1535",
+      "label": "1535 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0419",
+      "male_female_ratio": 0.92,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.556,
+        "region_fraction_100um": 0.778,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1561",
+      "label": "1561 BST-MPN Six3 Nrgn Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0425",
+      "male_female_ratio": 2.23,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.056,
+        "region_fraction_100um": 0.135,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1562",
+      "label": "1562 BST-MPN Six3 Nrgn Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0425",
+      "male_female_ratio": 32.33,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.058,
+        "region_fraction_100um": 0.243,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1563",
+      "label": "1563 BST-MPN Six3 Nrgn Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0425",
+      "male_female_ratio": 0.23,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.037,
+        "region_fraction_100um": 0.222,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1870",
+      "label": "1870 PVpo-VMPO-MPN Hmx2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0482",
+      "male_female_ratio": 1.38,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.22,
+        "region_fraction_100um": 0.505,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1871",
+      "label": "1871 PVpo-VMPO-MPN Hmx2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0482",
+      "male_female_ratio": 1.04,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.368,
+        "region_fraction_100um": 0.551,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_mpoa_esr1_neuron/discovery_candidates_rank1.json
+++ b/research/sexually_dimorphic/refresh_20260608_mpoa_esr1_neuron/discovery_candidates_rank1.json
@@ -1,0 +1,1519 @@
+{
+  "classical_node_id": "mpoa_esr1_neuron",
+  "classical_node_name": "MPOA estrogen receptor 1 (Esr1) neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 1,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_SUPT_0419",
+      "label": "0419 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.271,
+        "region_fraction_100um": 0.56,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0403",
+      "label": "0403 MPO-ADP Lhx8 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.421,
+        "region_fraction_100um": 0.641,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0401",
+      "label": "0401 SI-MPO-LPO Lhx8 Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.312,
+        "region_fraction_100um": 0.812,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0348",
+      "label": "0348 MEA-BST Lhx6 Sp9 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_074",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.107,
+        "region_fraction_100um": 0.203,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0398",
+      "label": "0398 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.293,
+        "region_fraction_100um": 0.568,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0248",
+      "label": "0248 NDB-SI-MA-STRv Lhx8 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.084,
+        "region_fraction_100um": 0.226,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0246",
+      "label": "0246 NDB-SI-MA-STRv Lhx8 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.046,
+        "region_fraction_100um": 0.227,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0251",
+      "label": "0251 NDB-SI-MA-STRv Lhx8 Gaba_8",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.05,
+        "region_fraction_100um": 0.161,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0250",
+      "label": "0250 NDB-SI-MA-STRv Lhx8 Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.037,
+        "region_fraction_100um": 0.137,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0244",
+      "label": "0244 NDB-SI-MA-STRv Lhx8 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_057",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.036,
+        "region_fraction_100um": 0.117,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0417",
+      "label": "0417 PVR Six3 Sox3 Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.129,
+        "region_fraction_100um": 0.281,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0416",
+      "label": "0416 PVR Six3 Sox3 Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.136,
+        "region_fraction_100um": 0.299,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0415",
+      "label": "0415 PVR Six3 Sox3 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.172,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0414",
+      "label": "0414 PVR Six3 Sox3 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.151,
+        "region_fraction_100um": 0.322,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0411",
+      "label": "0411 PVR Six3 Sox3 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.086,
+        "region_fraction_100um": 0.284,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0420",
+      "label": "0420 BST-MPN Six3 Nrgn Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.053,
+        "region_fraction_100um": 0.244,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0409",
+      "label": "0409 BST Tac2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_088",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.084,
+        "region_fraction_100um": 0.181,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0408",
+      "label": "0408 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_087",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.08,
+        "region_fraction_100um": 0.217,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0407",
+      "label": "0407 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_087",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.11,
+        "region_fraction_100um": 0.246,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0406",
+      "label": "0406 MPO-ADP Lhx8 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.112,
+        "region_fraction_100um": 0.242,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0405",
+      "label": "0405 MPO-ADP Lhx8 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.153,
+        "region_fraction_100um": 0.419,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0404",
+      "label": "0404 MPO-ADP Lhx8 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.247,
+        "region_fraction_100um": 0.437,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0402",
+      "label": "0402 MPO-ADP Lhx8 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.141,
+        "region_fraction_100um": 0.244,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0400",
+      "label": "0400 SI-MPO-LPO Lhx8 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.169,
+        "region_fraction_100um": 0.291,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0458",
+      "label": "0458 AHN Onecut3 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_100",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.066,
+        "region_fraction_100um": 0.215,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0426",
+      "label": "0426 BST-MPN Six3 Nrgn Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.033,
+        "region_fraction_100um": 0.192,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0425",
+      "label": "0425 BST-MPN Six3 Nrgn Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.047,
+        "region_fraction_100um": 0.165,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0422",
+      "label": "0422 BST-MPN Six3 Nrgn Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.035,
+        "region_fraction_100um": 0.136,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0421",
+      "label": "0421 BST-MPN Six3 Nrgn Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.173,
+        "region_fraction_100um": 0.379,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0483",
+      "label": "0483 PVpo-VMPO-MPN Hmx2 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.15,
+        "region_fraction_100um": 0.375,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0482",
+      "label": "0482 PVpo-VMPO-MPN Hmx2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.194,
+        "region_fraction_100um": 0.406,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0343",
+      "label": "0343 MEA-BST Sox6 Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_073",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.031,
+        "region_fraction_100um": 0.174,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0361",
+      "label": "0361 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.081,
+        "region_fraction_100um": 0.221,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0346",
+      "label": "0346 MEA-BST Sox6 Gaba_10",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_073",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.013,
+        "region_fraction_100um": 0.101,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0353",
+      "label": "0353 MEA-BST Lhx6 Sp9 Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_074",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.077,
+        "region_fraction_100um": 0.187,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0399",
+      "label": "0399 SI-MPO-LPO Lhx8 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.22,
+        "region_fraction_100um": 0.454,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0397",
+      "label": "0397 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.177,
+        "region_fraction_100um": 0.37,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0628",
+      "label": "0628 HY Gnrh1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_142",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.023,
+        "region_fraction_100um": 0.11,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0529",
+      "label": "0529 ADP-MPO Trp73 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_118",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.024,
+        "region_fraction_100um": 0.104,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0528",
+      "label": "0528 ADP-MPO Trp73 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_118",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.126,
+        "region_fraction_100um": 0.296,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0527",
+      "label": "0527 ADP-MPO Trp73 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_118",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.229,
+        "region_fraction_100um": 0.432,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0524",
+      "label": "0524 LHA Barhl2 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_117",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.034,
+        "region_fraction_100um": 0.124,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0523",
+      "label": "0523 AVPV-MEPO-SFO Tbr1 Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_116",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.051,
+        "region_fraction_100um": 0.192,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0522",
+      "label": "0522 AVPV-MEPO-SFO Tbr1 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_116",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.121,
+        "region_fraction_100um": 0.422,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0521",
+      "label": "0521 AVPV-MEPO-SFO Tbr1 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_116",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.032,
+        "region_fraction_100um": 0.138,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0520",
+      "label": "0520 AVPV-MEPO-SFO Tbr1 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_116",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.079,
+        "region_fraction_100um": 0.278,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0519",
+      "label": "0519 AVPV-MEPO-SFO Tbr1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_116",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.175,
+        "region_fraction_100um": 0.362,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0576",
+      "label": "0576 LHA-AHN-PVH Otp Trh Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_131",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.067,
+        "region_fraction_100um": 0.225,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0582",
+      "label": "0582 AHN-RCH-LHA Otp Fezf1 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_132",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.019,
+        "region_fraction_100um": 0.174,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0574",
+      "label": "0574 LHA-AHN-PVH Otp Trh Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_131",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:523"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.106,
+        "region_fraction_100um": 0.258,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_mpoa_esr1_neuron/prior_summary_preserved.md
+++ b/research/sexually_dimorphic/refresh_20260608_mpoa_esr1_neuron/prior_summary_preserved.md
@@ -1,0 +1,252 @@
+# MPOA estrogen receptor 1 (Esr1) neuron — WMBv1 Mapping Report
+*draft · 2026-04-25 · Source: `/Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
+
+**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+
+---
+
+## Introduction
+
+### Classical type
+
+**MPOA estrogen receptor 1 (Esr1) neuron** is defined by neurochemical criteria —
+Esr1, Ar, and Pgr expression — in the medial preoptic area (MPOA). The
+population is functionally heterogeneous: MPOA Esr1 neurons (alongside galanin
+neurons) are required for pup-directed/parental behavior, Esr1 governs male-type
+mating behavior, and an overlapping Nts (neurotensin)+ subtype governs female
+socio-sexual behaviors. The MPOA contains both GABAergic and glutamatergic
+neurons, and the Esr1+ population spans both NT subtypes — the classical node
+may be better represented as multiple cell-type terms. No CL term has been
+assigned and one is a candidate for new term(s).
+
+| Property | Value | References |
+|---|---|---|
+| Soma location | Medial preoptic nucleus [MBA:464] | [1] |
+| Defining markers | Esr1 (transcript), Ar (transcript), Pgr (transcript) | [1], [2] |
+
+<details>
+<summary>Details — source evidence for classical type properties</summary>
+
+- **Soma location (MPOA):** review · mouse · [1]
+  > A large hypothalamic structure, the MPOA sends projections to multiple downstream brain regions and is both larger and contains more neurons in males than in females [35]. Notably, the MPOA is home to various heterogeneous, molecularly defined, neuronal clusters, including many sexually dimorphic populations, such as androgen receptor (AR)-expressing population and estrogen receptor alpha (ESR1)expressing population [80]
+  > — Zilkha et al. 2021, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 233446934_5d0fb07e -->
+
+- **Esr1 / parental behavior context:** review · mouse · [1]
+  > At least two different subpopulations within the MPOA were shown to be required for the regulation of pupdirected behavior. The first is the ESR1 þ population, which is highly sexually dimorphic in its distribution and projection patterns [85]
+  > — Zilkha et al. 2021, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 233446934_9f0f55ea -->
+
+</details>
+
+---
+
+## Results
+
+### Mapping candidates
+
+Two co-primary mapping edges are recorded for mpoa_esr1_neuron, reflecting that
+the classical population is heterogeneous in NT type. SUPT_0486 (GABAergic,
+PVpo-VMPO-MPN) captures the GABAergic Esr1+ fraction with direct atlas-marker
+support; SUPT_0521 (glutamatergic, AVPV-MEPO-SFO Tbr1 Glut_3) is independently
+identified as the dominant POA-Esr1+ supertype by Knoedler 2022 bulk
+correlation [3]. Both are CROSS_CUTTING relationships and the classical node
+likely requires a glut/GABA split.
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
+|---|---|---|---|---|---|---|
+| 1 | 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] | (self) | 178 | 🟡 MODERATE | Esr1/Ar/Pgr CONSISTENT; NT APPROXIMATE (GABA only) | Best candidate (GABAergic fraction) |
+| 2 | 0521 AVPV-MEPO-SFO Tbr1 Glut_3 [CS20230722_SUPT_0521] | (self) | 391 | 🟡 MODERATE | Esr1 CONSISTENT; NT APPROXIMATE (Glut only); location APPROXIMATE | Best candidate (glutamatergic fraction) |
+2 edges total. Relationship type: CROSS_CUTTING (both edges).
+
+### Property alignment — primary candidate (SUPT_0486)
+
+**Table 1 — Property comparison.**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Medial preoptic nucleus [MBA:464] | MBA:515 (MPN) n=37; MBA:133 (PVpo) n=64; MBA:272 (AVPV) n=16 | not assessed | CONSISTENT |
+| NT type | mixed (GABAergic and glutamatergic, both documented in MPOA) | GABAergic (PVpo-VMPO-MPN Hmx2 Gaba subclass) | not assessed | APPROXIMATE |
+| Esr1 expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=7.72 (DEFINING atlas marker) | not assessed | CONSISTENT |
+| Ar expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=8.15 | not assessed | CONSISTENT |
+| Pgr expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=6.80 | not assessed | CONSISTENT |
+| Sex ratio | not documented on classical node | not available | not assessed | NOT_ASSESSED |
+
+**Table 2 — Evidence support.**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| SUPT_0486 atlas metadata (Esr1/Ar/Pgr, MPN n=37) | Atlas metadata | SUPPORT | Esr1=7.72 (DEFINING), Ar=8.15, Pgr=6.80; MBA:515 MPN n=37 | atlas-internal |
+
+*(Child-cluster breakdown not assessed — see proposed experiments.)*
+
+### Property alignment — co-primary candidate (SUPT_0521)
+
+**Table 1 — Property comparison.**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Medial preoptic nucleus [MBA:464] | Anteroventral periventricular nucleus, Median preoptic nucleus | CLUS_2085 primary soma in Anteroventral periventricular nucleus | APPROXIMATE |
+| NT type | mixed (GABAergic and glutamatergic, both documented in MPOA) | Glutamatergic (Tbr1 Glut_3 label) | not assessed | APPROXIMATE |
+| Esr1 expression | POSITIVE (transcript, primary defining marker) | Esr1+ by experimental design (TRAP-Cre line) | not assessed | CONSISTENT |
+| Sex ratio | not documented on classical node | not available | not assessed | NOT_ASSESSED |
+
+**Table 2 — Evidence support.**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Knoedler 2022 TRAP-seq POA_FR vs VMH_FR | Bulk transcriptomic correlation | SUPPORT | best child CLUS_2085 (rank 1 of 5322, δ=0.0151); 4 SUPT_0521 children in top 10 | [3] |
+
+*(4 of SUPT_0521's child clusters — CLUS_2085, CLUS_2087, CLUS_2082, CLUS_2079 — appear in the top 10 atlas clusters by POA_FR vs VMH_FR Esr1+ TRAP differential; CLUS_2085 ranks first overall. Best match: CLUS_2085.)*
+
+---
+
+
+
+### 0486 PVpo-VMPO-MPN Hmx2 Gaba_5 [CS20230722_SUPT_0486] · 🟡 MODERATE
+
+### Supporting evidence
+
+- **All three classical defining markers reach CONSISTENT alignment at supertype level.** Precomputed mean expression Esr1 = 7.72 (DEFINING atlas marker), Ar = 8.15, and Pgr = 6.80 — directly matching the steroid hormone receptor profile that defines mpoa_esr1_neuron [1], [2].
+- **Direct anatomical anchor in MPN.** SUPT_0486 carries n = 37 cells in Medial preoptic nucleus [MBA:515], which is the same structure as the classical node's soma assignment Medial preoptic nucleus [MBA:464] *(note: MBA:515 and MBA:464 both label MPN — the location is concordant)*.
+- **GABAergic component matches.** The supertype label PVpo-VMPO-MPN Hmx2 Gaba_5 is concordant with the GABAergic fraction of the mixed-NT classical population.
+- **Adjacent preoptic territory captured.** Additional cells in Periventricular preoptic nucleus [MBA:133] (n=64) and Anteroventral periventricular nucleus [MBA:272] (n=16) are within the broader medial preoptic zone.
+
+### Marker evidence provenance
+
+- **Esr1** — classical evidence is transcript-based (review citations) [1], [2]. Atlas precomputed Esr1 = 7.72 is transcript-based (10x Chromium) and Esr1 is a DEFINING atlas marker for SUPT_0486. Strong cross-platform agreement.
+- **Ar** — classical evidence is transcript-based [1], [2]. Atlas precomputed Ar = 8.15 (transcript). Highest of the three steroid receptors at supertype level. Consistent.
+- **Pgr** — classical evidence is from a single preprint citation [2]. Atlas precomputed Pgr = 6.80 (transcript). Supports the classical assertion; *(note: a single primary citation underlies the classical Pgr claim and a targeted cite-traverse for "MPOA progesterone receptor Esr1 co-expression" could strengthen this provenance)*.
+
+### Concerns
+
+- **NT-type alignment is APPROXIMATE — supertype captures only the GABAergic fraction.** SUPT_0486 is GABAergic; the classical mpoa_esr1_neuron population includes glutamatergic Esr1+ neurons that map elsewhere (specifically to SUPT_0521 — see co-primary candidate below). The supertype assignment alone does not represent the full classical population.
+- **Functional heterogeneity is unresolved.** The classical node spans multiple functional subtypes — parental (alongside galanin), male-type mating, and Nts+ female socio-sexual — that likely distribute across multiple clusters within SUPT_0486 *(distributed across clusters caveat from edge YAML)*.
+- **Child-cluster breakdown not assessed.** No specific child cluster of SUPT_0486 has been identified as carrying peak Esr1/Ar/Pgr or strongest MPN anatomical signal.
+- **Sex ratio not assessed.** Sex dimorphism is documented for MPOA generally [1] but is not in the classical node's properties or the supertype atlas metadata; child-cluster MFR data have not been collected for this edge.
+
+### What would upgrade confidence
+
+- **Child-cluster expression analysis** within SUPT_0486 to identify the cluster(s) with peak Esr1/Ar/Pgr and strongest MPN signal (resolves open question 1). Expected output: cluster-level edge with `ATLAS_METADATA` evidence and potential CONSISTENT location alignment at MPN.
+- **MapMyCells annotation transfer** of a published MPOA Esr1+ scRNA-seq dataset (e.g. Moffitt 2018) against WMBv1 at cluster resolution; F1 ≥ 0.50 at SUPT_0486 would support the supertype assignment, with the F1 split between SUPT_0486 and SUPT_0521 directly testing the NT heterogeneity. Expected output: `AnnotationTransferEvidence`.
+- **Targeted literature search** for the Nts+ MPOA Esr1+ subpopulation to determine whether it co-maps to SUPT_0486 (resolves open question 2).
+
+---
+
+### 0521 AVPV-MEPO-SFO Tbr1 Glut_3 [CS20230722_SUPT_0521] · 🟡 MODERATE
+
+### Supporting evidence
+
+- **Independent quantitative bulk-correlation evidence ranks SUPT_0521 first across the atlas [3].**
+  > Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq pooled POA female-receptive vs VMH female-receptive. SUPT_0521 (AVPV-MEPO-SFO Tbr1 Glut_3, glutamatergic) child cluster CLUS_2085 ranks #1 of 5,322 atlas clusters by δ = ρ(POA_FR) − ρ(VMH_FR), with δ=0.0151 and primary soma in the Anteroventral periventricular nucleus. Three additional SUPT_0521 child clusters (2087, 2082, 2079) appear in the top 10. This is the dominant POA-Esr1+ supertype by bulk correlation — but is glutamatergic, not GABAergic like the existing SUPT_0486 mapping. Suggests the classical mpoa_esr1_neuron node may be heterogeneous and need a glut/GABA split, or that SUPT_0486 captures only a subset of the classical population.
+  > — Knoedler et al. 2022 · [3]
+- **Esr1 identity is CONSISTENT by experimental design.** SUPT_0521 cells were captured in a Esr1+ TRAP-Cre line — Esr1 expression is established by the input contrast itself, independent of atlas precomputed values [3].
+- **Glutamatergic NT identity is captured.** The Tbr1 Glut_3 label resolves the glutamatergic fraction of the classical mixed-NT MPOA Esr1+ population that SUPT_0486 (GABAergic) does not represent.
+- **Multiple SUPT_0521 child clusters cluster together at the top of the differential.** Four child clusters in the top 10 of 5,322 indicates the differential signal is supertype-coherent rather than driven by a single cluster.
+
+### Marker evidence provenance
+
+- **Esr1** — classical evidence is transcript-based (ISH and review citations) [1], [2]. SUPT_0521 Esr1 status is inferred from TRAP-Cre transgenic capture rather than from atlas precomputed expression alone — this is a stronger experimental confirmation of Esr1 expression than precomputed mean values *(note: precomputed Esr1 expression for SUPT_0521 is not surfaced in this facts file and would strengthen the cross-platform comparison)*.
+- **Ar / Pgr** — not assessed for SUPT_0521 in this edge. The classical node's defining marker set (Esr1, Ar, Pgr) is only partially evaluated against SUPT_0521; Ar and Pgr expression at this supertype/its child clusters has not yet been compared.
+
+### Concerns
+
+- **Location is APPROXIMATE — SUPT_0521 spans AVPV/MePO, not MPN proper.** The classical mpoa_esr1_neuron is anchored at Medial preoptic nucleus [MBA:464]; SUPT_0521's primary somas are in Anteroventral periventricular nucleus and Median preoptic nucleus. AVPV/MePO is part of the broader medial preoptic area but is anatomically distinct from MPN proper *(adjacent region — could reflect the classical node's "MPOA" being broader than MPN, or could indicate the classical node should be narrowed to MPN-specific Esr1+ neurons; weak counter-evidence)*.
+- **Atlas dissection overlap caveat.** Knoedler's "POA" dissection captures a broader preoptic zone than MPN proper; AVPV and MePO Esr1+ neurons (anatomically anterior to MPN) are likely included in the bulk pool and contribute to the SUPT_0521 signal. The bulk-correlation evidence cannot distinguish MPN-Esr1+ from AVPV/MePO-Esr1+ contributions [3].
+- **NT-type alignment is APPROXIMATE — supertype captures only the glutamatergic fraction.** Mirror-image of the SUPT_0486 concern: SUPT_0521 represents the glutamatergic Esr1+ POA cells while SUPT_0486 represents the GABAergic fraction. Neither alone covers the full classical population.
+- **Co-primary mapping ambiguity.** This edge is co-primary alongside SUPT_0486; the two supertypes capture different NT-typed Esr1+ preoptic populations. The classical node likely needs to be split (mpoa_esr1_neuron_GABAergic vs mpoa_esr1_neuron_glutamatergic) or narrowed to MPN proper.
+- **Ar / Pgr not assessed at this supertype.** Two of the three classical defining markers have not been quantified for SUPT_0521.
+
+### What would upgrade confidence
+
+- **ISH or MERFISH co-staining for Esr1, Slc17a6 (vGlut2), Slc32a1 (vGAT) in MPOA** to quantify the GABAergic vs glutamatergic fractions of Esr1+ cells (proposed experiment 1). Expected output: `MarkerAnalysisEvidence` documenting the empirical NT split.
+- **MapMyCells annotation transfer of published MPOA Esr1+ scRNA-seq data (e.g. Moffitt 2018) to SUPT_0521 vs SUPT_0486** (proposed experiment 2); expect F1 to split between the two supertypes, directly testing the glut/GABA hypothesis. Expected output: `AnnotationTransferEvidence` on both edges. Target: F1 ≥ 0.50 at supertype level for the matched NT fraction in each case.
+- **Quantification of Ar and Pgr precomputed expression for SUPT_0521 and its top-ranked child clusters** to complete the defining-marker comparison.
+- **Anatomical / functional literature search** to determine whether the AVPV/MePO Esr1+ population (SUPT_0521) is functionally distinct from MPN Esr1+ (SUPT_0486) in the parental/mating circuit literature (resolves open question 4).
+
+---
+
+### Methods
+
+<details>
+<summary>Data sources, analyses, and reproducibility receipts</summary>
+
+**Classical type definition.** See classical type table in Introduction; defining_basis on the classical node and per-property literature support are listed there. The KB-side definition lives at the source graph file linked in the reproducibility footer.
+
+**Atlas mapping query.** Candidate atlas clusters were retrieved from CCN20230722 at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias). Full scoring rules: `workflows/map-cell-type.md`.
+
+**Property alignment.** Each defining property was compared to the corresponding atlas-side value via the `property_comparisons` schema; alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
+
+**Bulk transcriptomic correlation.** Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq pooled POA female-receptive vs VMH female-receptive. SUPT_0521 child cluster CLUS_2085 ranks #1 of 5,322 atlas clusters by δ. Run record: [`kb/correlation_runs/20260428_knoedler_esr1_wmbv1/manifest.yaml`](../../kb/correlation_runs/20260428_knoedler_esr1_wmbv1/manifest.yaml). Script: [`correlate.py`](https://github.com/Cellular-Semantics/evidencell/blob/4e67d6b/kb/correlation_runs/20260428_knoedler_esr1_wmbv1/correlate.py)
+
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote.
+
+*Generated by evidencell `0c97cfa` from [`kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`](../../kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+
+</details>
+
+---
+
+## Discussion
+
+**Primary mapping:** → SUPT_0486 (GABAergic) and SUPT_0521 (glutamatergic) at MODERATE (co-primary) confidence. Key support: ATLAS_METADATA (Esr1=7.72 DEFINING at SUPT_0486) and BULK_CORRELATION (Knoedler 2022 [3]) for SUPT_0521. Key caveats: `AMBIGUOUS_MAPPING` (glut/GABA split — classical node may need to be split into GABAergic/glutamatergic subnodes).
+
+No Cell Ontology term currently assigned for this classical type.
+
+### Proposed experiments and follow-ups
+
+### 1. ISH / MERFISH co-staining for Esr1 with Slc17a6 (vGlut2) and Slc32a1 (vGAT) in MPOA
+
+**What:** Multiplexed in situ co-staining of Esr1 with Slc17a6 and Slc32a1 across MPOA subregions (MPN, PVpo, AVPV, MePO).
+
+**Target:** Quantitative GABAergic vs glutamatergic fractions of Esr1+ cells per subregion.
+
+**Expected output:** `MarkerAnalysisEvidence` documenting the empirical NT split, supporting the proposed glut/GABA decomposition of mpoa_esr1_neuron.
+
+**Resolves:** Open questions 3 and 4. Directly tests whether mpoa_esr1_neuron should be split into GABAergic and glutamatergic subnodes.
+
+### 2. MapMyCells annotation transfer of an MPOA Esr1+ scRNA-seq dataset against WMBv1
+
+**What:** Retrieve a published MPOA Esr1+ scRNA-seq dataset (e.g. Moffitt 2018) and run MapMyCells against WMBv1 at cluster resolution.
+
+**Target:** F1 ≥ 0.50 at supertype level on whichever NT fraction is matched (GABAergic cells → SUPT_0486; glutamatergic cells → SUPT_0521); F1 split between SUPT_0486 and SUPT_0521 expected.
+
+**Expected output:** `AnnotationTransferEvidence` entries on both edges (edge_mpoa_esr1_neuron_to_cs20230722_supt_0486 and edge_mpoa_esr1_neuron_to_cs20230722_supt_0521). Atlas: WMBv1. Tool: MapMyCells. Output: F1 matrix per cluster.
+
+**Resolves:** Open questions 1, 3, and 4. Confirms or refutes the co-primary glut/GABA mapping; identifies best child clusters within each supertype.
+
+### 3. Targeted child-cluster expression analysis within SUPT_0486 and SUPT_0521
+
+**What:** Inspect precomputed expression for Esr1, Ar, Pgr, Nts, and Gal across all child clusters of SUPT_0486 and SUPT_0521; identify clusters with peak co-expression and strongest MPN/AVPV anatomical signal.
+
+**Target:** Identification of best child cluster(s) for each supertype edge with quantitative thresholds (e.g. Esr1 mean ≥ 5.0 and MPN cell count ≥ 10).
+
+**Expected output:** Cluster-level mapping edges with `ATLAS_METADATA` evidence; potential resolution of the Nts+ female socio-sexual subpopulation.
+
+**Resolves:** Open questions 1 and 2.
+
+---
+
+### Open questions
+
+1. Which clusters within SUPT_0486 [CS20230722_SUPT_0486] have highest Esr1/Ar/Pgr and strongest MPN anatomical signal? *(SUPT_0486 edge.)*
+2. Does the Nts+ female socio-sexual subpopulation map to SUPT_0486 or to a separate preoptic supertype? *(SUPT_0486 edge.)*
+3. Should mpoa_esr1_neuron be split into GABAergic (SUPT_0486) and glutamatergic (SUPT_0521) subnodes, or narrowed to MPN-proper Esr1+ neurons? *(SUPT_0521 edge; central organising question across both edges.)*
+4. Is the AVPV/MePO Esr1+ population (SUPT_0521) functionally distinct from MPN Esr1+ (SUPT_0486) in the parental/mating circuit literature? *(SUPT_0521 edge.)*
+
+---
+
+### Evidence base
+
+| Edge ID | Evidence type | Supports |
+|---|---|---|
+| edge_mpoa_esr1_neuron_to_cs20230722_supt_0486 | ATLAS_METADATA | SUPPORT — Esr1=7.72 (DEFINING), Ar=8.15, Pgr=6.80; MBA:515 MPN n=37; GABAergic fraction |
+| edge_mpoa_esr1_neuron_to_cs20230722_supt_0521 | BULK_CORRELATION ([3] Knoedler 2022) | SUPPORT — POA_FR vs VMH_FR; CLUS_2085 rank 1/5322 (δ=0.0151); 4 child clusters in top 10; glutamatergic fraction |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | Zilkha et al. 2021 | [PMID:33910083](https://pubmed.ncbi.nlm.nih.gov/33910083/) | Soma location (MPOA); Esr1 / Ar marker context; sexually dimorphic MPOA |
+| [2] | bioRxiv 2021.09.02.458782 | — | Esr1, Ar, Pgr marker evidence (steroid hormone receptors in MPOA) |
+| [3] | Knoedler et al. 2022 | [PMID:35143761](https://pubmed.ncbi.nlm.nih.gov/35143761/) | Esr1+ TRAP-seq POA female-receptive vs VMH female-receptive bulk correlation against WMBv1 |

--- a/research/sexually_dimorphic/refresh_20260608_mpoa_esr1_neuron/refresh_summary.json
+++ b/research/sexually_dimorphic/refresh_20260608_mpoa_esr1_neuron/refresh_summary.json
@@ -1,0 +1,135 @@
+{
+  "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+  "node_id": "mpoa_esr1_neuron",
+  "taxonomy_id": "CCN20230722",
+  "ranks": {
+    "rank0": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_CLUS_1466",
+          "CS20230722_CLUS_1536",
+          "CS20230722_CLUS_1885",
+          "CS20230722_CLUS_1887",
+          "CS20230722_CLUS_2118"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml mpoa_esr1_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_mpoa_esr1_neuron/discovery_candidates_rank0.json",
+          "  emit-stage-b: wrote 5 edge(s) + 5 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 5,
+        "edges_skipped_taxtype_not_in_topk": 2,
+        "skipped_details": [
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_cs20230722_supt_0486",
+            "taxonomy_type": "CS20230722_SUPT_0486"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_cs20230722_supt_0521",
+            "taxonomy_type": "CS20230722_SUPT_0521"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1466",
+            "taxonomy_type": "CS20230722_CLUS_1466"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1536",
+            "taxonomy_type": "CS20230722_CLUS_1536"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1885",
+            "taxonomy_type": "CS20230722_CLUS_1885"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1887",
+            "taxonomy_type": "CS20230722_CLUS_1887"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_2118",
+            "taxonomy_type": "CS20230722_CLUS_2118"
+          }
+        ]
+      }
+    },
+    "rank1": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_SUPT_0419",
+          "CS20230722_SUPT_0403",
+          "CS20230722_SUPT_0401",
+          "CS20230722_SUPT_0348",
+          "CS20230722_SUPT_0398"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml mpoa_esr1_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_mpoa_esr1_neuron/discovery_candidates_rank1.json",
+          "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 6,
+        "edges_skipped_taxtype_not_in_topk": 6,
+        "skipped_details": [
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_cs20230722_supt_0486",
+            "taxonomy_type": "CS20230722_SUPT_0486"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1466",
+            "taxonomy_type": "CS20230722_CLUS_1466"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1536",
+            "taxonomy_type": "CS20230722_CLUS_1536"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1885",
+            "taxonomy_type": "CS20230722_CLUS_1885"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1887",
+            "taxonomy_type": "CS20230722_CLUS_1887"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_2118",
+            "taxonomy_type": "CS20230722_CLUS_2118"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_cs20230722_supt_0521",
+            "taxonomy_type": "CS20230722_SUPT_0521"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0419",
+            "taxonomy_type": "CS20230722_SUPT_0419"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0403",
+            "taxonomy_type": "CS20230722_SUPT_0403"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0401",
+            "taxonomy_type": "CS20230722_SUPT_0401"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0348",
+            "taxonomy_type": "CS20230722_SUPT_0348"
+          },
+          {
+            "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0398",
+            "taxonomy_type": "CS20230722_SUPT_0398"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/research/sexually_dimorphic/refresh_20260608_pmv_otr_neuron/discovery_candidates_rank0.json
+++ b/research/sexually_dimorphic/refresh_20260608_pmv_otr_neuron/discovery_candidates_rank0.json
@@ -1,0 +1,2096 @@
+{
+  "classical_node_id": "pmv_otr_neuron",
+  "classical_node_name": "Ventral premammillary nucleus (PMv) oxytocin receptor neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 0,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_CLUS_2471",
+      "label": "2471 PMv-TMv Pitx2 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0607",
+      "male_female_ratio": 0.15,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Slc6a3",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.341,
+        "region_fraction_100um": 0.676,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2470",
+      "label": "2470 PMv-TMv Pitx2 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0607",
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Slc6a3",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.676,
+        "region_fraction_100um": 0.898,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2314",
+      "label": "2314 VMH Nr5a1 Glut_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0569",
+      "male_female_ratio": 3.17,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.018,
+        "region_fraction_100um": 0.018,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2575",
+      "label": "2575 MM Foxb1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0631",
+      "male_female_ratio": 4.0,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.029,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2395",
+      "label": "2395 PH-ant-LHA Otp Bsx Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0592",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.304,
+        "region_fraction_100um": 0.596,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2463",
+      "label": "2463 PMv-TMv Pitx2 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0605",
+      "male_female_ratio": 0.82,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.258,
+        "region_fraction_100um": 0.774,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2462",
+      "label": "2462 PMv-TMv Pitx2 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0605",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.37,
+        "region_fraction_100um": 0.613,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2464",
+      "label": "2464 PMv-TMv Pitx2 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0605",
+      "male_female_ratio": 1.78,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.263,
+        "region_fraction_100um": 0.711,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2469",
+      "label": "2469 PMv-TMv Pitx2 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0607",
+      "male_female_ratio": 1.04,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Slc6a3",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.108,
+        "region_fraction_100um": 0.297,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2527",
+      "label": "2527 PMd-LHA Foxb1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0620",
+      "male_female_ratio": 2.45,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.236,
+        "region_fraction_100um": 0.526,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2531",
+      "label": "2531 PMd-LHA Foxb1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0620",
+      "male_female_ratio": 0.79,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.576,
+        "region_fraction_100um": 0.939,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2530",
+      "label": "2530 PMd-LHA Foxb1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0620",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.489,
+        "region_fraction_100um": 0.714,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1571",
+      "label": "1571 ARH-PVi Six6 Dopa-Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0427",
+      "male_female_ratio": 5.25,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Slc6a3",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.028,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2281",
+      "label": "2281 ARH-PVp Tbx3 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0556",
+      "male_female_ratio": 32.33,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.004,
+        "region_fraction_100um": 0.007,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1573",
+      "label": "1573 TMv-PMv Tbx3 Hist-Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Hist",
+      "parent_id": "CS20230722_SUPT_0429",
+      "male_female_ratio": 0.85,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.143,
+        "region_fraction_100um": 0.5,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2265",
+      "label": "2265 DMH Hmx2 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0552",
+      "male_female_ratio": 1.5,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.125,
+        "region_fraction_100um": 0.188,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2407",
+      "label": "2407 PH-ant-LHA Otp Bsx Glut_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0594",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.05,
+        "region_fraction_100um": 0.175,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2457",
+      "label": "2457 STN-PSTN Pitx2 Glut_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0603",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.04,
+        "region_fraction_100um": 0.107,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2461",
+      "label": "2461 PMv-TMv Pitx2 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0605",
+      "male_female_ratio": 1.17,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.225,
+        "region_fraction_100um": 0.25,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2472",
+      "label": "2472 PMv-TMv Pitx2 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0607",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.793,
+        "region_fraction_100um": 0.988,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2473",
+      "label": "2473 PMv-TMv Pitx2 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0607",
+      "male_female_ratio": 2.23,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.573,
+        "region_fraction_100um": 0.829,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2484",
+      "label": "2484 PH Pitx2 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0610",
+      "male_female_ratio": 1.27,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.011,
+        "region_fraction_100um": 0.146,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2511",
+      "label": "2511 PH-LHA Foxb1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0614",
+      "male_female_ratio": 1.17,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.118,
+        "region_fraction_100um": 0.176,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2514",
+      "label": "2514 PH-LHA Foxb1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0614",
+      "male_female_ratio": 0.92,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.143,
+        "region_fraction_100um": 0.143,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2516",
+      "label": "2516 PH-LHA Foxb1 Glut_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0615",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.136,
+        "region_fraction_100um": 0.203,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2524",
+      "label": "2524 PMd-LHA Foxb1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0620",
+      "male_female_ratio": 1.78,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.181,
+        "region_fraction_100um": 0.34,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2523",
+      "label": "2523 PMd-LHA Foxb1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0619",
+      "male_female_ratio": 0.85,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.056,
+        "region_fraction_100um": 0.111,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2526",
+      "label": "2526 PMd-LHA Foxb1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0620",
+      "male_female_ratio": 0.67,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.5,
+        "region_fraction_100um": 0.625,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2528",
+      "label": "2528 PMd-LHA Foxb1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0620",
+      "male_female_ratio": 1.27,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.02,
+        "region_fraction_100um": 0.1,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2529",
+      "label": "2529 PMd-LHA Foxb1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0620",
+      "male_female_ratio": 1.86,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.129,
+        "region_fraction_100um": 0.475,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2532",
+      "label": "2532 PMd-LHA Foxb1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0620",
+      "male_female_ratio": 1.63,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.125,
+        "region_fraction_100um": 0.292,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2535",
+      "label": "2535 PMd-LHA Foxb1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0621",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.047,
+        "region_fraction_100um": 0.116,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2534",
+      "label": "2534 PMd-LHA Foxb1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0621",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.043,
+        "region_fraction_100um": 0.304,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2566",
+      "label": "2566 MM-ant Foxb1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0629",
+      "male_female_ratio": 0.96,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.015,
+        "region_fraction_100um": 0.142,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2568",
+      "label": "2568 MM-ant Foxb1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0629",
+      "male_female_ratio": 1.78,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.064,
+        "region_fraction_100um": 0.15,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2567",
+      "label": "2567 MM-ant Foxb1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0629",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.172,
+        "region_fraction_100um": 0.303,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2570",
+      "label": "2570 MM-ant Foxb1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0629",
+      "male_female_ratio": 1.38,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.217,
+        "region_fraction_100um": 0.381,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2573",
+      "label": "2573 MM Foxb1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0630",
+      "male_female_ratio": 0.85,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.008,
+        "region_fraction_100um": 0.128,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2577",
+      "label": "2577 MM Foxb1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0631",
+      "male_female_ratio": 1.5,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.228,
+        "region_fraction_100um": 0.306,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_4139",
+      "label": "4139 PRNc-PARN Tlx1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0935",
+      "male_female_ratio": 1.38,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.021,
+        "region_fraction_100um": 0.021,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2218",
+      "label": "2218 LHA-MEA Otp Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0542",
+      "male_female_ratio": 0.92,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.014,
+        "region_fraction_100um": 0.014,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2270",
+      "label": "2270 DMH Hmx2 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0552",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.023,
+        "region_fraction_100um": 0.062,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2283",
+      "label": "2283 ARH-PVp Tbx3 Glut_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0557",
+      "male_female_ratio": 1.27,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.033,
+        "region_fraction_100um": 0.067,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2316",
+      "label": "2316 VMH Nr5a1 Glut_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0569",
+      "male_female_ratio": 2.23,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.011,
+        "region_fraction_100um": 0.011,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2324",
+      "label": "2324 LHA Pmch Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0573",
+      "male_female_ratio": 0.75,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.045,
+        "region_fraction_100um": 0.075,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2402",
+      "label": "2402 PH-ant-LHA Otp Bsx Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0593",
+      "male_female_ratio": 0.89,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.037,
+        "region_fraction_100um": 0.093,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2499",
+      "label": "2499 PH-LHA Foxb1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0612",
+      "male_female_ratio": 0.69,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.041,
+        "region_fraction_100um": 0.041,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2491",
+      "label": "2491 PH Pitx2 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0611",
+      "male_female_ratio": 1.17,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.031,
+        "region_fraction_100um": 0.047,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2510",
+      "label": "2510 PH-LHA Foxb1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0614",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.029,
+        "region_fraction_100um": 0.086,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2517",
+      "label": "2517 PH-LHA Foxb1 Glut_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0616",
+      "male_female_ratio": 0.89,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 5,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.032,
+        "region_fraction_100um": 0.032,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_pmv_otr_neuron/discovery_candidates_rank1.json
+++ b/research/sexually_dimorphic/refresh_20260608_pmv_otr_neuron/discovery_candidates_rank1.json
@@ -1,0 +1,1594 @@
+{
+  "classical_node_id": "pmv_otr_neuron",
+  "classical_node_name": "Ventral premammillary nucleus (PMv) oxytocin receptor neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 1,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_SUPT_0607",
+      "label": "0607 PMv-TMv Pitx2 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_136",
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Oxtr",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Slc6a3",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.634,
+        "region_fraction_100um": 0.865,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0605",
+      "label": "0605 PMv-TMv Pitx2 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_136",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.307,
+        "region_fraction_100um": 0.631,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0557",
+      "label": "0557 ARH-PVp Tbx3 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Adcyap1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.033,
+        "region_fraction_100um": 0.067,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0429",
+      "label": "0429 TMv-PMv Tbx3 Hist-Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_092",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.077,
+        "region_fraction_100um": 0.247,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0430",
+      "label": "0430 TMv-PMv Tbx3 Hist-Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_092",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.094,
+        "region_fraction_100um": 0.157,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0479",
+      "label": "0479 TU-ARH Otp Six6 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_104",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.036,
+        "region_fraction_100um": 0.146,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0477",
+      "label": "0477 PVHd-DMH Lhx6 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_103",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.071,
+        "region_fraction_100um": 0.127,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0615",
+      "label": "0615 PH-LHA Foxb1 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_139",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.08,
+        "region_fraction_100um": 0.12,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0629",
+      "label": "0629 MM-ant Foxb1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_143",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.071,
+        "region_fraction_100um": 0.159,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0621",
+      "label": "0621 PMd-LHA Foxb1 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_140",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.028,
+        "region_fraction_100um": 0.119,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0620",
+      "label": "0620 PMd-LHA Foxb1 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_140",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.243,
+        "region_fraction_100um": 0.484,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0558",
+      "label": "0558 ARH-PVp Tbx3 Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.1,
+        "region_fraction_100um": 0.255,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0594",
+      "label": "0594 PH-ant-LHA Otp Bsx Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_134",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.055,
+        "region_fraction_100um": 0.104,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0592",
+      "label": "0592 PH-ant-LHA Otp Bsx Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_134",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.078,
+        "region_fraction_100um": 0.149,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0487",
+      "label": "0487 DMH Hmx2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.012,
+        "region_fraction_100um": 0.037,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0495",
+      "label": "0495 ARH-PVp Tbx3 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_108",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.002,
+        "region_fraction_100um": 0.029,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0494",
+      "label": "0494 ARH-PVp Tbx3 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_108",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.01,
+        "region_fraction_100um": 0.01,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0491",
+      "label": "0491 DMH Hmx2 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.004,
+        "region_fraction_100um": 0.006,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0481",
+      "label": "0481 TMd-DMH Foxd2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_105",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.029,
+        "region_fraction_100um": 0.098,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0480",
+      "label": "0480 TU-ARH Otp Six6 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_104",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.004,
+        "region_fraction_100um": 0.037,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0475",
+      "label": "0475 PVHd-DMH Lhx6 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_103",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.009,
+        "region_fraction_100um": 0.036,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0474",
+      "label": "0474 PVHd-DMH Lhx6 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_103",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.011,
+        "region_fraction_100um": 0.019,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0472",
+      "label": "0472 DMH-LHA Gsx1 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_102",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.004,
+        "region_fraction_100um": 0.017,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0470",
+      "label": "0470 DMH-LHA Gsx1 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_102",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.005,
+        "region_fraction_100um": 0.053,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0619",
+      "label": "0619 PMd-LHA Foxb1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_140",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.023,
+        "region_fraction_100um": 0.091,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0618",
+      "label": "0618 PH-LHA Foxb1 Glut_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_139",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.028,
+        "region_fraction_100um": 0.055,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0617",
+      "label": "0617 PH-LHA Foxb1 Glut_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_139",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.006,
+        "region_fraction_100um": 0.034,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0616",
+      "label": "0616 PH-LHA Foxb1 Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_139",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.014,
+        "region_fraction_100um": 0.027,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0614",
+      "label": "0614 PH-LHA Foxb1 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_139",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.016,
+        "region_fraction_100um": 0.018,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0610",
+      "label": "0610 PH Pitx2 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_138",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.006,
+        "region_fraction_100um": 0.081,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0606",
+      "label": "0606 PMv-TMv Pitx2 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_136",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.044,
+        "region_fraction_100um": 0.098,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0603",
+      "label": "0603 STN-PSTN Pitx2 Glut_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_135",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.023,
+        "region_fraction_100um": 0.061,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0631",
+      "label": "0631 MM Foxb1 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_144",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.036,
+        "region_fraction_100um": 0.087,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0630",
+      "label": "0630 MM Foxb1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_144",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.001,
+        "region_fraction_100um": 0.023,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0564",
+      "label": "0564 VMH Fezf1 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_128",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.002,
+        "region_fraction_100um": 0.011,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0573",
+      "label": "0573 LHA Pmch Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_130",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.028,
+        "region_fraction_100um": 0.056,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0556",
+      "label": "0556 ARH-PVp Tbx3 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.024,
+        "region_fraction_100um": 0.047,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0554",
+      "label": "0554 ARH-PVp Tbx3 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.005,
+        "region_fraction_100um": 0.046,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0553",
+      "label": "0553 DMH Hmx2 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_125",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.019,
+        "region_fraction_100um": 0.038,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0562",
+      "label": "0562 DMH-LHA Vgll2 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_127",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.035,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0552",
+      "label": "0552 DMH Hmx2 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_125",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.012,
+        "region_fraction_100um": 0.056,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0597",
+      "label": "0597 PH-ant-LHA Otp Bsx Glut_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_134",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.028,
+        "region_fraction_100um": 0.079,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0593",
+      "label": "0593 PH-ant-LHA Otp Bsx Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_134",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.018,
+        "region_fraction_100um": 0.054,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0591",
+      "label": "0591 PH-ant-LHA Otp Bsx Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_134",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.016,
+        "region_fraction_100um": 0.027,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0935",
+      "label": "0935 PRNc-PARN Tlx1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_226",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.005,
+        "region_fraction_100um": 0.005,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0427",
+      "label": "0427 ARH-PVi Six6 Dopa-Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_091",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Slc6a3",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_evidence": "DESCENDANT_ONLY"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0493",
+      "label": "0493 ARH-PVp Tbx3 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_108",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.016,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0490",
+      "label": "0490 DMH Hmx2 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.02,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0360",
+      "label": "0360 MEA-BST Lhx6 Nfib Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.009,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0453",
+      "label": "0453 SBPV-PVa Six6 Satb2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_099",
+      "discovery_score": {
+        "score": 0,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:1004",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_evidence": "DESCENDANT_ONLY"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_pmv_otr_neuron/prior_summary_preserved.md
+++ b/research/sexually_dimorphic/refresh_20260608_pmv_otr_neuron/prior_summary_preserved.md
@@ -1,0 +1,246 @@
+# Ventral premammillary nucleus (PMv) oxytocin receptor neuron — WMBv1 Mapping Report
+*draft · 2026-04-25 · Source: `kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
+
+**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+
+---
+
+## Introduction
+
+### Classical type
+
+**Ventral premammillary nucleus (PMv) oxytocin receptor neuron** is a male-biased
+sexually dimorphic population in the ventral premammillary nucleus, defined by
+neurochemical criteria (Oxtr, Slc6a3, Adcyap1). The classical node aggregates
+three molecularly defined subpopulations of the PMv that may not fully overlap:
+PMv-OTR (Oxtr+), PMv-DAT (Slc6a3+, dopaminergic), and PMv-PACAP (Adcyap1+).
+No CL term currently maps this population — it is a candidate for new term creation.
+
+| Property | Value | References |
+|---|---|---|
+| Soma location | Ventral premammillary nucleus [MBA:1004] | [1], [2] |
+| Defining markers | Oxtr (transcript), Slc6a3, Adcyap1 | [1], [2] |
+
+<details>
+<summary>Literature support — expand for verbatim quotes</summary>
+
+**[2] Newmaster et al. 2019 · PMID:32313029 — Neuronal Markers and Molecular Characteristics**
+
+> Sexual dimorphism of OTR expression. OTR is expressed in a sexually dimorphic manner as a part of neural circuit mechanism to generate behavioral differences in males and females 34,35 . Therefore, we compared OTR-Venus expression in male and female mice (N = 5 in male and female brains at different ages) to determine if there were any regions showing strong sexual dimorphism. Across the entire brain region throughout the postnatal development, we found significant sexual dimorphism in two hypothalamic regions (Fig. 7). The ventral premammillary nucleus (PMv) showed significantly higher OTR expression in males compared to females between P14 and P56 (Fig. 7a-d). In contrast, the anteroventral periventricular nucleus (AVPV) near the medial preoptic area showed higher OTR expression in females than males at P56, but not before (Fig. 7e-h). A recent study identified abundant estrogen- dependent OTR-expressing cells in the AVPV, co-expressing estrogen receptor in female mice 36 . This result suggests a potential role of OTR in sexual behavior [36][37][38] .
+> — Newmaster et al. 2019, Neuronal Markers and Molecular Characteristics · [2] <!-- quote_key: 201207691_ff444c30 -->
+
+**[1] Hemminger et al. 2024 · PMID:39416191 — Sexually Dimorphic Brain Regions and Structures**
+
+> We identified two adjacent regions within the hypothalamus that exhibited significant sexual dimorphism. Region 1 overlaps with the anterior hypothalamic nucleus (AHN), while Region 2 primarily overlaps with the ventral premammillary nucleus (PMv). Both regions are known to be sexually dimorphic (Vries et al., 2002) , though they have been studied to different extents
+> — Hemminger et al. 2024, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 273240437_ed3a4faa -->
+
+**[1] Hemminger et al. 2024 · PMID:39416191 — Sexually Dimorphic Brain Regions and Structures**
+
+> Our findings of specific neuronal subclass differences help further refine the molecular resolution of its dimorphic nature and providing a cellular basis for its role in sex-specific behaviors like aggression and parental care. Region 2, the PMv, is a well- established sexually dimorphic region, with roles in maternal aggression 38 , reproductive control 39 , male social behavior 40 , and intermale aggression 41 . Previous studies identified sexually dimorphic neuron populations within the PMv (e.g., PMv-DAT 42 , PMv- PACAP 43 ), complementing our systematic identification of subclass-level abundance changes.
+> — Hemminger et al. 2024, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 273240437_af6642f9 -->
+
+</details>
+
+---
+
+## Results
+
+### Mapping candidates
+
+Two mapping edges are recorded for pmv_otr_neuron: a supertype-level edge to SUPT_0607
+(the highest-DB-scoring candidate at any rank, expressing all three classical defining
+markers) and a child-cluster edge to CLUS_2470 (the PMv-dominant child cluster with
+the highest expression of all three markers).
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
+|---|---|---|---|---|---|---|
+| 1 | 2470 PMv-TMv Pitx2 Glut_3 [CS20230722_CLUS_2470] | 0607 PMv-TMv Pitx2 Glut_3 | 284 | 🔴 LOW | Oxtr/Slc6a3/Adcyap1 CONSISTENT; sex ratio NOT_ASSESSED | Speculative |
+| 2 | 0607 PMv-TMv Pitx2 Glut_3 [CS20230722_SUPT_0607] | (self) | 547 | 🔴 LOW | Oxtr/Slc6a3/Adcyap1 CONSISTENT; nt_type APPROXIMATE | Speculative |
+2 edges total. Relationship type: PARTIAL_OVERLAP (CLUS_2470) and CROSS_CUTTING (SUPT_0607).
+
+### Property alignment — primary candidate (CLUS_2470)
+
+**Table 1 — Property comparison.**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | MBA:1004 (Ventral premammillary nucleus) | MBA:1004 (PMv) n=347 (dominant location) | MBA:1004 (PMv) n=192 (primary soma — dominant location) | CONSISTENT |
+| Oxtr expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=2.0 (DEFINING_SCOPED atlas marker) | precomputed mean_expression=4.45 (vs supertype mean 2.0) | CONSISTENT |
+| Slc6a3 expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=3.07 (DEFINING atlas marker) | precomputed mean_expression=6.02 (vs supertype mean 3.07) | CONSISTENT |
+| Adcyap1 expression | POSITIVE (defining marker) | precomputed mean_expression=4.8 | precomputed mean_expression=8.13 (vs supertype mean 4.8) | CONSISTENT |
+| NT type | not specified; DAT+ subpopulation implies dopaminergic co-release | Glutamatergic (PMv-TMv Pitx2 Glut) | not assessed | SUPT: APPROXIMATE |
+| Sex ratio | male-biased (PMv OTR expression higher in males, P14–P56) | not available | NOT_ASSESSED — MFR absent from DB for CLUS_2470 | NOT_ASSESSED |
+| Annotation transfer F1 | not applicable | NOT_ASSESSED | NOT_ASSESSED | NOT_ASSESSED |
+
+**Table 2 — Evidence support.**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas precomputed expression (CLUS_2470 Oxtr/Slc6a3/Adcyap1) | Atlas metadata | SUPPORT | Oxtr=4.45, Slc6a3=6.02, Adcyap1=8.13; PMv n=192; MFR absent | atlas-internal |
+| SUPT_0607 atlas metadata (top DB score across all ranks) | Atlas metadata | SUPPORT | DB score=4 (top); Oxtr=2.0, Slc6a3=3.07, Adcyap1=4.8; Tac1=8.95; PMv n=347 | atlas-internal |
+
+*(1 of multiple SUPT_0607 child clusters — CLUS_2470 — concentrates the Oxtr/Slc6a3/Adcyap1 co-expression at PMv (n=192) with all three markers substantially above supertype means; sister supertype SUPT_0605 may capture an additional portion of the OTR+ population. MFR is absent at both supertype level and for CLUS_2470. Best match: CLUS_2470.)*
+
+---
+
+
+
+### 2470 PMv-TMv Pitx2 Glut_3 [CS20230722_CLUS_2470] · 🔴 LOW
+
+### Supporting evidence
+
+- **All three classical defining markers reach CONSISTENT alignment at cluster level.** CLUS_2470 shows substantially higher expression than the supertype mean for all three: Oxtr = 4.45 (vs supertype 2.0), Slc6a3 = 6.02 (vs 3.07), Adcyap1 = 8.13 (vs 4.8). Expression concentrates the marker-expressing PMv cells of SUPT_0607 into this cluster.
+- **PMv soma location is the dominant annotation.** MBA:1004 (Ventral premammillary nucleus) is the primary soma for n=192 cells in CLUS_2470 — the largest PMv cluster in SUPT_0607, providing a direct anatomical link to the classical type.
+- **Cluster was identified as the best PMv child within the top-DB supertype.** SUPT_0607 received the highest DB score (4) of any candidate at any rank for pmv_otr_neuron [1], [2]; CLUS_2470 is the child cluster within SUPT_0607 that concentrates all three classical marker signals at PMv.
+
+### Marker evidence provenance
+
+- **Oxtr** — at CLUS_2470, Oxtr = 4.45 and is annotated as DEFINING_SCOPED at supertype level (mean = 2.0). Classical evidence is transcript-based ([2] Newmaster 2019, OTR-Venus reporter expression). Atlas precomputed values are transcript-based (10x Chromium). No data-source discrepancy.
+- **Slc6a3** — CLUS_2470 Slc6a3 = 6.02 and is a DEFINING atlas marker at supertype level (mean = 3.07). Classical evidence comes from [1] Hemminger 2024, identifying PMv-DAT as a sexually dimorphic PMv subpopulation. Both classical and atlas signals are transcript-based — no data-source discrepancy.
+- **Adcyap1** — CLUS_2470 Adcyap1 = 8.13 (vs supertype 4.8). Classical evidence in the facts file lacks a specific PMID citation on the Adcyap1 marker (`refs: []` on the classical node). This is a gap: PMv-PACAP is referenced via [1] Hemminger 2024 in the broader sexually-dimorphic-PMv-subpopulations narrative, but a primary citation establishing Adcyap1 as a defining marker for this classical type is not in the facts. *(note: a targeted cite-traverse for "Adcyap1 PACAP PMv" may resolve this).*
+
+### Concerns
+
+- **Sex bias cannot be confirmed at cluster level.** male_female_ratio is absent from the DB for CLUS_2470 (n=192). Until sex bias is confirmed, confidence is capped at LOW. The absent MFR may reflect a DB ingest gap rather than a genuine absence in the precomputed stats. CLUS_2473 (PMv, n=86) has MFR=2.23 (mild male bias) but very low marker expression — it is a distinct PMv subtype, not a surrogate. *(note: source-side sex bias is well established at population level in [2]; target-side still unresolvable from atlas metadata until MFR is recovered or annotation transfer is run.)*
+- **Marker co-expression may conflate three classical subpopulations.** CLUS_2470 co-expresses Oxtr, Slc6a3, and Adcyap1 at levels suggesting it captures the PMv-OTR, PMv-DAT, and PMv-PACAP subpopulations simultaneously. If these are functionally distinct cell types, a single cluster-level edge conflates them. Node splitting (pmv_otr, pmv_dat, pmv_pacap) may be required before a higher-confidence cluster assignment can be made.
+- **Annotation transfer not yet performed.** No independent, data-driven cell-level mapping of published PMv scRNA-seq or Oxtr-Cre / Slc6a3-Cre lineage data has been run against WMBv1. This is the most important remaining gap in the evidence base.
+
+### What would upgrade confidence
+
+- **Direct precomputed-HDF5 query** for CLUS_2470 male_female_ratio (proposed in this edge) would distinguish a DB ingest gap from a genuine absence in the precomputed stats and immediately address the primary uncertainty cap on this edge.
+- **MapMyCells annotation transfer** of published PMv scRNA-seq or Oxtr-Cre / Slc6a3-Cre lineage data against WMBv1 at cluster resolution; F1 ≥ 0.80 against CLUS_2470 would substantially support upgrading to MODERATE/HIGH confidence and would add `AnnotationTransferEvidence`.
+- **Single-cell co-expression analysis within CLUS_2470** to determine whether Oxtr, Slc6a3, and Adcyap1 mark separable subpopulations or co-localise within individual cells. Resolution informs whether pmv_otr_neuron should be split into separate sub-nodes.
+
+---
+
+### 0607 PMv-TMv Pitx2 Glut_3 [CS20230722_SUPT_0607] · 🔴 LOW
+
+### Supporting evidence
+
+- **Highest DB candidate score across all ranks.** SUPT_0607 received the top DB score (4) of any candidate at any rank for pmv_otr_neuron — the single best supertype hit by atlas-metadata scoring.
+- **Direct PMv anatomical match.** MBA:1004 (Ventral premammillary nucleus) is the dominant soma location with n=347 cells in SUPT_0607.
+- **All three classical defining markers are present.** Precomputed mean expression: Oxtr = 2.0 (DEFINING_SCOPED atlas marker), Slc6a3 = 3.07 (DEFINING atlas marker), Adcyap1 = 4.8. The supertype simultaneously expresses all three markers corresponding to the potentially distinct PMv subpopulations (PMv-OTR, PMv-DAT, PMv-PACAP).
+- **Child cluster CLUS_2470 concentrates the marker-expressing PMv cells.** Within SUPT_0607, CLUS_2470 (n=192 PMv) shows substantially higher Oxtr (4.45), Slc6a3 (6.02), and Adcyap1 (8.13) than the supertype means — see CLUS_2470 edge above.
+
+### Marker evidence provenance
+
+- **Oxtr** — DEFINING_SCOPED at supertype level (mean = 2.0). Classical evidence transcript-based via OTR-Venus reporter [2]. Atlas value transcript-based (10x Chromium). Moderate atlas value at supertype level is expected for a marker concentrated in a child cluster (CLUS_2470 = 4.45).
+- **Slc6a3** — DEFINING atlas marker (mean = 3.07). Classical evidence via PMv-DAT subpopulation [1]. Both transcript-based — no data-source discrepancy.
+- **Adcyap1** — atlas mean = 4.8. Classical evidence on the node lacks a specific PMID (`refs: []`); PMv-PACAP is referenced in [1] but without a primary citation in the facts. Flag as weak source-side evidence.
+- **Tac1 — atlas annotation/literature discrepancy.** Tac1 = 8.95 is the *highest-expressing* DEFINING atlas marker for SUPT_0607 but is absent from the classical pmv_otr_neuron definition. SUPT_0607 may be more accurately characterised as a Tac1+ PMv population with OTR/DAT/PACAP as co-expressed subtype markers. *(note: this suggests the classical definition may underspecify Tac1 — a candidate for a targeted literature search on Tac1 in PMv).*
+
+### Concerns
+
+- **Supertype is glutamatergic, not dopaminergic.** SUPT_0607 carries a Glut_3 (glutamatergic) label (PMv-TMv Pitx2 Glut). The classical node's PMv-DAT subpopulation implies dopaminergic co-release, which is captured only APPROXIMATEly at supertype level. Glutamatergic identity is likely for the OTR+ and PACAP+ populations; dopaminergic co-release is possible for the Slc6a3+ subset. *(adjacent NT phenotype — weak counter-evidence; co-release is biologically plausible).*
+- **Cross-cutting marker pattern conflates three classical subpopulations.** SUPT_0607 expresses all three marker signatures (Oxtr, Slc6a3, Adcyap1) simultaneously, indicating the supertype aggregates neurons the classical taxonomy may treat as distinct subtypes (PMv-OTR, PMv-DAT, PMv-PACAP). Sister supertype SUPT_0605 (PMv-TMv Pitx2 Glut_1, DB score = 2) may capture an additional portion of the OTR+ male-biased population.
+- **Tac1 as the strongest atlas marker is unaccounted for.** Tac1 = 8.95 (DEFINING) is higher than any of the three classical markers at supertype level, but is not in the classical node definition. This is a marker mismatch flagged for investigation.
+- **Sex ratio not available at supertype level.** MFR is computed only at rank 0 (cluster); the male-biased dimorphism — a defining feature of pmv_otr_neuron [2] — cannot be assessed from supertype metadata.
+- **Annotation transfer NOT_ASSESSED.**
+
+### What would upgrade confidence
+
+- **Child-cluster expression query for SUPT_0607.** Query Oxtr, Slc6a3, Adcyap1, Tac1 expression in all child clusters of SUPT_0607 to determine whether subpopulations are resolvable at cluster level — partially addressed for CLUS_2470 above.
+- **Annotation transfer** (MapMyCells) of published PMv scRNA-seq data against WMBv1; F1 ≥ 0.50 at SUPT_0607 level would upgrade this edge; F1 ≥ 0.80 at CLUS_2470 level would support the cluster-level edge. Expected output: `AnnotationTransferEvidence`.
+- **Targeted literature search** for primary citations on Adcyap1 (PMv-PACAP) and Tac1 in PMv to resolve the marker provenance gap.
+- **Node split decision.** Decide whether pmv_otr_neuron should be split into pmv_otr, pmv_dat, and pmv_pacap sub-nodes prior to final mapping, given that SUPT_0607 cross-cuts the three subpopulations.
+
+---
+
+### Methods
+
+<details>
+<summary>Data sources, analyses, and reproducibility receipts</summary>
+
+**Classical type definition.** See classical type table in Introduction; defining_basis on the classical node and per-property literature support are listed there. The KB-side definition lives at the source graph file linked in the reproducibility footer.
+
+**Atlas mapping query.** Candidate atlas clusters were retrieved from CCN20230722 at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias). Full scoring rules: `workflows/map-cell-type.md`.
+
+**Property alignment.** Each defining property was compared to the corresponding atlas-side value via the `property_comparisons` schema; alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
+
+
+
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote.
+
+*Generated by evidencell `0c97cfa` from [`kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`](../../kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+
+</details>
+
+---
+
+## Discussion
+
+**Primary mapping:** → 2470 PMv-TMv Pitx2 Glut_3 [CS20230722_CLUS_2470] at LOW confidence. Key support: ATLAS_METADATA (PMv-localised Pitx2 Glut subclass; Oxtr expression annotated on parent SUPT_0607). Key caveats: `MARKER_NOT_SPECIFIC` (Oxtr expression not directly resolvable at cluster rank); `LOW_CELL_COUNT`.
+
+No Cell Ontology term currently assigned for this classical type.
+
+### Proposed experiments and follow-ups
+
+### 1. Direct precomputed-HDF5 query for CLUS_2470 male_female_ratio
+
+**What:** Query the precomputed HDF5 stats directly for CLUS_2470 male_female_ratio, bypassing the DB ingest layer.
+
+**Target:** Recover MFR for CLUS_2470 (n=192 cells) and confirm whether sex bias matches the classical male-biased dimorphism.
+
+**Expected output:** Updated property_comparison on the CLUS_2470 edge with sex_ratio alignment resolved (CONSISTENT / DISCORDANT / NOT_ASSESSED if genuinely absent in the source HDF5).
+
+**Resolves:** Open question 1 (the primary cap on confidence for the CLUS_2470 edge). Distinguishes a DB ingest gap from a genuine absence.
+
+### 2. MapMyCells annotation transfer of an external PMv scRNA-seq dataset against WMBv1
+
+**What:** Retrieve a published scRNA-seq dataset enriched for PMv neurons (e.g. Oxtr-Cre, Slc6a3-Cre, or PMv-DAT lineage preparations; sex-stratified hypothalamic atlases). Run MapMyCells against WMBv1 at cluster resolution.
+
+**Target:** F1 ≥ 0.50 at SUPT_0607 level; F1 ≥ 0.80 at CLUS_2470 level for Oxtr+/Slc6a3+/Adcyap1+ cells.
+
+**Expected output:** `AnnotationTransferEvidence` entries on both edges (edge_pmv_otr_neuron_to_cs20230722_supt_0607 and edge_pmv_otr_neuron_to_cs20230722_clus_2470). Atlas: WMBv1. Tool: MapMyCells. Output format: F1 matrix per cluster, fed back as `AnnotationTransferEvidence` YAML.
+
+**Resolves:** Open questions 2 and 3. Addresses the `annotation_transfer_f1` NOT_ASSESSED gap on both edges.
+
+### 3. Single-cell marker co-expression analysis within CLUS_2470
+
+**What:** Within-cluster re-clustering of CLUS_2470 cells, stratified by Oxtr+/Slc6a3+/Adcyap1+ profiles. Determine whether the three markers co-localise within individual cells or mark separable subpopulations.
+
+**Target:** Detection of separable PMv-OTR, PMv-DAT, and PMv-PACAP sub-populations within CLUS_2470, or formal demonstration that they are co-extensive at this resolution.
+
+**Expected output:** Additional `MarkerAnalysisEvidence` records and a node-split decision (pmv_otr / pmv_dat / pmv_pacap as separate classical nodes, or retain as a single aggregated node).
+
+**Resolves:** Open questions 2 and 4 (node splitting decision).
+
+### 4. Targeted literature search for Adcyap1 and Tac1 in PMv
+
+**What:** Cite-traverse for primary citations establishing Adcyap1 as a defining marker for the classical PMv-PACAP population, and for Tac1 expression in PMv.
+
+**Target:** Recover primary PMID(s) supporting Adcyap1 as a PMv-PACAP defining marker; assess whether Tac1 should be added to the classical node definition.
+
+**Expected output:** Additional `LiteratureEvidence` entries; updated classical node definition if Tac1 is supported.
+
+**Resolves:** Adcyap1 marker provenance gap; Tac1 atlas/literature discrepancy (open question 5).
+
+---
+
+### Open questions
+
+1. Why is MFR absent for CLUS_2470 (n=192 cells)? Is this a DB ingest gap or a genuine absence in precomputed stats? *(Appears on the cluster edge.)*
+2. Do Oxtr, Slc6a3, and Adcyap1 co-localise within individual CLUS_2470 cells, or do they mark distinct subpopulations within the cluster? *(Appears on the cluster edge.)*
+3. Do individual clusters within SUPT_0607 segregate by marker (Oxtr-high, Slc6a3-high, Adcyap1-high), allowing sub-resolution mapping? *(Appears on the supertype edge; partially addressed by CLUS_2470 ATLAS_METADATA evidence.)*
+4. Should pmv_otr_neuron be split into separate pmv_otr, pmv_dat, pmv_pacap sub-nodes prior to final mapping? *(Appears on the supertype edge.)*
+5. What is the role of Tac1 (mean = 8.95, highest DEFINING atlas marker in SUPT_0607) relative to the classical pmv_otr_neuron definition? Should it be added as a co-expressed marker or treated as a distinguishing feature of a related but distinct supertype? *(Appears on the supertype edge.)*
+
+---
+
+### Evidence base
+
+| Edge ID | Evidence type | Supports |
+|---|---|---|
+| edge_pmv_otr_neuron_to_cs20230722_supt_0607 | ATLAS_METADATA | SUPPORT — DB top score=4; Oxtr=2.0 (DEFINING_SCOPED), Slc6a3=3.07 (DEFINING), Adcyap1=4.8; Tac1=8.95 unexpected; MBA:1004 PMv n=347 |
+| edge_pmv_otr_neuron_to_cs20230722_clus_2470 | ATLAS_METADATA | SUPPORT — Oxtr=4.45, Slc6a3=6.02, Adcyap1=8.13 (all above supertype means); MBA:1004 PMv n=192 (largest PMv cluster); MFR absent |
+
+All evidence is atlas-metadata only. No literature, annotation transfer, or direct experimental evidence has been incorporated at this stage.
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | Hemminger et al. 2024 | [PMID:39416191](https://pubmed.ncbi.nlm.nih.gov/39416191/) | Soma location (PMv); PMv-DAT and PMv-PACAP sexually dimorphic subpopulations |
+| [2] | Newmaster et al. 2019 | [PMID:32313029](https://pubmed.ncbi.nlm.nih.gov/32313029/) | Soma location (PMv); Oxtr (OTR) marker; male-biased PMv OTR expression P14–P56 |

--- a/research/sexually_dimorphic/refresh_20260608_pmv_otr_neuron/refresh_summary.json
+++ b/research/sexually_dimorphic/refresh_20260608_pmv_otr_neuron/refresh_summary.json
@@ -1,0 +1,135 @@
+{
+  "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+  "node_id": "pmv_otr_neuron",
+  "taxonomy_id": "CCN20230722",
+  "ranks": {
+    "rank0": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_CLUS_2471",
+          "CS20230722_CLUS_2470",
+          "CS20230722_CLUS_2314",
+          "CS20230722_CLUS_2575",
+          "CS20230722_CLUS_2395"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml pmv_otr_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_pmv_otr_neuron/discovery_candidates_rank0.json",
+          "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 6,
+        "edges_skipped_taxtype_not_in_topk": 1,
+        "skipped_details": [
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_cs20230722_supt_0607",
+            "taxonomy_type": "CS20230722_SUPT_0607"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_cs20230722_clus_2470",
+            "taxonomy_type": "CS20230722_CLUS_2470"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2471",
+            "taxonomy_type": "CS20230722_CLUS_2471"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2470",
+            "taxonomy_type": "CS20230722_CLUS_2470"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2314",
+            "taxonomy_type": "CS20230722_CLUS_2314"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2575",
+            "taxonomy_type": "CS20230722_CLUS_2575"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2395",
+            "taxonomy_type": "CS20230722_CLUS_2395"
+          }
+        ]
+      }
+    },
+    "rank1": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_SUPT_0607",
+          "CS20230722_SUPT_0605",
+          "CS20230722_SUPT_0557",
+          "CS20230722_SUPT_0429",
+          "CS20230722_SUPT_0430"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml pmv_otr_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_pmv_otr_neuron/discovery_candidates_rank1.json",
+          "  emit-stage-b: wrote 5 edge(s) + 3 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 6,
+        "edges_skipped_taxtype_not_in_topk": 6,
+        "skipped_details": [
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_cs20230722_clus_2470",
+            "taxonomy_type": "CS20230722_CLUS_2470"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2471",
+            "taxonomy_type": "CS20230722_CLUS_2471"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2470",
+            "taxonomy_type": "CS20230722_CLUS_2470"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2314",
+            "taxonomy_type": "CS20230722_CLUS_2314"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2575",
+            "taxonomy_type": "CS20230722_CLUS_2575"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2395",
+            "taxonomy_type": "CS20230722_CLUS_2395"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_cs20230722_supt_0607",
+            "taxonomy_type": "CS20230722_SUPT_0607"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_SUPT_0607",
+            "taxonomy_type": "CS20230722_SUPT_0607"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_SUPT_0605",
+            "taxonomy_type": "CS20230722_SUPT_0605"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_SUPT_0557",
+            "taxonomy_type": "CS20230722_SUPT_0557"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_SUPT_0429",
+            "taxonomy_type": "CS20230722_SUPT_0429"
+          },
+          {
+            "edge_id": "edge_pmv_otr_neuron_to_CS20230722_SUPT_0430",
+            "taxonomy_type": "CS20230722_SUPT_0430"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/research/sexually_dimorphic/refresh_20260608_pvn_crfr1_neuron/discovery_candidates_rank0.json
+++ b/research/sexually_dimorphic/refresh_20260608_pvn_crfr1_neuron/discovery_candidates_rank0.json
@@ -1,0 +1,1639 @@
+{
+  "classical_node_id": "pvn_crfr1_neuron",
+  "classical_node_name": "PVN corticotropin-releasing factor receptor 1 (CRFR1) neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 0,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_CLUS_2366",
+      "label": "2366 PVH-SO-PVa Otp Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0585",
+      "male_female_ratio": 1.94,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.619,
+        "region_fraction_100um": 0.81,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1549",
+      "label": "1549 BST-MPN Six3 Nrgn Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0423",
+      "male_female_ratio": 3.35,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.357,
+        "region_fraction_100um": 0.821,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1550",
+      "label": "1550 BST-MPN Six3 Nrgn Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0423",
+      "male_female_ratio": 3.35,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.25,
+        "region_fraction_100um": 0.521,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1561",
+      "label": "1561 BST-MPN Six3 Nrgn Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0425",
+      "male_female_ratio": 2.23,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.083,
+        "region_fraction_100um": 0.378,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1563",
+      "label": "1563 BST-MPN Six3 Nrgn Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0425",
+      "male_female_ratio": 0.23,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.037,
+        "region_fraction_100um": 0.111,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1695",
+      "label": "1695 SBPV-PVa Six6 Satb2 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0455",
+      "male_female_ratio": 3.17,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.304,
+        "region_fraction_100um": 0.565,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1696",
+      "label": "1696 SBPV-PVa Six6 Satb2 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0455",
+      "male_female_ratio": 3.0,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.364,
+        "region_fraction_100um": 0.818,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1912",
+      "label": "1912 PVpo-VMPO-MPN Hmx2 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0486",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.054,
+        "region_fraction_100um": 0.108,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2331",
+      "label": "2331 LHA-AHN-PVH Otp Trh Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0575",
+      "male_female_ratio": 2.45,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.07,
+        "region_fraction_100um": 0.193,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2332",
+      "label": "2332 LHA-AHN-PVH Otp Trh Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0575",
+      "male_female_ratio": 3.17,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.468,
+        "region_fraction_100um": 0.628,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2354",
+      "label": "2354 AHN-RCH-LHA Otp Fezf1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0581",
+      "male_female_ratio": 3.17,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.152,
+        "region_fraction_100um": 0.5,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2364",
+      "label": "2364 PVH-SO-PVa Otp Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0585",
+      "male_female_ratio": 2.45,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.667,
+        "region_fraction_100um": 0.9,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2365",
+      "label": "2365 PVH-SO-PVa Otp Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0585",
+      "male_female_ratio": 2.12,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.391,
+        "region_fraction_100um": 0.602,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2368",
+      "label": "2368 PVH-SO-PVa Otp Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0585",
+      "male_female_ratio": 1.94,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.269,
+        "region_fraction_100um": 0.557,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2367",
+      "label": "2367 PVH-SO-PVa Otp Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0585",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.517,
+        "region_fraction_100um": 0.552,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2369",
+      "label": "2369 PVH-SO-PVa Otp Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0586",
+      "male_female_ratio": 5.67,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.73,
+        "region_fraction_100um": 0.865,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2373",
+      "label": "2373 PVH-SO-PVa Otp Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0586",
+      "male_female_ratio": 4.26,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.426,
+        "region_fraction_100um": 0.752,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2375",
+      "label": "2375 PVH-SO-PVa Otp Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0587",
+      "male_female_ratio": 3.0,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.785,
+        "region_fraction_100um": 0.916,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2377",
+      "label": "2377 PVH-SO-PVa Otp Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0587",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.821,
+        "region_fraction_100um": 0.97,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2376",
+      "label": "2376 PVH-SO-PVa Otp Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0587",
+      "male_female_ratio": 3.35,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.701,
+        "region_fraction_100um": 0.915,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2378",
+      "label": "2378 PVH-SO-PVa Otp Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0587",
+      "male_female_ratio": 3.17,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.798,
+        "region_fraction_100um": 0.983,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2370",
+      "label": "2370 PVH-SO-PVa Otp Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0586",
+      "male_female_ratio": 3.76,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.407,
+        "region_fraction_100um": 0.741,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2384",
+      "label": "2384 PVH-SO-PVa Otp Glut_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0589",
+      "male_female_ratio": 2.57,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.551,
+        "region_fraction_100um": 0.71,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2385",
+      "label": "2385 PVH-SO-PVa Otp Glut_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUPT_0590",
+      "male_female_ratio": 2.7,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.108,
+        "region_fraction_100um": 0.514,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2382",
+      "label": "2382 PVH-SO-PVa Otp Glut_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0589",
+      "male_female_ratio": 2.7,
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.212,
+        "region_fraction_100um": 0.384,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1349",
+      "label": "1349 CEA-AAA-BST Six3 Sp9 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0373",
+      "male_female_ratio": 1.17,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Ar",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.027,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1909",
+      "label": "1909 PVpo-VMPO-MPN Hmx2 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0484",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.054,
+        "region_fraction_100um": 0.089,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1471",
+      "label": "1471 MPO-ADP Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0404",
+      "male_female_ratio": 2.12,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.034,
+        "region_fraction_100um": 0.172,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1484",
+      "label": "1484 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0407",
+      "male_female_ratio": 0.64,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.091,
+        "region_fraction_100um": 0.106,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1486",
+      "label": "1486 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0407",
+      "male_female_ratio": 0.52,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.017,
+        "region_fraction_100um": 0.117,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1516",
+      "label": "1516 PVR Six3 Sox3 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0414",
+      "male_female_ratio": 1.7,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.039,
+        "region_fraction_100um": 0.137,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1543",
+      "label": "1543 BST-MPN Six3 Nrgn Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0422",
+      "male_female_ratio": 2.45,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.006,
+        "region_fraction_100um": 0.131,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1544",
+      "label": "1544 BST-MPN Six3 Nrgn Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0422",
+      "male_female_ratio": 3.0,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.015,
+        "region_fraction_100um": 0.261,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1545",
+      "label": "1545 BST-MPN Six3 Nrgn Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0422",
+      "male_female_ratio": 3.0,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.065,
+        "region_fraction_100um": 0.283,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1546",
+      "label": "1546 BST-MPN Six3 Nrgn Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0422",
+      "male_female_ratio": 2.23,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.05,
+        "region_fraction_100um": 0.3,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1548",
+      "label": "1548 BST-MPN Six3 Nrgn Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0423",
+      "male_female_ratio": 2.03,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.034,
+        "region_fraction_100um": 0.101,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1572",
+      "label": "1572 ARH-PVi Six6 Dopa-Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0428",
+      "male_female_ratio": 3.76,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.053,
+        "region_fraction_100um": 0.183,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1631",
+      "label": "1631 PVHd-SBPV Six3 Prox1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0442",
+      "male_female_ratio": 2.12,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.019,
+        "region_fraction_100um": 0.121,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1634",
+      "label": "1634 PVHd-SBPV Six3 Prox1 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0443",
+      "male_female_ratio": 2.12,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.011,
+        "region_fraction_100um": 0.236,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1635",
+      "label": "1635 PVHd-SBPV Six3 Prox1 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0443",
+      "male_female_ratio": 2.85,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.013,
+        "region_fraction_100um": 0.103,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1684",
+      "label": "1684 SBPV-PVa Six6 Satb2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0453",
+      "male_female_ratio": 2.03,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.152,
+        "region_fraction_100um": 0.485,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1685",
+      "label": "1685 SBPV-PVa Six6 Satb2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0453",
+      "male_female_ratio": 32.33,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.058,
+        "region_fraction_100um": 0.163,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1686",
+      "label": "1686 SBPV-PVa Six6 Satb2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0453",
+      "male_female_ratio": 1.7,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.04,
+        "region_fraction_100um": 0.16,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1688",
+      "label": "1688 SBPV-PVa Six6 Satb2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0454",
+      "male_female_ratio": 3.35,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.08,
+        "region_fraction_100um": 0.1,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1691",
+      "label": "1691 SBPV-PVa Six6 Satb2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0454",
+      "male_female_ratio": 4.88,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.071,
+        "region_fraction_100um": 0.168,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1692",
+      "label": "1692 SBPV-PVa Six6 Satb2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0454",
+      "male_female_ratio": 4.56,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.083,
+        "region_fraction_100um": 0.111,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1693",
+      "label": "1693 SBPV-PVa Six6 Satb2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0454",
+      "male_female_ratio": 3.76,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.25,
+        "region_fraction_100um": 0.35,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1694",
+      "label": "1694 SBPV-PVa Six6 Satb2 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0455",
+      "male_female_ratio": 4.26,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.347,
+        "region_fraction_100um": 0.429,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1697",
+      "label": "1697 SBPV-PVa Six6 Satb2 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0455",
+      "male_female_ratio": 3.0,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.111,
+        "region_fraction_100um": 0.153,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1729",
+      "label": "1729 ZI Pax6 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0460",
+      "male_female_ratio": 1.63,
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.034,
+        "region_fraction_100um": 0.123,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_pvn_crfr1_neuron/discovery_candidates_rank1.json
+++ b/research/sexually_dimorphic/refresh_20260608_pvn_crfr1_neuron/discovery_candidates_rank1.json
@@ -1,0 +1,1549 @@
+{
+  "classical_node_id": "pvn_crfr1_neuron",
+  "classical_node_name": "PVN corticotropin-releasing factor receptor 1 (CRFR1) neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 1,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_SUPT_0585",
+      "label": "0585 PVH-SO-PVa Otp Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_133",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.383,
+        "region_fraction_100um": 0.665,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0587",
+      "label": "0587 PVH-SO-PVa Otp Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_133",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.833,
+        "region_fraction_100um": 0.975,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0586",
+      "label": "0586 PVH-SO-PVa Otp Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_133",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.361,
+        "region_fraction_100um": 0.61,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0414",
+      "label": "0414 PVR Six3 Sox3 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Crhr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.011,
+        "region_fraction_100um": 0.04,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0486",
+      "label": "0486 PVpo-VMPO-MPN Hmx2 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.011,
+        "region_fraction_100um": 0.02,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0455",
+      "label": "0455 SBPV-PVa Six6 Satb2 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_099",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.146,
+        "region_fraction_100um": 0.217,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0454",
+      "label": "0454 SBPV-PVa Six6 Satb2 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_099",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.074,
+        "region_fraction_100um": 0.128,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0443",
+      "label": "0443 PVHd-SBPV Six3 Prox1 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_097",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.015,
+        "region_fraction_100um": 0.135,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0453",
+      "label": "0453 SBPV-PVa Six6 Satb2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_099",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.053,
+        "region_fraction_100um": 0.16,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0428",
+      "label": "0428 ARH-PVi Six6 Dopa-Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_091",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.053,
+        "region_fraction_100um": 0.183,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0423",
+      "label": "0423 BST-MPN Six3 Nrgn Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.093,
+        "region_fraction_100um": 0.211,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0422",
+      "label": "0422 BST-MPN Six3 Nrgn Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.013,
+        "region_fraction_100um": 0.157,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0484",
+      "label": "0484 PVpo-VMPO-MPN Hmx2 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.088,
+        "region_fraction_100um": 0.134,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0645",
+      "label": "0645 PVT-PT Ntrk1 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_149",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.062,
+        "region_fraction_100um": 0.136,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0525",
+      "label": "0525 LHA Barhl2 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_117",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.051,
+        "region_fraction_100um": 0.161,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0577",
+      "label": "0577 LHA-AHN-PVH Otp Trh Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_131",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.098,
+        "region_fraction_100um": 0.18,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0575",
+      "label": "0575 LHA-AHN-PVH Otp Trh Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_131",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.174,
+        "region_fraction_100um": 0.323,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0581",
+      "label": "0581 AHN-RCH-LHA Otp Fezf1 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_132",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.088,
+        "region_fraction_100um": 0.294,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0589",
+      "label": "0589 PVH-SO-PVa Otp Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_133",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.325,
+        "region_fraction_100um": 0.46,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0588",
+      "label": "0588 PVH-SO-PVa Otp Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_133",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.203,
+        "region_fraction_100um": 0.235,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0596",
+      "label": "0596 PH-ant-LHA Otp Bsx Glut_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_134",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.053,
+        "region_fraction_100um": 0.246,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0590",
+      "label": "0590 PVH-SO-PVa Otp Glut_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_133",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.264,
+        "region_fraction_100um": 0.465,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0720",
+      "label": "0720 SPA-SPFm-SPFp-POL-PIL-PoT Sp9 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_168",
+      "discovery_score": {
+        "score": 2,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.045,
+        "region_fraction_100um": 0.107,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_1175",
+      "label": "1175 Ependymal NN_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_323",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.005,
+        "region_fraction_100um": 0.021,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0407",
+      "label": "0407 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_087",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.03,
+        "region_fraction_100um": 0.056,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0404",
+      "label": "0404 MPO-ADP Lhx8 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.002,
+        "region_fraction_100um": 0.015,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0461",
+      "label": "0461 ZI Pax6 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_101",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.013,
+        "region_fraction_100um": 0.019,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0460",
+      "label": "0460 ZI Pax6 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_101",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.022,
+        "region_fraction_100um": 0.08,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0448",
+      "label": "0448 AHN-SBPV-PVHd Pdrm12 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_098",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.011,
+        "region_fraction_100um": 0.097,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0445",
+      "label": "0445 PVHd-SBPV Six3 Prox1 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_097",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.005,
+        "region_fraction_100um": 0.053,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0444",
+      "label": "0444 PVHd-SBPV Six3 Prox1 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_097",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.015,
+        "region_fraction_100um": 0.04,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0442",
+      "label": "0442 PVHd-SBPV Six3 Prox1 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_097",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.003,
+        "region_fraction_100um": 0.051,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0441",
+      "label": "0441 PVHd Gsc Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_096",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.02,
+        "region_fraction_100um": 0.041,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0426",
+      "label": "0426 BST-MPN Six3 Nrgn Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.026,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0425",
+      "label": "0425 BST-MPN Six3 Nrgn Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.038,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0468",
+      "label": "0468 ZI Pax6 Gaba_10",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_101",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.007,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0467",
+      "label": "0467 ZI Pax6 Gaba_9",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_101",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.009,
+        "region_fraction_100um": 0.026,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0466",
+      "label": "0466 ZI Pax6 Gaba_8",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_101",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.046,
+        "region_fraction_100um": 0.093,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0465",
+      "label": "0465 ZI Pax6 Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_101",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.018,
+        "region_fraction_100um": 0.035,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0357",
+      "label": "0357 MEA-BST Lhx6 Nfib Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.013,
+        "region_fraction_100um": 0.021,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0348",
+      "label": "0348 MEA-BST Lhx6 Sp9 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_074",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          }
+        ],
+        "region_fraction": 0.0,
+        "region_fraction_100um": 0.004,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0398",
+      "label": "0398 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.002,
+        "region_fraction_100um": 0.017,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0397",
+      "label": "0397 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.008,
+        "region_fraction_100um": 0.025,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0648",
+      "label": "0648 PVT-PT Ntrk1 Glut_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_149",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.013,
+        "region_fraction_100um": 0.033,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0647",
+      "label": "0647 PVT-PT Ntrk1 Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_149",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.006,
+        "region_fraction_100um": 0.015,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0646",
+      "label": "0646 PVT-PT Ntrk1 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_149",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.003,
+        "region_fraction_100um": 0.015,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0644",
+      "label": "0644 PVT-PT Ntrk1 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_149",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.014,
+        "region_fraction_100um": 0.02,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0643",
+      "label": "0643 PVT-PT Ntrk1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_149",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.008,
+        "region_fraction_100um": 0.023,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0669",
+      "label": "0669 RE-Xi Nox4 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_152",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.001,
+        "region_fraction_100um": 0.009,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0670",
+      "label": "0670 RE-Xi Nox4 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_152",
+      "discovery_score": {
+        "score": 1,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 3,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:38"
+            ]
+          }
+        ],
+        "expression_detail": [],
+        "region_fraction": 0.016,
+        "region_fraction_100um": 0.057,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_pvn_crfr1_neuron/prior_summary_preserved.md
+++ b/research/sexually_dimorphic/refresh_20260608_pvn_crfr1_neuron/prior_summary_preserved.md
@@ -1,0 +1,257 @@
+# PVN corticotropin-releasing factor receptor 1 (CRFR1) neuron — WMBv1 Mapping Report
+*draft · 2026-04-25 · Source: `kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
+
+**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+
+---
+
+## Introduction
+
+### Classical type
+
+**PVN corticotropin-releasing factor receptor 1 (CRFR1) neuron** is defined neurochemically by
+expression of CRFR1 (Crhr1) and obligate co-expression of estrogen receptor alpha (Esr1, moderate)
+and androgen receptor (Ar, high). Somas are concentrated in the paraventricular hypothalamic
+nucleus (PVN). The population is male-biased (males > females), with the sex difference emerging
+during puberty/early adulthood and persisting into old age; adult gonadectomy in males (but not
+females) reduces CRFR1-immunoreactive cell counts, indicating gonadal-hormone-dependent
+regulation. Characterisation rests on a single primary source (Rosinger 2019).
+
+CL term: **corticotropin-releasing neuron (CL:4072021)** — mapping is RELATED only. CL:4072021
+defines neurons by CRH *secretion*, while this node is defined by CRFR1 *receptor* expression.
+No exact CL term exists; this is a candidate for a new term.
+
+| Property | Value | References |
+|---|---|---|
+| Soma location | Paraventricular hypothalamic nucleus [MBA:38] | [1] |
+| Defining markers | Crhr1 (transcript), Esr1 (transcript, moderate co-expression), Ar (transcript, high co-expression) | [1] |
+| CL term | CL:4072021 (corticotropin-releasing neuron) — RELATED only | |
+
+<details>
+<summary>Literature support — expand for verbatim quotes</summary>
+
+**[1] Rosinger et al. 2019 · PMID:31055007 — Soma location, Crhr1/Esr1/Ar markers, sex dimorphism**
+
+> Sex differences in neural structures are generally believed to underlie sex differences reported in anxiety, depression, and the hypothalamic-pituitary-adrenal axis, although the specific circuitry involved is largely unclear. Using a corticotropin-releasing factor receptor 1 (CRFR1) reporter mouse line, we report a sexually dimorphic distribution of CRFR1 expressing cells within the paraventricular hypothalamus (PVN; males > females). Relative to adult levels, PVN CRFR1-expressing cells are sparse and not sexually dimorphic at postnatal days 0, 4, or 21. This suggests that PVN cells might recruit CRFR1 during puberty or early adulthood in a sex-specific manner. The adult sex difference in PVN CRFR1 persists in old mice (20-24 months). Adult gonadectomy (6 weeks) resulted in a significant decrease in CRFR1-immunoreactive cells in the male but not female PVN. CRFR1 cells show moderate co-expression with estrogen receptor alpha (ERα) and high co-expression with androgen receptor, indicating potential mechanisms through which circulating gonadal hormones might regulate CRFR1 expression and function. Finally, we demonstrate that a psychological stressor, restraint stress, induces a sexually dimorphic pattern of neural activation in PVN CRFR1 cells (males >females) as assessed by co-localization with the transcription/neural activation marker phosphorylated CREB. Given the known role of CRFR1 in regulating stress-associated behaviors and hormonal responses, this CRFR1 PVN sex difference might contribute to sex differences in these functions.
+> — Rosinger et al. 2019, Introduction · [1] <!-- quote_key: 143424909_2b990710 -->
+
+</details>
+
+---
+
+## Results
+
+### Mapping candidates
+
+One mapping edge is recorded for pvn_crfr1_neuron: a supertype-level edge to SUPT_0585
+(0585 PVH-SO-PVa Otp Glut_1), the highest rank-1 candidate by DB score (=3) among PVN-localised
+supertypes.
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
+|---|---|---|---|---|---|---|
+| 1 | 0585 PVH-SO-PVa Otp Glut_1 [CS20230722_SUPT_0585] | (self) | 183 | 🟡 MODERATE | Esr1 APPROXIMATE; Ar APPROXIMATE; Crhr1 APPROXIMATE (low) | Best candidate |
+1 edge total. Relationship type: PARTIAL_OVERLAP.
+
+### Property alignment — primary candidate (SUPT_0585)
+
+**Table 1 — Property comparison.**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Paraventricular hypothalamic nucleus [MBA:38] | MBA:38 (PVN) n=98 (primary location) | not assessed | CONSISTENT |
+| NT type | not stated; PVN principal neurons predominantly glutamatergic | Glutamatergic (PVH-SO-PVa Otp Glut) | not assessed | CONSISTENT |
+| Crhr1 expression | POSITIVE (transcript, primary defining marker) | precomputed mean_expression=0.84 | not assessed | APPROXIMATE |
+| Esr1 expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=3.65 (DEFINING_SCOPED atlas marker) | not assessed | APPROXIMATE |
+| Ar expression | POSITIVE (transcript, defining marker) | precomputed mean_expression=4.95 | not assessed | APPROXIMATE |
+| Sex ratio | MALE_BIASED (males > females; emerges at puberty; gonadectomy-sensitive in males) | not available | not assessed | NOT_ASSESSED |
+
+**Table 2 — Evidence support.**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| SUPT_0585 atlas metadata (PVN n=98; Crhr1/Esr1/Ar; rank-1 DB score=3) | Atlas metadata | PARTIAL | MBA:38 n=98; Crhr1=0.84; Esr1=3.65 (DEFINING_SCOPED); Ar=4.95; Crh=2.5 | atlas-internal |
+
+*(Child-cluster breakdown not assessed — see proposed experiments. Note: rank-0 candidate CLUS_2382, child of SUPT_0589, has male_female_ratio=2.7 consistent with male-biased dimorphism, suggesting SUPT_0589 is an alternative or co-equal mapping target.)*
+
+---
+
+
+
+### 0585 PVH-SO-PVa Otp Glut_1 [CS20230722_SUPT_0585] · 🟡 MODERATE
+
+### Supporting evidence
+
+- **Direct PVN soma location match.** SUPT_0585 (PVH-SO-PVa Otp Glut_1) has Paraventricular
+  hypothalamic nucleus [MBA:38] as its primary location with n=98 cells, providing CONSISTENT
+  anatomical alignment with the classical node's PVN soma criterion [1].
+- **Steroid hormone receptor co-expression strongly supported.** Precomputed mean expression
+  Esr1=3.65 (a DEFINING_SCOPED atlas marker for SUPT_0585) and Ar=4.95 directly support the
+  classical node's defining estrogen receptor alpha (moderate) and androgen receptor (high)
+  co-expression profile. The relative magnitudes — Ar > Esr1 — are consistent with the
+  "high androgen receptor / moderate ERα" pattern reported in [1].
+- **Glutamatergic identity is concordant.** The supertype carries a Glut label (PVH-SO-PVa Otp
+  Glut), consistent with the predominantly glutamatergic phenotype expected of PVN principal
+  neurons. The classical node does not specify NT type, but glutamatergic identity is the
+  expected default for non-magnocellular PVN populations *(note: NT type not stated in [1];
+  glutamatergic is inferred from regional convention and the supertype Otp Glut label.)*
+- **Crh expression confirms PVN neuroendocrine identity.** Precomputed mean Crh = 2.5 within
+  SUPT_0585 confirms the supertype is part of the PVN CRH/neuroendocrine network, the expected
+  context in which CRFR1+ cells reside.
+- **Highest DB score among rank-1 candidates.** SUPT_0585 was selected as the best candidate
+  by DB score = 3, the highest among rank-1 PVN-localised supertypes.
+
+### Marker evidence provenance
+
+- **Crhr1** — classical node evidence is from a CRFR1 reporter mouse line (transgenic
+  fluorescent reporter; protein-level cell counting) [1], with co-expression confirmed by
+  immunofluorescence (CRFR1-IR cells). Atlas precomputed Crhr1 = 0.84 is transcript-based
+  (10x Chromium). The atlas value is low — consistent with CRFR1+ neurons being a *subset*
+  of SUPT_0585 rather than the entire supertype. *(note: this is the expected pattern when a
+  classical type is defined by a sparsely expressed receptor whose protein is detectable by
+  reporter line but whose transcript is diluted across a heterogeneous transcriptomic
+  supertype.)* No data-source contradiction; the discrepancy reflects scope, not absence.
+- **Esr1** — classical node evidence is protein-level (ERα immunoreactivity co-localisation
+  with CRFR1) [1]. Atlas precomputed Esr1 = 3.65 is transcript-based and listed as a
+  DEFINING_SCOPED atlas marker for SUPT_0585. Strong cross-modal agreement.
+- **Ar** — classical node evidence is protein-level (androgen receptor immunoreactivity
+  co-localisation with CRFR1, "high" co-expression) [1]. Atlas precomputed Ar = 4.95 is
+  transcript-based and is the highest of the three steroid-related markers, in agreement with
+  the "high" qualitative ranking in [1]. Strong cross-modal agreement.
+- **Single-source caveat.** All three defining markers (Crhr1, Esr1, Ar) and the soma location
+  are sourced from a single primary study (Rosinger 2019, PMID:31055007). Marker provenance is
+  internally consistent but lacks independent literature replication.
+
+### Concerns
+
+- **Crhr1 expression is low at supertype level (APPROXIMATE).** Precomputed mean Crhr1 = 0.84
+  indicates CRFR1+ neurons are a minority subset of SUPT_0585. Mapping at supertype resolution
+  averages the CRFR1 signal across many cells, most of which may not express Crhr1.
+  Cluster-level resolution would be required to identify the specific Crhr1-enriched
+  subpopulation. *(weak counter-evidence — expected pattern for a subset-defining marker.)*
+- **Sex ratio not available at supertype level.** Male-biased sex dimorphism — a defining
+  feature of pvn_crfr1_neuron [1] — cannot be assessed from supertype-level metadata
+  (male_female_ratio is computed only at rank 0). The rank-0 candidate CLUS_2382 (parent
+  SUPT_0589, *not* SUPT_0585) shows male_female_ratio = 2.7, consistent with male-biased
+  dimorphism — raising the possibility that SUPT_0589 is a better or co-equal mapping target.
+- **Alternative supertype (SUPT_0589) not yet assessed in detail.** Because the male-biased
+  child cluster CLUS_2382 belongs to SUPT_0589 rather than SUPT_0585, curator review is needed
+  to determine whether SUPT_0589 should be added as a co-equal or preferred mapping edge.
+- **Single-dataset characterisation.** All classical-node evidence is from Rosinger 2019
+  (PMID:31055007). Confidence is capped at MODERATE pending secondary literature validation.
+- **Annotation transfer NOT_ASSESSED.** No independent, data-driven cell-level mapping of
+  CRFR1+ PVN cells to WMBv1 has been run.
+
+### What would upgrade confidence
+
+- **Child-cluster expression analysis of SUPT_0585** to identify the specific cluster(s)
+  combining peak Crhr1 expression with male-biased sex ratio (male_female_ratio > 1) would
+  resolve unresolved question 1 and clarify whether the CRFR1 subset is concentrated in one
+  child cluster. Expected output: refined `MappingEdge` at cluster level with stronger
+  Crhr1 alignment and (where MFR is available) CONSISTENT sex-ratio support.
+- **Comparative assessment of SUPT_0589** (parent of male-biased CLUS_2382, MFR=2.7) against
+  SUPT_0585 to determine whether SUPT_0589 is a better or co-equal mapping target. Expected
+  output: an additional `MappingEdge` to SUPT_0589 with property comparisons documenting the
+  sex-ratio agreement.
+- **MapMyCells annotation transfer** of an external CRFR1-reporter or Crhr1+ FACS-sorted PVN
+  scRNA-seq dataset against WMBv1 at cluster resolution; F1 ≥ 0.50 at the supertype level
+  would upgrade this edge. Expected output: `AnnotationTransferEvidence`.
+- **Targeted cite-traverse** for primary studies independently profiling PVN Crhr1+ neurons
+  (scRNA-seq, RNAscope, or alternative reporter lines) would address the SINGLE_DATASET caveat
+  and could promote confidence beyond MODERATE.
+
+---
+
+### Methods
+
+<details>
+<summary>Data sources, analyses, and reproducibility receipts</summary>
+
+**Classical type definition.** See classical type table in Introduction; defining_basis on the classical node and per-property literature support are listed there. The KB-side definition lives at the source graph file linked in the reproducibility footer.
+
+**Atlas mapping query.** Candidate atlas clusters were retrieved from CCN20230722 at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias). Full scoring rules: `workflows/map-cell-type.md`.
+
+**Property alignment.** Each defining property was compared to the corresponding atlas-side value via the `property_comparisons` schema; alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
+
+
+
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote.
+
+*Generated by evidencell `0c97cfa` from [`kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`](../../kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+
+</details>
+
+---
+
+## Discussion
+
+**Primary mapping:** → 0585 PVH-SO-PVa Otp Glut_1 [CS20230722_SUPT_0585] at MODERATE confidence. Key support: ATLAS_METADATA (PVN/SO/PVa anatomy match; Otp Glut subclass consistent with neuroendocrine PVN identity). Key caveats: `MARKER_NOT_SPECIFIC` (Crhr1 expression not directly resolvable in atlas metadata).
+
+No Cell Ontology term currently assigned for this classical type.
+
+### Proposed experiments and follow-ups
+
+### 1. Child-cluster expression analysis of SUPT_0585 (and SUPT_0589) for Crhr1 and male-biased MFR
+
+**What:** For each child cluster of SUPT_0585 and SUPT_0589, retrieve precomputed
+mean_expression for Crhr1, Esr1, Ar, and male_female_ratio. Identify cluster(s) with peak
+Crhr1 combined with MFR > 1.
+
+**Target:** At least one cluster with Crhr1 ≥ supertype mean and MFR ≥ 1.5 (male-biased).
+
+**Expected output:** A refined `MappingEdge` at cluster level (rank 0) with stronger
+Crhr1 alignment and CONSISTENT sex-ratio support.
+
+**Resolves:** Open questions 1 and 2.
+
+### 2. MapMyCells annotation transfer of an external CRFR1+ PVN scRNA-seq dataset against WMBv1
+
+**What:** Retrieve a published scRNA-seq dataset enriched for PVN CRFR1+ neurons
+(e.g., Crhr1-Cre or CRFR1-reporter sorted preparations, sex-stratified). Run MapMyCells
+against WMBv1 at cluster resolution.
+
+**Target:** F1 ≥ 0.50 at SUPT_0585 (or SUPT_0589) level; F1 ≥ 0.80 at the best child cluster.
+
+**Expected output:** `AnnotationTransferEvidence` entry on the edge, atlas: WMBv1, tool:
+MapMyCells, output: F1 matrix per cluster.
+
+**Resolves:** The annotation_transfer_f1 NOT_ASSESSED gap and questions 1–2.
+
+### 3. Targeted cite-traverse for secondary literature on PVN Crhr1+ neurons
+
+**What:** Run a `cite-traverse` skill query for primary studies independently profiling PVN
+Crhr1+ neurons (scRNA-seq, RNAscope, alternative reporter lines, or sex-stratified
+characterisations).
+
+**Target:** At least one independent primary study (non-Rosinger) describing PVN Crhr1+
+neuron molecular profile or sex dimorphism.
+
+**Expected output:** Additional `LiteratureEvidence` entries; lifts the SINGLE_DATASET caveat
+and could support upgrading confidence beyond MODERATE.
+
+**Resolves:** SINGLE_DATASET caveat.
+
+---
+
+### Open questions
+
+1. Which cluster within the PVH-SO-PVa Otp Glut subclass shows highest Crhr1 expression
+   combined with male-biased sex ratio?
+2. Is SUPT_0589 a better or co-equal mapping target compared to SUPT_0585? *(The rank-0
+   candidate CLUS_2382, with male_female_ratio = 2.7 consistent with male-biased dimorphism,
+   is a child of SUPT_0589 rather than SUPT_0585.)*
+
+---
+
+### Evidence base
+
+| Edge ID | Evidence type | Supports |
+|---|---|---|
+| edge_pvn_crfr1_neuron_to_cs20230722_supt_0585 | ATLAS_METADATA | PARTIAL — MBA:38 PVN n=98 (primary); Crhr1=0.84 (low, subset); Esr1=3.65 (DEFINING_SCOPED); Ar=4.95; Crh=2.5; rank-1 DB score=3 |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | Rosinger et al. 2019 | [PMID:31055007](https://pubmed.ncbi.nlm.nih.gov/31055007/) | Soma location (PVN); Crhr1, Esr1, Ar markers; male-biased sex dimorphism; gonadectomy and stress-activation findings |

--- a/research/sexually_dimorphic/refresh_20260608_pvn_crfr1_neuron/refresh_summary.json
+++ b/research/sexually_dimorphic/refresh_20260608_pvn_crfr1_neuron/refresh_summary.json
@@ -1,0 +1,127 @@
+{
+  "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+  "node_id": "pvn_crfr1_neuron",
+  "taxonomy_id": "CCN20230722",
+  "ranks": {
+    "rank0": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_CLUS_2366",
+          "CS20230722_CLUS_1549",
+          "CS20230722_CLUS_1550",
+          "CS20230722_CLUS_1561",
+          "CS20230722_CLUS_1563"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml pvn_crfr1_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_pvn_crfr1_neuron/discovery_candidates_rank0.json",
+          "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 5,
+        "edges_skipped_taxtype_not_in_topk": 1,
+        "skipped_details": [
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_cs20230722_supt_0585",
+            "taxonomy_type": "CS20230722_SUPT_0585"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_2366",
+            "taxonomy_type": "CS20230722_CLUS_2366"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1549",
+            "taxonomy_type": "CS20230722_CLUS_1549"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1550",
+            "taxonomy_type": "CS20230722_CLUS_1550"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1561",
+            "taxonomy_type": "CS20230722_CLUS_1561"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1563",
+            "taxonomy_type": "CS20230722_CLUS_1563"
+          }
+        ]
+      }
+    },
+    "rank1": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_SUPT_0585",
+          "CS20230722_SUPT_0587",
+          "CS20230722_SUPT_0586",
+          "CS20230722_SUPT_0414",
+          "CS20230722_SUPT_0486"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml pvn_crfr1_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_pvn_crfr1_neuron/discovery_candidates_rank1.json",
+          "  emit-stage-b: wrote 5 edge(s) + 3 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 6,
+        "edges_skipped_taxtype_not_in_topk": 5,
+        "skipped_details": [
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_2366",
+            "taxonomy_type": "CS20230722_CLUS_2366"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1549",
+            "taxonomy_type": "CS20230722_CLUS_1549"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1550",
+            "taxonomy_type": "CS20230722_CLUS_1550"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1561",
+            "taxonomy_type": "CS20230722_CLUS_1561"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1563",
+            "taxonomy_type": "CS20230722_CLUS_1563"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_cs20230722_supt_0585",
+            "taxonomy_type": "CS20230722_SUPT_0585"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0585",
+            "taxonomy_type": "CS20230722_SUPT_0585"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0587",
+            "taxonomy_type": "CS20230722_SUPT_0587"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0586",
+            "taxonomy_type": "CS20230722_SUPT_0586"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0414",
+            "taxonomy_type": "CS20230722_SUPT_0414"
+          },
+          {
+            "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0486",
+            "taxonomy_type": "CS20230722_SUPT_0486"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/research/sexually_dimorphic/refresh_20260608_sdn_poa_calbindin_neuron/discovery_candidates_rank0.json
+++ b/research/sexually_dimorphic/refresh_20260608_sdn_poa_calbindin_neuron/discovery_candidates_rank0.json
@@ -1,0 +1,2467 @@
+{
+  "classical_node_id": "sdn_poa_calbindin_neuron",
+  "classical_node_name": "Sexually dimorphic nucleus of the preoptic area (SDN-POA) calbindin neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 0,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_CLUS_1304",
+      "label": "1304 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0361",
+      "male_female_ratio": 13.29,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 7,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 10.28,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.997
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.581,
+        "region_fraction_100um": 0.605,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1305",
+      "label": "1305 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0361",
+      "male_female_ratio": 6.14,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 7,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.89,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.959
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.25,
+        "region_fraction_100um": 0.6,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1303",
+      "label": "1303 MEA-BST Lhx6 Nfib Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0360",
+      "male_female_ratio": 9.0,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.52,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.929
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.364,
+        "region_fraction_100um": 0.727,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1310",
+      "label": "1310 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0361",
+      "male_female_ratio": 8.09,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.37,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.785
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.427,
+        "region_fraction_100um": 0.649,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1542",
+      "label": "1542 BST-MPN Six3 Nrgn Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0422",
+      "male_female_ratio": 4.0,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 3.26,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.408
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.273,
+        "region_fraction_100um": 0.576,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1549",
+      "label": "1549 BST-MPN Six3 Nrgn Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0423",
+      "male_female_ratio": 3.35,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.71,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.832
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.25,
+        "region_fraction_100um": 0.714,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1550",
+      "label": "1550 BST-MPN Six3 Nrgn Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0423",
+      "male_female_ratio": 3.35,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 6.66,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.704
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.458,
+        "region_fraction_100um": 0.812,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1562",
+      "label": "1562 BST-MPN Six3 Nrgn Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0425",
+      "male_female_ratio": 32.33,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 5.81,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.636
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.391,
+        "region_fraction_100um": 0.518,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1685",
+      "label": "1685 SBPV-PVa Six6 Satb2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0453",
+      "male_female_ratio": 32.33,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 5.31,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.584
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.512,
+        "region_fraction_100um": 0.779,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1881",
+      "label": "1881 PVpo-VMPO-MPN Hmx2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0482",
+      "male_female_ratio": 32.33,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.19,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.476
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.421,
+        "region_fraction_100um": 0.526,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1888",
+      "label": "1888 PVpo-VMPO-MPN Hmx2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0483",
+      "male_female_ratio": 5.67,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 6.17,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.663
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.4,
+        "region_fraction_100um": 0.635,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1890",
+      "label": "1890 PVpo-VMPO-MPN Hmx2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0483",
+      "male_female_ratio": 19.0,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 3.59,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.418
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.469,
+        "region_fraction_100um": 0.663,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1894",
+      "label": "1894 PVpo-VMPO-MPN Hmx2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0483",
+      "male_female_ratio": 8.09,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 1.79,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.272
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.371,
+        "region_fraction_100um": 0.569,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1913",
+      "label": "1913 PVpo-VMPO-MPN Hmx2 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0486",
+      "male_female_ratio": 10.11,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 5.09,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.562
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.153,
+        "region_fraction_100um": 0.519,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1914",
+      "label": "1914 PVpo-VMPO-MPN Hmx2 Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0486",
+      "male_female_ratio": 10.11,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.13,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.47
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.29,
+        "region_fraction_100um": 0.696,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2247",
+      "label": "2247 MPN-MPO-PVpo Hmx2 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0548",
+      "male_female_ratio": 13.29,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.01,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.878
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.436,
+        "region_fraction_100um": 0.698,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2249",
+      "label": "2249 MPN-MPO-PVpo Hmx2 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0548",
+      "male_female_ratio": 4.0,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.04,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.758
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.654,
+        "region_fraction_100um": 0.865,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2330",
+      "label": "2330 LHA-AHN-PVH Otp Trh Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0575",
+      "male_female_ratio": 3.35,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.89,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.861
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.279,
+        "region_fraction_100um": 0.695,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1306",
+      "label": "1306 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0361",
+      "male_female_ratio": 99.0,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.74,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.946
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.181,
+        "region_fraction_100um": 0.31,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1307",
+      "label": "1307 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0361",
+      "male_female_ratio": 0.54,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.9,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.962
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.371,
+        "region_fraction_100um": 0.514,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1309",
+      "label": "1309 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0361",
+      "male_female_ratio": 1.56,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.79,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.957
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.481,
+        "region_fraction_100um": 0.691,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1512",
+      "label": "1512 PVR Six3 Sox3 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0413",
+      "male_female_ratio": 3.35,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 2.16,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.326
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.031,
+        "region_fraction_100um": 0.118,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1565",
+      "label": "1565 BST-MPN Six3 Nrgn Gaba_7",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0426",
+      "male_female_ratio": 3.35,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 6.32,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.682
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.19,
+        "region_fraction_100um": 0.476,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1567",
+      "label": "1567 BST-MPN Six3 Nrgn Gaba_7",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0426",
+      "male_female_ratio": 4.88,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.0,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.451
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.073,
+        "region_fraction_100um": 0.164,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1644",
+      "label": "1644 PVHd-SBPV Six3 Prox1 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0445",
+      "male_female_ratio": 3.35,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.67,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.943
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.133,
+        "region_fraction_100um": 0.4,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1645",
+      "label": "1645 PVHd-SBPV Six3 Prox1 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0445",
+      "male_female_ratio": 4.0,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.72,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.837
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.036,
+        "region_fraction_100um": 0.138,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1654",
+      "label": "1654 AHN-SBPV-PVHd Pdrm12 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0447",
+      "male_female_ratio": 3.17,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.11,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.894
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.023,
+        "region_fraction_100um": 0.116,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1695",
+      "label": "1695 SBPV-PVa Six6 Satb2 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0455",
+      "male_female_ratio": 3.17,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 1.42,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.223
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.087,
+        "region_fraction_100um": 0.174,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1228",
+      "label": "1228 MEA-BST Sox6 Gaba_7",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0343",
+      "male_female_ratio": 4.26,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.41,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.791
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.08,
+        "region_fraction_100um": 0.294,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1235",
+      "label": "1235 MEA-BST Sox6 Gaba_10",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0346",
+      "male_female_ratio": 3.17,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 2.25,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.337
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.034,
+        "region_fraction_100um": 0.172,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1263",
+      "label": "1263 MEA-BST Lhx6 Sp9 Gaba_7",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0353",
+      "male_female_ratio": 3.17,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 6.7,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.717
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.184,
+        "region_fraction_100um": 0.263,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2234",
+      "label": "2234 MPN-MPO-PVpo Hmx2 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0546",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 9.11,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.976
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.259,
+        "region_fraction_100um": 0.519,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2259",
+      "label": "2259 MPN-MPO-PVpo Hmx2 Glut_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0550",
+      "male_female_ratio": 3.76,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.83,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.851
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.213,
+        "region_fraction_100um": 0.359,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2332",
+      "label": "2332 LHA-AHN-PVH Otp Trh Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0575",
+      "male_female_ratio": 3.17,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.1,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.891
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.149,
+        "region_fraction_100um": 0.394,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2355",
+      "label": "2355 AHN-RCH-LHA Otp Fezf1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0581",
+      "male_female_ratio": 3.55,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.42,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.921
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.075,
+        "region_fraction_100um": 0.196,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2354",
+      "label": "2354 AHN-RCH-LHA Otp Fezf1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0581",
+      "male_female_ratio": 3.17,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 6.59,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.698
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.022,
+        "region_fraction_100um": 0.217,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1571",
+      "label": "1571 ARH-PVi Six6 Dopa-Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0427",
+      "male_female_ratio": 5.25,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 5.6,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.614
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.014,
+        "region_fraction_100um": 0.014,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1703",
+      "label": "1703 AHN Onecut3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0456",
+      "male_female_ratio": 3.76,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.61,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.938
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.004,
+        "region_fraction_100um": 0.051,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2353",
+      "label": "2353 AHN-RCH-LHA Otp Fezf1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0581",
+      "male_female_ratio": 3.55,
+      "criteria_applied": [
+        "sex_bias=male"
+      ],
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.26,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.899
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.006,
+        "region_fraction_100um": 0.089,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1302",
+      "label": "1302 MEA-BST Lhx6 Nfib Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0360",
+      "male_female_ratio": 1.08,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 9.21,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.978
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.108,
+        "region_fraction_100um": 0.263,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1308",
+      "label": "1308 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0361",
+      "male_female_ratio": 2.33,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.2,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.481
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.708,
+        "region_fraction_100um": 0.917,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1433",
+      "label": "1433 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0397",
+      "male_female_ratio": 0.89,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 1.54,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.239
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.268,
+        "region_fraction_100um": 0.549,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1440",
+      "label": "1440 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0398",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 0.34,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.041
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.412,
+        "region_fraction_100um": 0.684,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1485",
+      "label": "1485 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0407",
+      "male_female_ratio": 1.7,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.64,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.818
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.454,
+        "region_fraction_100um": 0.615,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1491",
+      "label": "1491 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0408",
+      "male_female_ratio": 2.45,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.47,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.804
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.9,
+        "region_fraction_100um": 1.0,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1510",
+      "label": "1510 PVR Six3 Sox3 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0412",
+      "male_female_ratio": 2.12,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 1.95,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.296
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.304,
+        "region_fraction_100um": 0.521,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1538",
+      "label": "1538 BST-MPN Six3 Nrgn Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0420",
+      "male_female_ratio": 2.33,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.78,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.527
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.708,
+        "region_fraction_100um": 0.908,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1539",
+      "label": "1539 BST-MPN Six3 Nrgn Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0420",
+      "male_female_ratio": 2.7,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.28,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.905
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.773,
+        "region_fraction_100um": 0.902,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1540",
+      "label": "1540 BST-MPN Six3 Nrgn Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0421",
+      "male_female_ratio": 1.94,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.86,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.533
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.489,
+        "region_fraction_100um": 0.671,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1541",
+      "label": "1541 BST-MPN Six3 Nrgn Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0422",
+      "male_female_ratio": 2.7,
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.69,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.519
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.417,
+        "region_fraction_100um": 0.66,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_sdn_poa_calbindin_neuron/discovery_candidates_rank1.json
+++ b/research/sexually_dimorphic/refresh_20260608_sdn_poa_calbindin_neuron/discovery_candidates_rank1.json
@@ -1,0 +1,2359 @@
+{
+  "classical_node_id": "sdn_poa_calbindin_neuron",
+  "classical_node_name": "Sexually dimorphic nucleus of the preoptic area (SDN-POA) calbindin neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 1,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_SUPT_0360",
+      "label": "0360 MEA-BST Lhx6 Nfib Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.68,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.971
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.414,
+        "region_fraction_100um": 0.619,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0420",
+      "label": "0420 BST-MPN Six3 Nrgn Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 6.53,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.79
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.759,
+        "region_fraction_100um": 0.903,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0422",
+      "label": "0422 BST-MPN Six3 Nrgn Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 5.49,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.686
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.583,
+        "region_fraction_100um": 0.768,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0421",
+      "label": "0421 BST-MPN Six3 Nrgn Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.86,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.59
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.489,
+        "region_fraction_100um": 0.671,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0486",
+      "label": "0486 PVpo-VMPO-MPN Hmx2 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.16,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.486
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.197,
+        "region_fraction_100um": 0.697,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0485",
+      "label": "0485 PVpo-VMPO-MPN Hmx2 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 1.37,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.171
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.257,
+        "region_fraction_100um": 0.593,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0484",
+      "label": "0484 PVpo-VMPO-MPN Hmx2 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 5.25,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.638
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.192,
+        "region_fraction_100um": 0.587,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0483",
+      "label": "0483 PVpo-VMPO-MPN Hmx2 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 3.68,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.419
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.359,
+        "region_fraction_100um": 0.529,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0361",
+      "label": "0361 MEA-BST Lhx6 Nfib Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.17,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.943
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.333,
+        "region_fraction_100um": 0.512,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0575",
+      "label": "0575 LHA-AHN-PVH Otp Trh Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_131",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.02,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.829
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.299,
+        "region_fraction_100um": 0.563,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0549",
+      "label": "0549 MPN-MPO-PVpo Hmx2 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_124",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.46,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.524
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.548,
+        "region_fraction_100um": 0.676,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0548",
+      "label": "0548 MPN-MPO-PVpo Hmx2 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_124",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 5.55,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.705
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.48,
+        "region_fraction_100um": 0.7,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0547",
+      "label": "0547 MPN-MPO-PVpo Hmx2 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_124",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 1.64,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.219
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.496,
+        "region_fraction_100um": 0.677,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0551",
+      "label": "0551 MPN-MPO-PVpo Hmx2 Glut_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_124",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.65,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.571
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.376,
+        "region_fraction_100um": 0.676,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0358",
+      "label": "0358 MEA-BST Lhx6 Nfib Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.86,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.981
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.008,
+        "region_fraction_100um": 0.014,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0362",
+      "label": "0362 MEA-BST Lhx6 Nfib Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.4,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.962
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.05,
+        "region_fraction_100um": 0.08,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0588",
+      "label": "0588 PVH-SO-PVa Otp Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_133",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.28,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.952
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.013,
+        "region_fraction_100um": 0.037,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0419",
+      "label": "0419 PVR Six3 Sox3 Gaba_9",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 3.28,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.362
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.1,
+        "region_fraction_100um": 0.271,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0418",
+      "label": "0418 PVR Six3 Sox3 Gaba_8",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 0.68,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.067
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.023,
+        "region_fraction_100um": 0.137,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0417",
+      "label": "0417 PVR Six3 Sox3 Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 1.57,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.21
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.024,
+        "region_fraction_100um": 0.169,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0416",
+      "label": "0416 PVR Six3 Sox3 Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 0.63,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.038
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.045,
+        "region_fraction_100um": 0.134,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0413",
+      "label": "0413 PVR Six3 Sox3 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 3.92,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.448
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.027,
+        "region_fraction_100um": 0.1,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0412",
+      "label": "0412 PVR Six3 Sox3 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 2.33,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.276
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.088,
+        "region_fraction_100um": 0.17,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0411",
+      "label": "0411 PVR Six3 Sox3 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_089",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 2.45,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.314
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.025,
+        "region_fraction_100um": 0.178,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0408",
+      "label": "0408 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_087",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 6.23,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.743
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.101,
+        "region_fraction_100um": 0.134,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0407",
+      "label": "0407 MPN-MPO-LPO Lhx6 Zfhx3 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_087",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 5.03,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.619
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.217,
+        "region_fraction_100um": 0.306,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0406",
+      "label": "0406 MPO-ADP Lhx8 Gaba_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 1.5,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.19
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.048,
+        "region_fraction_100um": 0.134,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0404",
+      "label": "0404 MPO-ADP Lhx8 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 1.98,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.248
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.067,
+        "region_fraction_100um": 0.249,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0403",
+      "label": "0403 MPO-ADP Lhx8 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_086",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 1.49,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.181
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.043,
+        "region_fraction_100um": 0.192,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0445",
+      "label": "0445 PVHd-SBPV Six3 Prox1 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_097",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.52,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.886
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.034,
+        "region_fraction_100um": 0.163,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0453",
+      "label": "0453 SBPV-PVa Six6 Satb2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_099",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 3.33,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.371
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.278,
+        "region_fraction_100um": 0.457,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0426",
+      "label": "0426 BST-MPN Six3 Nrgn Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.69,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.581
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.146,
+        "region_fraction_100um": 0.278,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0425",
+      "label": "0425 BST-MPN Six3 Nrgn Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 3.87,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.438
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.25,
+        "region_fraction_100um": 0.345,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0423",
+      "label": "0423 BST-MPN Six3 Nrgn Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_090",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 6.42,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.771
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.14,
+        "region_fraction_100um": 0.336,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0482",
+      "label": "0482 PVpo-VMPO-MPN Hmx2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_106",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 3.25,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.352
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.17,
+        "region_fraction_100um": 0.292,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0357",
+      "label": "0357 MEA-BST Lhx6 Nfib Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_076",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.16,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.838
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.19,
+        "region_fraction_100um": 0.262,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0348",
+      "label": "0348 MEA-BST Lhx6 Sp9 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_074",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.33,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.867
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.111,
+        "region_fraction_100um": 0.195,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0353",
+      "label": "0353 MEA-BST Lhx6 Sp9 Gaba_7",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_074",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 5.43,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.676
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.068,
+        "region_fraction_100um": 0.124,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0398",
+      "label": "0398 SI-MPO-LPO Lhx8 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 0.41,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.01
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.194,
+        "region_fraction_100um": 0.387,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0397",
+      "label": "0397 SI-MPO-LPO Lhx8 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_085",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.44,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.514
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.096,
+        "region_fraction_100um": 0.197,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0539",
+      "label": "0539 MEA-BST Otp Zic2 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_121",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.0,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.467
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.105,
+        "region_fraction_100um": 0.133,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0527",
+      "label": "0527 ADP-MPO Trp73 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_118",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 2.52,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.333
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.153,
+        "region_fraction_100um": 0.326,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0522",
+      "label": "0522 AVPV-MEPO-SFO Tbr1 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_116",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 3.36,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.381
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.131,
+        "region_fraction_100um": 0.366,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0520",
+      "label": "0520 AVPV-MEPO-SFO Tbr1 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_116",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 5.53,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.695
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.078,
+        "region_fraction_100um": 0.347,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0519",
+      "label": "0519 AVPV-MEPO-SFO Tbr1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_116",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 4.19,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.495
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.092,
+        "region_fraction_100um": 0.163,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0578",
+      "label": "0578 LHA-AHN-PVH Otp Trh Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_131",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 3.22,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.343
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.081,
+        "region_fraction_100um": 0.249,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0577",
+      "label": "0577 LHA-AHN-PVH Otp Trh Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_131",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 8.03,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.933
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.113,
+        "region_fraction_100um": 0.302,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0582",
+      "label": "0582 AHN-RCH-LHA Otp Fezf1 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_132",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 6.4,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.762
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.027,
+        "region_fraction_100um": 0.166,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0581",
+      "label": "0581 AHN-RCH-LHA Otp Fezf1 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_132",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 7.79,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.905
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.028,
+        "region_fraction_100um": 0.21,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0574",
+      "label": "0574 LHA-AHN-PVH Otp Trh Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_131",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 4,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:515",
+              "sex_bias=male"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Calb1",
+            "val": 5.01,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.61
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.109,
+        "region_fraction_100um": 0.274,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_sdn_poa_calbindin_neuron/prior_summary_preserved.md
+++ b/research/sexually_dimorphic/refresh_20260608_sdn_poa_calbindin_neuron/prior_summary_preserved.md
@@ -1,0 +1,238 @@
+# Sexually dimorphic nucleus of the preoptic area (SDN-POA) calbindin neuron — WMBv1 Mapping Report
+*draft · 2026-04-25 · Source: `kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
+
+**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+
+---
+
+## Introduction
+
+### Classical type
+
+The **sexually dimorphic nucleus of the preoptic area (SDN-POA) calbindin neuron** is
+defined by neurochemical and histological criteria: Calbindin-D28K (Calb1)
+immunoreactivity in a histologically delineable subnucleus within the rodent medial
+preoptic nucleus, with absence of tyrosine hydroxylase (TH) cell bodies. The structure
+is male-biased in cell number and is considered the rodent homolog of the third
+interstitial nucleus of the anterior hypothalamus (INAH3) in humans, with homologous
+structures described in sheep, rhesus monkey, and quail.
+
+No CL term currently exists for this population — it is a candidate for a new term.
+
+| Property | Value | References |
+|---|---|---|
+| Soma location | Medial preoptic nucleus [MBA:515] (SDN-POA is a histologically defined subnucleus within MPN) | [1], [2] |
+| Defining markers | Calb1 (calbindin-D28K, protein, IHC) | [2] |
+| Negative markers | Th (no TH-positive cell bodies in SDN-POA) | [2] |
+
+<details>
+<summary>Literature support — expand for verbatim quotes</summary>
+
+**[1] Negri-Cesi 2015 · PMID:26672480 — Sexually Dimorphic Brain Regions and Structures**
+
+> The 2 best known dimorphic brain structures are the sexual dimorphic nucleus of the medial preoptic hypothalamic area (SDN-POA) in rodents, which correspond to the interstitial nucleus of the anterior hypothalamus (INAH) in humans, and the anteroventral periventricular (AVPV) nucleus. The first one controls male sex behavior and is larger in males than in females; the second one is critical for the cyclic control of ovulation and is larger in females than in males.
+> — Negri-Cesi 2015, Sexually Dimorphic Brain Regions and Structures · [1] <!-- quote_key: 14863067_fa51fcf7 -->
+
+**[2] He et al. 2013 · PMID:25206587 — Sexually Dimorphic Brain Regions and Structures**
+
+> One of the well-defined sexually dimorphic structures in the brain is the sexually dimorphic nucleus, a cluster of cells located in the preoptic area of the hypothalamus. The rodent sexually dimorphic nucleus of the preoptic area can be delineated histologically using conventional Nissl staining or immunohistochemically using calbindin D28K immunoreactivity
+> — He et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 3481177_d6c3a647 -->
+
+**[2] He et al. 2013 · PMID:25206587 — Sexually Dimorphic Brain Regions and Structures (cross-species homology)**
+
+> The sexually dimorphic nucleus has been specifically defined in the brains of human and other mammalian and non-mammalian and includes the third interstitial nucleus of the anterior hypothalamus in humans (Allen et al., 1989)(Allen et al., 1990) , the ovine sexually dimorphic nucleus in the medial preoptic area (Roselli et al., 2004) , the medial preoptic and anterior hypothalamic regions in rhesus monkeys (Byne, 1998) , a specific area in the medial preoptic nucleus in quail (Viglietti‐Panzica et al., 1986) , and the sexually dimorphic nucleus of the preoptic area in rats (Gorski et al., 1978)(Gorski et al., 1980) . The human sexually dimorphic nucleus of the preoptic area is located in the medial part of the preoptic area, between the dorsolateral supraoptic nucleus and the rostral pole of the paraventricular nucleus (Hofman et al., 1989)
+> — He et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 3481177_1098a86b -->
+
+**[2] He et al. 2013 · PMID:25206587 — Calbindin/TH profile of SDN-POA**
+
+> The sexually dimorphic nucleus of the preoptic area is highlighted by calbindin-D28K immunoreactivity: no TH-positive cells were found, but fine axon-like projections/synaptic structures were seen
+> — He et al. 2013, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 3481177_17d4bd9d -->
+
+</details>
+
+---
+
+## Results
+
+### Mapping candidates
+
+Two mapping edges are recorded for sdn_poa_calbindin_neuron: a supertype-level edge
+to SUPT_0423 and a cluster-level edge to CLUS_1550, the only child cluster of SUPT_0423
+whose primary soma is MBA:515 (MPN) and which carries an unambiguous male bias.
+Both edges are LOW confidence: SDN-POA is a histologically defined subnucleus within
+MPN that cannot be resolved as a distinct spatial domain in WMBv1 MERFISH data.
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
+|---|---|---|---|---|---|---|
+| 1 | 1550 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1550] | 0423 BST-MPN Six3 Nrgn Gaba_4 | 48 | 🔴 LOW | Calb1 CONSISTENT; MFR=3.35 CONSISTENT; Th DISCORDANT | Speculative |
+| 2 | 0423 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_SUPT_0423] | (self) | 336 | 🔴 LOW | Calb1 CONSISTENT; Th DISCORDANT | Speculative |
+2 edges total. Relationship type: PARTIAL_OVERLAP (CLUS_1550) / UNCERTAIN (SUPT_0423).
+
+### Property alignment — primary candidate (CLUS_1550)
+
+**Table 1 — Property comparison.**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Medial preoptic nucleus [MBA:515] (SDN-POA is histological subnucleus within MPN) | MBA:515 (MPN) n=47; also BNST n=18, AHN n=46, PVN n=31 | MBA:515 (MPN) n=22 (primary soma); also PVH n=9, PVHap n=4, Hypothalamus n=9 | APPROXIMATE (both levels) |
+| Calb1 expression | POSITIVE (protein, primary defining marker) | precomputed mean_expression=6.42 (DEFINING_SCOPED atlas marker) | precomputed mean_expression=6.66 | CONSISTENT (both levels) |
+| Th (negative marker) | ABSENT (negative marker; no TH cell bodies in SDN-POA) | precomputed mean_expression=0.99 | precomputed mean_expression=2.75 | DISCORDANT (both levels) |
+| Sex ratio | male-biased (SDN-POA larger in males; classical IHC) | not available at supertype level | MFR=3.35 (CLUS_1550) — male-biased | CONSISTENT |
+| Annotation transfer F1 | not applicable | NOT_ASSESSED | NOT_ASSESSED | NOT_ASSESSED |
+
+**Table 2 — Evidence support.**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Atlas precomputed expression (CLUS_1550 Calb1/Th, MFR) | Atlas metadata | WEAK | Calb1=6.66; Th=2.75; MFR=3.35; MPN primary soma n=22 | atlas-internal |
+| SUPT_0423 atlas metadata (Calb1/Th, MBA:515 n=47) | Atlas metadata | WEAK | Calb1=6.42 (DEFINING_SCOPED); Th=0.99; MPN n=47 | atlas-internal |
+
+*(1 of an unreported number of child clusters of SUPT_0423 — CLUS_1550 — has MBA:515 (MPN) as primary soma and an unambiguous male-biased MFR; however, Th=2.75 at cluster level remains discordant with the classical Th NEGATIVE assertion, and the SDN-POA cytoarchitectonic zone cannot be resolved within MPN from MERFISH data alone. Best match: CLUS_1550.)*
+
+---
+
+
+
+### 1550 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1550] · 🔴 LOW
+
+### Supporting evidence
+
+- **Calb1 expression is high and concordant.** CLUS_1550 precomputed mean Calb1 = 6.66 directly matches the primary classical defining marker (calbindin-D28K immunoreactivity) [2]. This is the strongest atlas-side signal supporting the mapping.
+- **MPN primary soma is confirmed.** CLUS_1550 has MBA:515 (Medial preoptic nucleus) as its primary soma annotation (n=22 cells), placing the cluster in the broader brain region in which SDN-POA is histologically defined [1], [2].
+- **Sex ratio is concordant and unambiguous.** male_female_ratio = 3.35 in CLUS_1550 — clearly male-biased — directly matches the male-biased dimorphism that defines sdn_poa_calbindin_neuron [1]. CLUS_1550 is the only child cluster of SUPT_0423 with both MPN-primary soma and an unambiguous male bias.
+- **Cluster was identified by targeted child-cluster analysis.** CLUS_1550 emerged from systematic inspection of SUPT_0423 child clusters for an MPN-restricted, male-biased, Calb1-high cluster — the only one matching all three filters.
+
+### Marker evidence provenance
+
+- **Calb1** — classical evidence is protein-level (calbindin-D28K immunohistochemistry, the histological criterion used to delineate SDN-POA from surrounding MPN) [2]. Atlas precomputed value (mean = 6.66) is transcript-based (10x Chromium). The high atlas value is consistent with the protein evidence; no data-source discrepancy. Calb1 is a DEFINING_SCOPED marker at the supertype level (mean = 6.42), confirming Calb1 as a marker shared across SUPT_0423 rather than specific to the SDN-POA subnucleus.
+- **Th (negative marker)** — classical evidence is protein-level: He et al. 2013 explicitly report "no TH-positive cells were found" within the calbindin-delineated SDN-POA [2]. Atlas precomputed Th = 2.75 at CLUS_1550 (transcript-based) is non-zero and discordant with the classical NEGATIVE assertion. The discrepancy is between **classical protein-IHC negative** and **atlas transcript positive at moderate level**. Transcript-level Th may reflect cells outside the SDN-POA cytoarchitectonic zone (PVH/PVHap components of CLUS_1550), or low-abundance transcript not translated to detectable protein. This concern persists at supertype level (Th = 0.99) and is amplified at cluster level (Th = 2.75).
+
+### Concerns
+
+- **SDN-POA is not resolvable as a distinct spatial domain in WMBv1 MERFISH.** SDN-POA is a histologically defined subnucleus within MPN [MBA:515]; WMBv1 MERFISH registers cells to MBA:515 as a whole and cannot distinguish SDN-POA cells from other MPN Calb1+ neurons. Mapping is possible only at MPN level. *(adjacent region — could reflect registration boundary error; weak counter-evidence at the level of SDN-POA-specific identity, but the broader MPN-level placement is correct)*
+- **Th = 2.75 at cluster level is discordant with the Th NEGATIVE classical assertion.** The classical negative-marker call is protein-level (no TH-positive cell bodies in SDN-POA) [2]; the atlas value is transcript-level. CLUS_1550 spans MPN, PVH, and PVHap — Th transcript signal may originate from non-MPN cells within the cluster, but this cannot be confirmed from MERFISH data alone. Spatial inspection of the Th MERFISH channel for CLUS_1550 cells assigned to MBA:515 is needed.
+- **CLUS_1550 is not MPN-restricted.** The cluster spans MBA:515 (MPN) n=22, PVH n=9, PVHap n=4, and Hypothalamus n=9. The MPN-primary soma annotation (n=22) is the largest single-region count, but the cluster as a whole is multi-regional.
+- **Annotation transfer NOT_ASSESSED.** No data-driven cell-level mapping of Calb1+ MPN/SDN-POA scRNA-seq cells to WMBv1 has been run; this is the most important remaining gap in the evidence base for this edge.
+
+### What would upgrade confidence
+
+- **MapMyCells annotation transfer** of an SDN-POA-focused or MPN Calb1+ scRNA-seq dataset against WMBv1 (see Proposed experiments) is the priority experiment. F1 ≥ 0.50 at CLUS_1550 would support upgrading to MODERATE confidence and would add `AnnotationTransferEvidence`.
+- **MERFISH spatial inspection of the Th channel** for CLUS_1550 cells assigned to MBA:515 would resolve whether Th transcript signal originates from MPN cells (refuting the mapping) or from PVH/PVHap components of the cluster (preserving the mapping).
+- **Sub-regional MERFISH spatial analysis** of CLUS_1550 cells within MBA:515 — testing for clustering consistent with the SDN-POA dorsomedial position — would address whether atlas data can recover the histological subnucleus despite the lack of explicit MBA-level annotation.
+
+---
+
+### 0423 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_SUPT_0423] · 🔴 LOW
+
+### Supporting evidence
+
+- **Calb1 is a DEFINING_SCOPED supertype marker.** Precomputed mean Calb1 = 6.42 at SUPT_0423 directly matches the classical primary defining marker [2]. This is the strongest quantitative agreement between classical node and supertype.
+- **MPN cells are present.** n = 47 cells within SUPT_0423 are labelled to Medial preoptic nucleus [MBA:515], providing a direct anatomical anchor for the broader MPN region in which SDN-POA is histologically defined [1], [2].
+- **DB-score rank-1 candidate at supertype level.** SUPT_0423 was the only anatomically plausible rank-1 candidate (DB score = 1) returned by atlas-metadata candidate search for Calb1+ MPN.
+
+### Marker evidence provenance
+
+- **Calb1** — classical evidence is protein-level (calbindin-D28K IHC) [2]; atlas precomputed value is transcript-level (mean = 6.42, DEFINING_SCOPED). The values are concordant; specificity is reduced because Calb1 is widely expressed and is DEFINING_SCOPED rather than DEFINING — i.e. it is a defining marker only within the scope of SUPT_0423, not exclusive to it.
+- **Th (negative marker)** — classical protein-IHC evidence reports no TH-positive cell bodies in SDN-POA [2]. Atlas Th = 0.99 at supertype level is low but non-zero, discordant with the classical NEGATIVE assertion. The discrepancy is amplified at child-cluster level (CLUS_1550 Th = 2.75). Th transcript signal at supertype level may reflect Th-expressing cells in BST/AHN/PVN components of SUPT_0423 rather than MPN-proper cells.
+
+### Concerns
+
+- **Supertype spans BST, MPN, AHN, and PVN.** SUPT_0423 covers MBA:515 (MPN, n=47), BNST (n=18), AHN (n=46), and PVN (n=31). Multiple classical types — not just SDN-POA Calb1 neurons — are expected to map to this same supertype; SDN-POA Calb1 neurons are a subset within the MPN component. *(distant regions — BST, AHN, PVN are anatomically distinct from MPN; this is a significant caveat at supertype level)*
+- **Calb1 alone is insufficient to identify SDN-POA neurons specifically.** Calb1 is expressed across many brain regions and is DEFINING_SCOPED (not DEFINING) in SUPT_0423. The supertype-level Calb1 signal does not discriminate SDN-POA from other MPN Calb1+ populations or from BST/AHN/PVN Calb1+ populations within the supertype.
+- **Th = 0.99 at supertype level is discordant with the Th NEGATIVE classical assertion.** Although low, this contradicts the protein-level IHC evidence [2] that no TH-positive cell bodies exist in SDN-POA. The signal may originate from non-MPN components.
+- **SDN-POA is not resolvable as a subnucleus within MPN in MERFISH data.** Matching is possible only at MPN level; SDN-POA cells cannot be distinguished from other MPN Calb1 neurons.
+- **Sex ratio data not available at supertype level.** Male-biased dimorphism — a defining feature of SDN-POA — cannot be assessed from supertype-level metadata. The signal is visible only in CLUS_1550 (MFR = 3.35).
+- **Annotation transfer NOT_ASSESSED.**
+
+### What would upgrade confidence
+
+- The child-cluster inspection (proposed in this edge) has already been carried out and is captured in the CLUS_1550 edge above.
+- MapMyCells annotation transfer of an SDN-POA-focused or MPN Calb1+ scRNA-seq dataset against WMBv1 — F1 ≥ 0.50 at SUPT_0423 would upgrade this edge; F1 ≥ 0.80 at CLUS_1550 level would support MODERATE confidence on the cluster edge. Expected output: `AnnotationTransferEvidence`.
+- Targeted cite-traverse for studies reporting scRNA-seq of histologically delineated SDN-POA Calb1+ cells from male and female rodents could provide independent transcriptomic confirmation of the supertype assignment and address the Th discrepancy.
+
+---
+
+### Methods
+
+<details>
+<summary>Data sources, analyses, and reproducibility receipts</summary>
+
+**Classical type definition.** See classical type table in Introduction; defining_basis on the classical node and per-property literature support are listed there. The KB-side definition lives at the source graph file linked in the reproducibility footer.
+
+**Atlas mapping query.** Candidate atlas clusters were retrieved from CCN20230722 at ranks 0 (cluster) and 1 (supertype) using metadata-based scoring (region match, NT type, defining markers, sex bias). Full scoring rules: `workflows/map-cell-type.md`.
+
+**Property alignment.** Each defining property was compared to the corresponding atlas-side value via the `property_comparisons` schema; alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side numerical values came from precomputed expression on the cluster (cluster.yaml in the taxonomy reference store) and from MERFISH spatial registration for soma location.
+
+
+
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim literature quotes in this report are validated against the evidencell knowledge base at write time. Authored-prose evidence narratives are validated against their source `evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable identifier or unattributed blockquote.
+
+*Generated by evidencell `0c97cfa` from [`kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`](../../kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+
+</details>
+
+---
+
+## Discussion
+
+**Primary mapping:** → 1550 BST-MPN Six3 Nrgn Gaba_4 [CS20230722_CLUS_1550] at LOW confidence. Key support: ATLAS_METADATA (Calb1=1.6, MFR=3.35 male-biased, Th=2.75 — classical Th-negative criterion violated). Key caveats: `MARKER_NOT_SPECIFIC` (Calb1 expressed broadly; SDN-POA specificity not resolvable from atlas alone) and `Th` discordance.
+
+No Cell Ontology term currently assigned for this classical type.
+
+### Proposed experiments and follow-ups
+
+### 1. MapMyCells annotation transfer of an SDN-POA / MPN Calb1+ scRNA-seq dataset against WMBv1
+
+**What:** Retrieve a published scRNA-seq dataset enriched for MPN Calb1+ cells, ideally a Calb1-Cre or SDN-POA-microdissected preparation from male and female rodents. Run MapMyCells against WMBv1 at cluster resolution.
+
+**Target:** F1 ≥ 0.50 at SUPT_0423 level; F1 ≥ 0.80 at CLUS_1550 level for Calb1+ MPN cells.
+
+**Expected output:** `AnnotationTransferEvidence` entries on both edges (edge_sdn_poa_calbindin_neuron_to_cs20230722_supt_0423 and edge_sdn_poa_calbindin_neuron_to_cs20230722_clus_1550). Atlas: WMBv1. Tool: MapMyCells. Output format: F1 matrix per cluster, fed back as `AnnotationTransferEvidence` YAML.
+
+**Resolves:** Open questions 1 and 3. Confirms or refutes CLUS_1550 as the correct cluster assignment. Addresses the `annotation_transfer_f1` NOT_ASSESSED gap on both edges.
+
+### 2. MERFISH spatial inspection of the Th channel within CLUS_1550 cells at MBA:515
+
+**What:** For CLUS_1550 cells assigned to MBA:515 in WMBv1 MERFISH data, examine the per-cell Th channel intensity. Compare to CLUS_1550 cells in PVH and PVHap.
+
+**Target:** Determination of whether Th transcript signal in CLUS_1550 originates from the MPN component (refuting the SDN-POA mapping at cluster level) or from PVH/PVHap components (preserving the mapping by attributing Th to non-SDN-POA cells within a multi-region cluster).
+
+**Expected output:** Curatorial note attached to the CLUS_1550 edge summarising per-region Th signal; potentially a refined `MarkerAnalysisEvidence` record.
+
+**Resolves:** Open question 1 (Th source within CLUS_1550).
+
+### 3. Sub-regional MERFISH spatial analysis of CLUS_1550 cells within MBA:515
+
+**What:** Within MBA:515, test CLUS_1550 cells for sub-regional clustering consistent with the dorsomedial cytoarchitectonic position of the SDN-POA. Compare cell density and distribution between male and female samples.
+
+**Target:** Detection of a male-biased dorsomedial sub-cluster within MBA:515 cells of CLUS_1550 — the spatial signature of SDN-POA — or formal demonstration that no such sub-cluster exists at MERFISH spatial resolution.
+
+**Expected output:** Curatorial note or, if positive, a refined `MarkerAnalysisEvidence` / spatial-evidence record.
+
+**Resolves:** Open question 2 (sub-regional resolution of SDN-POA within MPN).
+
+---
+
+### Open questions
+
+1. Do CLUS_1550 cells at MBA:515 (MPN) express Th, or does the cluster-level Th=2.75 signal originate from PVH/PVHap components of this multi-region cluster? *(Appears on the cluster edge.)*
+2. Can sub-regional MERFISH spatial data distinguish SDN-POA dorsomedial cells from other MPN Calb1+ neurons within CLUS_1550? *(Appears on the cluster edge; partially shared with the supertype edge.)*
+3. Do any clusters within SUPT_0423 — beyond CLUS_1550 — show peak Calb1 co-located with MBA:515 (MPN) and male-biased sex ratio consistent with SDN-POA identity? *(Appears on the supertype edge; partially addressed by the CLUS_1550 child-cluster analysis but not exhaustively surveyed.)*
+
+---
+
+### Evidence base
+
+| Edge ID | Evidence type | Supports |
+|---|---|---|
+| edge_sdn_poa_calbindin_neuron_to_cs20230722_supt_0423 | ATLAS_METADATA | WEAK — Calb1=6.42 (DEFINING_SCOPED); Th=0.99 (discordant with NEGATIVE); MBA:515 n=47; supertype spans BST/MPN/AHN/PVN |
+| edge_sdn_poa_calbindin_neuron_to_cs20230722_clus_1550 | ATLAS_METADATA | WEAK — Calb1=6.66; Th=2.75 (discordant with NEGATIVE); MBA:515 primary soma n=22; MFR=3.35 (male-biased, concordant); cluster spans MPN/PVH/PVHap |
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | Negri-Cesi 2015 | [PMID:26672480](https://pubmed.ncbi.nlm.nih.gov/26672480/) | Soma location; SDN-POA male-biased dimorphism; INAH homology |
+| [2] | He et al. 2013 | [PMID:25206587](https://pubmed.ncbi.nlm.nih.gov/25206587/) | Soma location; calbindin-D28K defining marker (IHC); Th NEGATIVE marker (no TH cell bodies); cross-species homology |

--- a/research/sexually_dimorphic/refresh_20260608_sdn_poa_calbindin_neuron/refresh_summary.json
+++ b/research/sexually_dimorphic/refresh_20260608_sdn_poa_calbindin_neuron/refresh_summary.json
@@ -1,0 +1,135 @@
+{
+  "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+  "node_id": "sdn_poa_calbindin_neuron",
+  "taxonomy_id": "CCN20230722",
+  "ranks": {
+    "rank0": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_CLUS_1304",
+          "CS20230722_CLUS_1305",
+          "CS20230722_CLUS_1303",
+          "CS20230722_CLUS_1310",
+          "CS20230722_CLUS_1542"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml sdn_poa_calbindin_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_sdn_poa_calbindin_neuron/discovery_candidates_rank0.json",
+          "  emit-stage-b: wrote 5 edge(s) + 5 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 6,
+        "edges_skipped_taxtype_not_in_topk": 1,
+        "skipped_details": [
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_cs20230722_supt_0423",
+            "taxonomy_type": "CS20230722_SUPT_0423"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_cs20230722_clus_1550",
+            "taxonomy_type": "CS20230722_CLUS_1550"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1304",
+            "taxonomy_type": "CS20230722_CLUS_1304"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1305",
+            "taxonomy_type": "CS20230722_CLUS_1305"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1303",
+            "taxonomy_type": "CS20230722_CLUS_1303"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1310",
+            "taxonomy_type": "CS20230722_CLUS_1310"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1542",
+            "taxonomy_type": "CS20230722_CLUS_1542"
+          }
+        ]
+      }
+    },
+    "rank1": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_SUPT_0360",
+          "CS20230722_SUPT_0420",
+          "CS20230722_SUPT_0422",
+          "CS20230722_SUPT_0421",
+          "CS20230722_SUPT_0486"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml sdn_poa_calbindin_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_sdn_poa_calbindin_neuron/discovery_candidates_rank1.json",
+          "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 6,
+        "edges_skipped_taxtype_not_in_topk": 6,
+        "skipped_details": [
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_cs20230722_clus_1550",
+            "taxonomy_type": "CS20230722_CLUS_1550"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1304",
+            "taxonomy_type": "CS20230722_CLUS_1304"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1305",
+            "taxonomy_type": "CS20230722_CLUS_1305"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1303",
+            "taxonomy_type": "CS20230722_CLUS_1303"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1310",
+            "taxonomy_type": "CS20230722_CLUS_1310"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1542",
+            "taxonomy_type": "CS20230722_CLUS_1542"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_cs20230722_supt_0423",
+            "taxonomy_type": "CS20230722_SUPT_0423"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0360",
+            "taxonomy_type": "CS20230722_SUPT_0360"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0420",
+            "taxonomy_type": "CS20230722_SUPT_0420"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0422",
+            "taxonomy_type": "CS20230722_SUPT_0422"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0421",
+            "taxonomy_type": "CS20230722_SUPT_0421"
+          },
+          {
+            "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0486",
+            "taxonomy_type": "CS20230722_SUPT_0486"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/research/sexually_dimorphic/refresh_20260608_stale_audit.md
+++ b/research/sexually_dimorphic/refresh_20260608_stale_audit.md
@@ -1,0 +1,46 @@
+# Stale-location audit — sexually_dimorphic — 20260608
+
+Edges whose `taxonomy_type` is NOT in current Stage A top-50 at the rank that matches the edge target's level.
+(Rank-mismatch skips — e.g. supertype edge skipped at rank-0 cluster refresh — are filtered out; those are not stale.)
+These need curator review — current proximity-aware scoring placed the cluster/supertype outside the candidate pool.
+
+## Stale edges
+
+### avpv_kiss1_neuron (rank0) — `edge_avpv_kiss1_neuron_to_cs20230722_clus_1915`
+
+- **Graph**: `kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`
+- **taxonomy_type**: `CS20230722_CLUS_1915`
+- **Skip reason**: taxonomy_type not in current Stage A top-50 at matching rank
+
+### mpoa_esr1_neuron (rank1) — `edge_mpoa_esr1_neuron_to_cs20230722_supt_0486`
+
+- **Graph**: `kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`
+- **taxonomy_type**: `CS20230722_SUPT_0486`
+- **Skip reason**: taxonomy_type not in current Stage A top-50 at matching rank
+
+### bnst_crf_neuron (rank1) — `edge_bnst_crf_neuron_to_cs20230722_supt_0358`
+
+- **Graph**: `kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`
+- **taxonomy_type**: `CS20230722_SUPT_0358`
+- **Skip reason**: taxonomy_type not in current Stage A top-50 at matching rank
+
+### arc_aromatase_neuron (rank1) — `edge_arc_aromatase_neuron_to_cs20230722_supt_0486`
+
+- **Graph**: `kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`
+- **taxonomy_type**: `CS20230722_SUPT_0486`
+- **Skip reason**: taxonomy_type not in current Stage A top-50 at matching rank
+
+
+## Refresh summary
+
+| Node | Rank0 refreshed / skipped | Rank1 refreshed / skipped |
+|---|---|---|
+| `avpv_kiss1_neuron` | 5 / 7 | 6 / 6 |
+| `avpv_th_neuron` | 6 / 1 | 6 / 6 |
+| `sdn_poa_calbindin_neuron` | 6 / 1 | 6 / 6 |
+| `mpoa_esr1_neuron` | 5 / 2 | 6 / 6 |
+| `vmhvl_esr1_pr_neuron` | 5 / 2 | 7 / 5 |
+| `pvn_crfr1_neuron` | 5 / 1 | 6 / 5 |
+| `bnst_crf_neuron` | 5 / 2 | 6 / 6 |
+| `arc_aromatase_neuron` | 5 / 1 | 5 / 6 |
+| `pmv_otr_neuron` | 6 / 1 | 6 / 6 |

--- a/research/sexually_dimorphic/refresh_20260608_summary.json
+++ b/research/sexually_dimorphic/refresh_20260608_summary.json
@@ -1,0 +1,1223 @@
+[
+  {
+    "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+    "node_id": "avpv_kiss1_neuron",
+    "taxonomy_id": "CCN20230722",
+    "ranks": {
+      "rank0": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_CLUS_1301",
+            "CS20230722_CLUS_1876",
+            "CS20230722_CLUS_1891",
+            "CS20230722_CLUS_1895",
+            "CS20230722_CLUS_1507"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml avpv_kiss1_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_avpv_kiss1_neuron/discovery_candidates_rank0.json",
+            "  emit-stage-b: skipped 5 existing edge(s): edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1301, edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1876, edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1891, edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1895, edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1507",
+            "  emit-stage-b: nothing to write (all edges already present)."
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 5,
+          "edges_skipped_taxtype_not_in_topk": 7,
+          "skipped_details": [
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_cs20230722_supt_0486",
+              "taxonomy_type": "CS20230722_SUPT_0486"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_cs20230722_clus_1915",
+              "taxonomy_type": "CS20230722_CLUS_1915"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0411",
+              "taxonomy_type": "CS20230722_SUPT_0411"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0494",
+              "taxonomy_type": "CS20230722_SUPT_0494"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0550",
+              "taxonomy_type": "CS20230722_SUPT_0550"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0249",
+              "taxonomy_type": "CS20230722_SUPT_0249"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0486",
+              "taxonomy_type": "CS20230722_SUPT_0486"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1301",
+              "taxonomy_type": "CS20230722_CLUS_1301"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1876",
+              "taxonomy_type": "CS20230722_CLUS_1876"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1891",
+              "taxonomy_type": "CS20230722_CLUS_1891"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1895",
+              "taxonomy_type": "CS20230722_CLUS_1895"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1507",
+              "taxonomy_type": "CS20230722_CLUS_1507"
+            }
+          ]
+        }
+      },
+      "rank1": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_SUPT_0411",
+            "CS20230722_SUPT_0494",
+            "CS20230722_SUPT_0550",
+            "CS20230722_SUPT_0249",
+            "CS20230722_SUPT_0486"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml avpv_kiss1_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_avpv_kiss1_neuron/discovery_candidates_rank1.json",
+            "  emit-stage-b: skipped 5 existing edge(s): edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0411, edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0494, edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0550, edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0249, edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0486",
+            "  emit-stage-b: nothing to write (all edges already present)."
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 6,
+          "edges_skipped_taxtype_not_in_topk": 6,
+          "skipped_details": [
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_cs20230722_clus_1915",
+              "taxonomy_type": "CS20230722_CLUS_1915"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1301",
+              "taxonomy_type": "CS20230722_CLUS_1301"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1876",
+              "taxonomy_type": "CS20230722_CLUS_1876"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1891",
+              "taxonomy_type": "CS20230722_CLUS_1891"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1895",
+              "taxonomy_type": "CS20230722_CLUS_1895"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_CLUS_1507",
+              "taxonomy_type": "CS20230722_CLUS_1507"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_cs20230722_supt_0486",
+              "taxonomy_type": "CS20230722_SUPT_0486"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0411",
+              "taxonomy_type": "CS20230722_SUPT_0411"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0494",
+              "taxonomy_type": "CS20230722_SUPT_0494"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0550",
+              "taxonomy_type": "CS20230722_SUPT_0550"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0249",
+              "taxonomy_type": "CS20230722_SUPT_0249"
+            },
+            {
+              "edge_id": "edge_avpv_kiss1_neuron_to_CS20230722_SUPT_0486",
+              "taxonomy_type": "CS20230722_SUPT_0486"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+    "node_id": "avpv_th_neuron",
+    "taxonomy_id": "CCN20230722",
+    "ranks": {
+      "rank0": {
+        "stage_a": {
+          "n_candidates": 10,
+          "top5": [
+            "CS20230722_CLUS_1915",
+            "CS20230722_CLUS_1469",
+            "CS20230722_CLUS_5246",
+            "CS20230722_CLUS_1910",
+            "CS20230722_CLUS_5211"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml avpv_th_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_avpv_th_neuron/discovery_candidates_rank0.json",
+            "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 6,
+          "edges_skipped_taxtype_not_in_topk": 1,
+          "skipped_details": [
+            {
+              "edge_id": "edge_avpv_th_neuron_to_cs20230722_supt_0486",
+              "taxonomy_type": "CS20230722_SUPT_0486"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_avpv_th_neuron_to_cs20230722_clus_1915",
+              "taxonomy_type": "CS20230722_CLUS_1915"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_1915",
+              "taxonomy_type": "CS20230722_CLUS_1915"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_1469",
+              "taxonomy_type": "CS20230722_CLUS_1469"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_5246",
+              "taxonomy_type": "CS20230722_CLUS_5246"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_1910",
+              "taxonomy_type": "CS20230722_CLUS_1910"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_5211",
+              "taxonomy_type": "CS20230722_CLUS_5211"
+            }
+          ]
+        }
+      },
+      "rank1": {
+        "stage_a": {
+          "n_candidates": 12,
+          "top5": [
+            "CS20230722_SUPT_0550",
+            "CS20230722_SUPT_1172",
+            "CS20230722_SUPT_0419",
+            "CS20230722_SUPT_0485",
+            "CS20230722_SUPT_0400"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml avpv_th_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_avpv_th_neuron/discovery_candidates_rank1.json",
+            "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 6,
+          "edges_skipped_taxtype_not_in_topk": 6,
+          "skipped_details": [
+            {
+              "edge_id": "edge_avpv_th_neuron_to_cs20230722_clus_1915",
+              "taxonomy_type": "CS20230722_CLUS_1915"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_1915",
+              "taxonomy_type": "CS20230722_CLUS_1915"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_1469",
+              "taxonomy_type": "CS20230722_CLUS_1469"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_5246",
+              "taxonomy_type": "CS20230722_CLUS_5246"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_1910",
+              "taxonomy_type": "CS20230722_CLUS_1910"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_CLUS_5211",
+              "taxonomy_type": "CS20230722_CLUS_5211"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_avpv_th_neuron_to_cs20230722_supt_0486",
+              "taxonomy_type": "CS20230722_SUPT_0486"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_SUPT_0550",
+              "taxonomy_type": "CS20230722_SUPT_0550"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_SUPT_1172",
+              "taxonomy_type": "CS20230722_SUPT_1172"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_SUPT_0419",
+              "taxonomy_type": "CS20230722_SUPT_0419"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_SUPT_0485",
+              "taxonomy_type": "CS20230722_SUPT_0485"
+            },
+            {
+              "edge_id": "edge_avpv_th_neuron_to_CS20230722_SUPT_0400",
+              "taxonomy_type": "CS20230722_SUPT_0400"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+    "node_id": "sdn_poa_calbindin_neuron",
+    "taxonomy_id": "CCN20230722",
+    "ranks": {
+      "rank0": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_CLUS_1304",
+            "CS20230722_CLUS_1305",
+            "CS20230722_CLUS_1303",
+            "CS20230722_CLUS_1310",
+            "CS20230722_CLUS_1542"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml sdn_poa_calbindin_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_sdn_poa_calbindin_neuron/discovery_candidates_rank0.json",
+            "  emit-stage-b: wrote 5 edge(s) + 5 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 6,
+          "edges_skipped_taxtype_not_in_topk": 1,
+          "skipped_details": [
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_cs20230722_supt_0423",
+              "taxonomy_type": "CS20230722_SUPT_0423"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_cs20230722_clus_1550",
+              "taxonomy_type": "CS20230722_CLUS_1550"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1304",
+              "taxonomy_type": "CS20230722_CLUS_1304"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1305",
+              "taxonomy_type": "CS20230722_CLUS_1305"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1303",
+              "taxonomy_type": "CS20230722_CLUS_1303"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1310",
+              "taxonomy_type": "CS20230722_CLUS_1310"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1542",
+              "taxonomy_type": "CS20230722_CLUS_1542"
+            }
+          ]
+        }
+      },
+      "rank1": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_SUPT_0360",
+            "CS20230722_SUPT_0420",
+            "CS20230722_SUPT_0422",
+            "CS20230722_SUPT_0421",
+            "CS20230722_SUPT_0486"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml sdn_poa_calbindin_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_sdn_poa_calbindin_neuron/discovery_candidates_rank1.json",
+            "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 6,
+          "edges_skipped_taxtype_not_in_topk": 6,
+          "skipped_details": [
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_cs20230722_clus_1550",
+              "taxonomy_type": "CS20230722_CLUS_1550"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1304",
+              "taxonomy_type": "CS20230722_CLUS_1304"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1305",
+              "taxonomy_type": "CS20230722_CLUS_1305"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1303",
+              "taxonomy_type": "CS20230722_CLUS_1303"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1310",
+              "taxonomy_type": "CS20230722_CLUS_1310"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_CLUS_1542",
+              "taxonomy_type": "CS20230722_CLUS_1542"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_cs20230722_supt_0423",
+              "taxonomy_type": "CS20230722_SUPT_0423"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0360",
+              "taxonomy_type": "CS20230722_SUPT_0360"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0420",
+              "taxonomy_type": "CS20230722_SUPT_0420"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0422",
+              "taxonomy_type": "CS20230722_SUPT_0422"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0421",
+              "taxonomy_type": "CS20230722_SUPT_0421"
+            },
+            {
+              "edge_id": "edge_sdn_poa_calbindin_neuron_to_CS20230722_SUPT_0486",
+              "taxonomy_type": "CS20230722_SUPT_0486"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+    "node_id": "mpoa_esr1_neuron",
+    "taxonomy_id": "CCN20230722",
+    "ranks": {
+      "rank0": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_CLUS_1466",
+            "CS20230722_CLUS_1536",
+            "CS20230722_CLUS_1885",
+            "CS20230722_CLUS_1887",
+            "CS20230722_CLUS_2118"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml mpoa_esr1_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_mpoa_esr1_neuron/discovery_candidates_rank0.json",
+            "  emit-stage-b: wrote 5 edge(s) + 5 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 5,
+          "edges_skipped_taxtype_not_in_topk": 2,
+          "skipped_details": [
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_cs20230722_supt_0486",
+              "taxonomy_type": "CS20230722_SUPT_0486"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_cs20230722_supt_0521",
+              "taxonomy_type": "CS20230722_SUPT_0521"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1466",
+              "taxonomy_type": "CS20230722_CLUS_1466"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1536",
+              "taxonomy_type": "CS20230722_CLUS_1536"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1885",
+              "taxonomy_type": "CS20230722_CLUS_1885"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1887",
+              "taxonomy_type": "CS20230722_CLUS_1887"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_2118",
+              "taxonomy_type": "CS20230722_CLUS_2118"
+            }
+          ]
+        }
+      },
+      "rank1": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_SUPT_0419",
+            "CS20230722_SUPT_0403",
+            "CS20230722_SUPT_0401",
+            "CS20230722_SUPT_0348",
+            "CS20230722_SUPT_0398"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml mpoa_esr1_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_mpoa_esr1_neuron/discovery_candidates_rank1.json",
+            "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 6,
+          "edges_skipped_taxtype_not_in_topk": 6,
+          "skipped_details": [
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_cs20230722_supt_0486",
+              "taxonomy_type": "CS20230722_SUPT_0486"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1466",
+              "taxonomy_type": "CS20230722_CLUS_1466"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1536",
+              "taxonomy_type": "CS20230722_CLUS_1536"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1885",
+              "taxonomy_type": "CS20230722_CLUS_1885"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_1887",
+              "taxonomy_type": "CS20230722_CLUS_1887"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_CLUS_2118",
+              "taxonomy_type": "CS20230722_CLUS_2118"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_cs20230722_supt_0521",
+              "taxonomy_type": "CS20230722_SUPT_0521"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0419",
+              "taxonomy_type": "CS20230722_SUPT_0419"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0403",
+              "taxonomy_type": "CS20230722_SUPT_0403"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0401",
+              "taxonomy_type": "CS20230722_SUPT_0401"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0348",
+              "taxonomy_type": "CS20230722_SUPT_0348"
+            },
+            {
+              "edge_id": "edge_mpoa_esr1_neuron_to_CS20230722_SUPT_0398",
+              "taxonomy_type": "CS20230722_SUPT_0398"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+    "node_id": "vmhvl_esr1_pr_neuron",
+    "taxonomy_id": "CCN20230722",
+    "ranks": {
+      "rank0": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_CLUS_2290",
+            "CS20230722_CLUS_2292",
+            "CS20230722_CLUS_1959",
+            "CS20230722_CLUS_2295",
+            "CS20230722_CLUS_2297"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml vmhvl_esr1_pr_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_vmhvl_esr1_pr_neuron/discovery_candidates_rank0.json",
+            "  emit-stage-b: wrote 5 edge(s) + 5 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 5,
+          "edges_skipped_taxtype_not_in_topk": 2,
+          "skipped_details": [
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564",
+              "taxonomy_type": "CS20230722_SUPT_0564"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563",
+              "taxonomy_type": "CS20230722_SUPT_0563"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2290",
+              "taxonomy_type": "CS20230722_CLUS_2290"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2292",
+              "taxonomy_type": "CS20230722_CLUS_2292"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_1959",
+              "taxonomy_type": "CS20230722_CLUS_1959"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2295",
+              "taxonomy_type": "CS20230722_CLUS_2295"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2297",
+              "taxonomy_type": "CS20230722_CLUS_2297"
+            }
+          ]
+        }
+      },
+      "rank1": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_SUPT_0557",
+            "CS20230722_SUPT_0563",
+            "CS20230722_SUPT_0439",
+            "CS20230722_SUPT_0569",
+            "CS20230722_SUPT_0568"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml vmhvl_esr1_pr_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_vmhvl_esr1_pr_neuron/discovery_candidates_rank1.json",
+            "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 7,
+          "edges_skipped_taxtype_not_in_topk": 5,
+          "skipped_details": [
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2290",
+              "taxonomy_type": "CS20230722_CLUS_2290"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2292",
+              "taxonomy_type": "CS20230722_CLUS_2292"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_1959",
+              "taxonomy_type": "CS20230722_CLUS_1959"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2295",
+              "taxonomy_type": "CS20230722_CLUS_2295"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2297",
+              "taxonomy_type": "CS20230722_CLUS_2297"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564",
+              "taxonomy_type": "CS20230722_SUPT_0564"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563",
+              "taxonomy_type": "CS20230722_SUPT_0563"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0557",
+              "taxonomy_type": "CS20230722_SUPT_0557"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0563",
+              "taxonomy_type": "CS20230722_SUPT_0563"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0439",
+              "taxonomy_type": "CS20230722_SUPT_0439"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0569",
+              "taxonomy_type": "CS20230722_SUPT_0569"
+            },
+            {
+              "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0568",
+              "taxonomy_type": "CS20230722_SUPT_0568"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+    "node_id": "pvn_crfr1_neuron",
+    "taxonomy_id": "CCN20230722",
+    "ranks": {
+      "rank0": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_CLUS_2366",
+            "CS20230722_CLUS_1549",
+            "CS20230722_CLUS_1550",
+            "CS20230722_CLUS_1561",
+            "CS20230722_CLUS_1563"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml pvn_crfr1_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_pvn_crfr1_neuron/discovery_candidates_rank0.json",
+            "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 5,
+          "edges_skipped_taxtype_not_in_topk": 1,
+          "skipped_details": [
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_cs20230722_supt_0585",
+              "taxonomy_type": "CS20230722_SUPT_0585"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_2366",
+              "taxonomy_type": "CS20230722_CLUS_2366"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1549",
+              "taxonomy_type": "CS20230722_CLUS_1549"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1550",
+              "taxonomy_type": "CS20230722_CLUS_1550"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1561",
+              "taxonomy_type": "CS20230722_CLUS_1561"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1563",
+              "taxonomy_type": "CS20230722_CLUS_1563"
+            }
+          ]
+        }
+      },
+      "rank1": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_SUPT_0585",
+            "CS20230722_SUPT_0587",
+            "CS20230722_SUPT_0586",
+            "CS20230722_SUPT_0414",
+            "CS20230722_SUPT_0486"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml pvn_crfr1_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_pvn_crfr1_neuron/discovery_candidates_rank1.json",
+            "  emit-stage-b: wrote 5 edge(s) + 3 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 6,
+          "edges_skipped_taxtype_not_in_topk": 5,
+          "skipped_details": [
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_2366",
+              "taxonomy_type": "CS20230722_CLUS_2366"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1549",
+              "taxonomy_type": "CS20230722_CLUS_1549"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1550",
+              "taxonomy_type": "CS20230722_CLUS_1550"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1561",
+              "taxonomy_type": "CS20230722_CLUS_1561"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_CLUS_1563",
+              "taxonomy_type": "CS20230722_CLUS_1563"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_cs20230722_supt_0585",
+              "taxonomy_type": "CS20230722_SUPT_0585"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0585",
+              "taxonomy_type": "CS20230722_SUPT_0585"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0587",
+              "taxonomy_type": "CS20230722_SUPT_0587"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0586",
+              "taxonomy_type": "CS20230722_SUPT_0586"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0414",
+              "taxonomy_type": "CS20230722_SUPT_0414"
+            },
+            {
+              "edge_id": "edge_pvn_crfr1_neuron_to_CS20230722_SUPT_0486",
+              "taxonomy_type": "CS20230722_SUPT_0486"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+    "node_id": "bnst_crf_neuron",
+    "taxonomy_id": "CCN20230722",
+    "ranks": {
+      "rank0": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_CLUS_1409",
+            "CS20230722_CLUS_1410",
+            "CS20230722_CLUS_1475",
+            "CS20230722_CLUS_1476",
+            "CS20230722_CLUS_1499"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml bnst_crf_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_bnst_crf_neuron/discovery_candidates_rank0.json",
+            "  emit-stage-b: wrote 5 edge(s) + 5 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 5,
+          "edges_skipped_taxtype_not_in_topk": 2,
+          "skipped_details": [
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_cs20230722_supt_0393",
+              "taxonomy_type": "CS20230722_SUPT_0393"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_cs20230722_supt_0358",
+              "taxonomy_type": "CS20230722_SUPT_0358"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1409",
+              "taxonomy_type": "CS20230722_CLUS_1409"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1410",
+              "taxonomy_type": "CS20230722_CLUS_1410"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1475",
+              "taxonomy_type": "CS20230722_CLUS_1475"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1476",
+              "taxonomy_type": "CS20230722_CLUS_1476"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1499",
+              "taxonomy_type": "CS20230722_CLUS_1499"
+            }
+          ]
+        }
+      },
+      "rank1": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_SUPT_0410",
+            "CS20230722_SUPT_0393",
+            "CS20230722_SUPT_0343",
+            "CS20230722_SUPT_0379",
+            "CS20230722_SUPT_0383"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml bnst_crf_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_bnst_crf_neuron/discovery_candidates_rank1.json",
+            "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 6,
+          "edges_skipped_taxtype_not_in_topk": 6,
+          "skipped_details": [
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_cs20230722_supt_0358",
+              "taxonomy_type": "CS20230722_SUPT_0358"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1409",
+              "taxonomy_type": "CS20230722_CLUS_1409"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1410",
+              "taxonomy_type": "CS20230722_CLUS_1410"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1475",
+              "taxonomy_type": "CS20230722_CLUS_1475"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1476",
+              "taxonomy_type": "CS20230722_CLUS_1476"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_CLUS_1499",
+              "taxonomy_type": "CS20230722_CLUS_1499"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_cs20230722_supt_0393",
+              "taxonomy_type": "CS20230722_SUPT_0393"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_SUPT_0410",
+              "taxonomy_type": "CS20230722_SUPT_0410"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_SUPT_0393",
+              "taxonomy_type": "CS20230722_SUPT_0393"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_SUPT_0343",
+              "taxonomy_type": "CS20230722_SUPT_0343"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_SUPT_0379",
+              "taxonomy_type": "CS20230722_SUPT_0379"
+            },
+            {
+              "edge_id": "edge_bnst_crf_neuron_to_CS20230722_SUPT_0383",
+              "taxonomy_type": "CS20230722_SUPT_0383"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+    "node_id": "arc_aromatase_neuron",
+    "taxonomy_id": "CCN20230722",
+    "ranks": {
+      "rank0": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_CLUS_5303",
+            "CS20230722_CLUS_1569",
+            "CS20230722_CLUS_1570",
+            "CS20230722_CLUS_1571",
+            "CS20230722_CLUS_1683"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml arc_aromatase_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_arc_aromatase_neuron/discovery_candidates_rank0.json",
+            "  emit-stage-b: wrote 5 edge(s) + 5 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 5,
+          "edges_skipped_taxtype_not_in_topk": 1,
+          "skipped_details": [
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_cs20230722_supt_0486",
+              "taxonomy_type": "CS20230722_SUPT_0486"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_5303",
+              "taxonomy_type": "CS20230722_CLUS_5303"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1569",
+              "taxonomy_type": "CS20230722_CLUS_1569"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1570",
+              "taxonomy_type": "CS20230722_CLUS_1570"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1571",
+              "taxonomy_type": "CS20230722_CLUS_1571"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1683",
+              "taxonomy_type": "CS20230722_CLUS_1683"
+            }
+          ]
+        }
+      },
+      "rank1": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_SUPT_1190",
+            "CS20230722_SUPT_1173",
+            "CS20230722_SUPT_1174",
+            "CS20230722_SUPT_0427",
+            "CS20230722_SUPT_0495"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml arc_aromatase_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_arc_aromatase_neuron/discovery_candidates_rank1.json",
+            "  emit-stage-b: wrote 5 edge(s) + 5 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 5,
+          "edges_skipped_taxtype_not_in_topk": 6,
+          "skipped_details": [
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_cs20230722_supt_0486",
+              "taxonomy_type": "CS20230722_SUPT_0486"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_5303",
+              "taxonomy_type": "CS20230722_CLUS_5303"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1569",
+              "taxonomy_type": "CS20230722_CLUS_1569"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1570",
+              "taxonomy_type": "CS20230722_CLUS_1570"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1571",
+              "taxonomy_type": "CS20230722_CLUS_1571"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_CLUS_1683",
+              "taxonomy_type": "CS20230722_CLUS_1683"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_SUPT_1190",
+              "taxonomy_type": "CS20230722_SUPT_1190"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_SUPT_1173",
+              "taxonomy_type": "CS20230722_SUPT_1173"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_SUPT_1174",
+              "taxonomy_type": "CS20230722_SUPT_1174"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_SUPT_0427",
+              "taxonomy_type": "CS20230722_SUPT_0427"
+            },
+            {
+              "edge_id": "edge_arc_aromatase_neuron_to_CS20230722_SUPT_0495",
+              "taxonomy_type": "CS20230722_SUPT_0495"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+    "node_id": "pmv_otr_neuron",
+    "taxonomy_id": "CCN20230722",
+    "ranks": {
+      "rank0": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_CLUS_2471",
+            "CS20230722_CLUS_2470",
+            "CS20230722_CLUS_2314",
+            "CS20230722_CLUS_2575",
+            "CS20230722_CLUS_2395"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml pmv_otr_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_pmv_otr_neuron/discovery_candidates_rank0.json",
+            "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 6,
+          "edges_skipped_taxtype_not_in_topk": 1,
+          "skipped_details": [
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_cs20230722_supt_0607",
+              "taxonomy_type": "CS20230722_SUPT_0607"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_cs20230722_clus_2470",
+              "taxonomy_type": "CS20230722_CLUS_2470"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2471",
+              "taxonomy_type": "CS20230722_CLUS_2471"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2470",
+              "taxonomy_type": "CS20230722_CLUS_2470"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2314",
+              "taxonomy_type": "CS20230722_CLUS_2314"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2575",
+              "taxonomy_type": "CS20230722_CLUS_2575"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2395",
+              "taxonomy_type": "CS20230722_CLUS_2395"
+            }
+          ]
+        }
+      },
+      "rank1": {
+        "stage_a": {
+          "n_candidates": 50,
+          "top5": [
+            "CS20230722_SUPT_0607",
+            "CS20230722_SUPT_0605",
+            "CS20230722_SUPT_0557",
+            "CS20230722_SUPT_0429",
+            "CS20230722_SUPT_0430"
+          ]
+        },
+        "emit_b": {
+          "last_lines": [
+            "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml pmv_otr_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_pmv_otr_neuron/discovery_candidates_rank1.json",
+            "  emit-stage-b: wrote 5 edge(s) + 3 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+          ]
+        },
+        "refresh_pc": {
+          "edges_refreshed": 6,
+          "edges_skipped_taxtype_not_in_topk": 6,
+          "skipped_details": [
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_cs20230722_clus_2470",
+              "taxonomy_type": "CS20230722_CLUS_2470"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2471",
+              "taxonomy_type": "CS20230722_CLUS_2471"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2470",
+              "taxonomy_type": "CS20230722_CLUS_2470"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2314",
+              "taxonomy_type": "CS20230722_CLUS_2314"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2575",
+              "taxonomy_type": "CS20230722_CLUS_2575"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_CLUS_2395",
+              "taxonomy_type": "CS20230722_CLUS_2395"
+            }
+          ],
+          "refreshed_details": [
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_cs20230722_supt_0607",
+              "taxonomy_type": "CS20230722_SUPT_0607"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_SUPT_0607",
+              "taxonomy_type": "CS20230722_SUPT_0607"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_SUPT_0605",
+              "taxonomy_type": "CS20230722_SUPT_0605"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_SUPT_0557",
+              "taxonomy_type": "CS20230722_SUPT_0557"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_SUPT_0429",
+              "taxonomy_type": "CS20230722_SUPT_0429"
+            },
+            {
+              "edge_id": "edge_pmv_otr_neuron_to_CS20230722_SUPT_0430",
+              "taxonomy_type": "CS20230722_SUPT_0430"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/research/sexually_dimorphic/refresh_20260608_vmhvl_esr1_pr_neuron/discovery_candidates_rank0.json
+++ b/research/sexually_dimorphic/refresh_20260608_vmhvl_esr1_pr_neuron/discovery_candidates_rank0.json
@@ -1,0 +1,3143 @@
+{
+  "classical_node_id": "vmhvl_esr1_pr_neuron",
+  "classical_node_name": "VMHvl estrogen-receptor alpha / progesterone receptor neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 0,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_CLUS_2290",
+      "label": "2290 VMH Fezf1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0563",
+      "male_female_ratio": 0.08,
+      "discovery_score": {
+        "score": 7,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 6.69,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.989
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 6.07,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.901
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.317,
+        "region_fraction_100um": 0.817,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2292",
+      "label": "2292 VMH Fezf1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0563",
+      "male_female_ratio": 0.12,
+      "discovery_score": {
+        "score": 7,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 6.28,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.949
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 8.62,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.964
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.5,
+        "region_fraction_100um": 1.0,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1959",
+      "label": "1959 DMH Hmx2 Gaba_6",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0492",
+      "male_female_ratio": 1.78,
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 0.26,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.423
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.36,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.321
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.189,
+        "region_fraction_100um": 0.522,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2295",
+      "label": "2295 VMH Fezf1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0564",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 6.16,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.942
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 1.87,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.752
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.742,
+        "region_fraction_100um": 0.889,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2297",
+      "label": "2297 VMH Fezf1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0564",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 3.8,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.763
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 1.45,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.73
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.455,
+        "region_fraction_100um": 0.737,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2299",
+      "label": "2299 VMH Fezf1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0565",
+      "male_female_ratio": 3.17,
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 5.29,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.869
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 4.15,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.836
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.468,
+        "region_fraction_100um": 0.83,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2291",
+      "label": "2291 VMH Fezf1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0563",
+      "male_female_ratio": 1.27,
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.43,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.971
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 4.0,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.832
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.565,
+        "region_fraction_100um": 0.848,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2293",
+      "label": "2293 VMH Fezf1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0563",
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 7.12,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.993
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 7.24,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.942
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.13,
+        "region_fraction_100um": 0.67,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2300",
+      "label": "2300 VMH Fezf1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0565",
+      "male_female_ratio": 0.92,
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 5.92,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.923
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 6.71,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.912
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.492,
+        "region_fraction_100um": 0.758,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2313",
+      "label": "2313 VMH Nr5a1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0568",
+      "male_female_ratio": 1.94,
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.56,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.982
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 3.31,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.814
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.816,
+        "region_fraction_100um": 0.946,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2316",
+      "label": "2316 VMH Nr5a1 Glut_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0569",
+      "male_female_ratio": 2.23,
+      "discovery_score": {
+        "score": 6,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.41,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.964
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.19,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.117
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.86,
+        "region_fraction_100um": 0.978,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1569",
+      "label": "1569 ARH-PVi Six6 Dopa-Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Dopa",
+      "parent_id": "CS20230722_SUPT_0427",
+      "male_female_ratio": 0.96,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.39,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.5
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.38,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.354
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.211,
+        "region_fraction_100um": 0.579,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1575",
+      "label": "1575 TMv-PMv Tbx3 Hist-Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Hist",
+      "parent_id": "CS20230722_SUPT_0429",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 1.61,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.617
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 3.24,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.81
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.151,
+        "region_fraction_100um": 0.585,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1620",
+      "label": "1620 DMH Prdm13 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0439",
+      "male_female_ratio": 1.78,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.47,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.978
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.55,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.551
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.152,
+        "region_fraction_100um": 0.364,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1621",
+      "label": "1621 DMH Prdm13 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0439",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.36,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.96
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.21,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.139
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.017,
+        "region_fraction_100um": 0.121,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1788",
+      "label": "1788 DMH-LHA Gsx1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0470",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.28,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.445
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.41,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.42
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.211,
+        "region_fraction_100um": 0.537,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1791",
+      "label": "1791 DMH-LHA Gsx1 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0470",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 1.97,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.642
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 1.35,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.723
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.081,
+        "region_fraction_100um": 0.548,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1810",
+      "label": "1810 DMH-LHA Gsx1 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Chol",
+      "parent_id": "CS20230722_SUPT_0472",
+      "male_female_ratio": 1.27,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 0.41,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.515
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.29,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.252
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.112,
+        "region_fraction_100um": 0.366,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1813",
+      "label": "1813 DMH-LHA Gsx1 Gaba_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0473",
+      "male_female_ratio": 1.17,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 0.17,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.347
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.42,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.427
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.1,
+        "region_fraction_100um": 0.174,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1838",
+      "label": "1838 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0478",
+      "male_female_ratio": 0.92,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 0.26,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.423
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.17,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.095
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.018,
+        "region_fraction_100um": 0.125,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1839",
+      "label": "1839 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0478",
+      "male_female_ratio": 1.94,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.18,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.369
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.36,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.321
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.327,
+        "region_fraction_100um": 0.631,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1851",
+      "label": "1851 TU-ARH Otp Six6 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0479",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 1.31,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.584
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.43,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.453
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.268,
+        "region_fraction_100um": 0.695,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1852",
+      "label": "1852 TU-ARH Otp Six6 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0479",
+      "male_female_ratio": 1.63,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 2.45,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.657
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.29,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.252
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.138,
+        "region_fraction_100um": 0.572,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1853",
+      "label": "1853 TU-ARH Otp Six6 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0480",
+      "male_female_ratio": 1.17,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 1.84,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.635
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.38,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.354
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.339,
+        "region_fraction_100um": 0.679,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1857",
+      "label": "1857 TU-ARH Otp Six6 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0480",
+      "male_female_ratio": 1.08,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 1.37,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.595
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.57,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.562
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.182,
+        "region_fraction_100um": 0.591,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1864",
+      "label": "1864 TMd-DMH Foxd2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0481",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.26,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.423
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 8.91,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.967
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.034,
+        "region_fraction_100um": 0.224,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1866",
+      "label": "1866 TMd-DMH Foxd2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0481",
+      "male_female_ratio": 1.38,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.18,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.369
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 9.07,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.974
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.051,
+        "region_fraction_100um": 0.128,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1918",
+      "label": "1918 DMH Hmx2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0487",
+      "male_female_ratio": 1.78,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.21,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.401
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 8.5,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.956
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.073,
+        "region_fraction_100um": 0.255,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1919",
+      "label": "1919 DMH Hmx2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0487",
+      "male_female_ratio": 2.33,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.38,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.489
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 4.16,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.839
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.455,
+        "region_fraction_100um": 0.758,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1927",
+      "label": "1927 DMH Hmx2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0487",
+      "male_female_ratio": 1.27,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.21,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.401
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 9.79,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.993
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.258,
+        "region_fraction_100um": 0.468,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1923",
+      "label": "1923 DMH Hmx2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0487",
+      "male_female_ratio": 1.5,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 0.18,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.369
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.18,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.109
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.018,
+        "region_fraction_100um": 0.107,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1925",
+      "label": "1925 DMH Hmx2 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0487",
+      "male_female_ratio": 1.08,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 0.14,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.314
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.32,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.281
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.046,
+        "region_fraction_100um": 0.154,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1936",
+      "label": "1936 DMH Hmx2 Gaba_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0488",
+      "male_female_ratio": 1.33,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.7,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.544
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 4.33,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.847
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.122,
+        "region_fraction_100um": 0.512,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1961",
+      "label": "1961 ARH-PVp Tbx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0493",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 4.39,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.785
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.78,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.642
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.052,
+        "region_fraction_100um": 0.271,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1963",
+      "label": "1963 ARH-PVp Tbx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0493",
+      "male_female_ratio": 1.7,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.35,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.956
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.47,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.496
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.159,
+        "region_fraction_100um": 0.413,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1964",
+      "label": "1964 ARH-PVp Tbx3 Gaba_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0493",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 1.79,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.631
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 5.85,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.894
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.2,
+        "region_fraction_100um": 0.576,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_1969",
+      "label": "1969 ARH-PVp Tbx3 Gaba_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "GABA",
+      "parent_id": "CS20230722_SUPT_0495",
+      "male_female_ratio": 1.27,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 3.03,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.69
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.4,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.398
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.165,
+        "region_fraction_100um": 0.588,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2229",
+      "label": "2229 DMH Nkx2-4 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0545",
+      "male_female_ratio": 1.44,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 5.77,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.909
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.61,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.584
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.343,
+        "region_fraction_100um": 0.605,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2263",
+      "label": "2263 DMH Hmx2 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut-GABA",
+      "parent_id": "CS20230722_SUPT_0552",
+      "male_female_ratio": 1.22,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 4.55,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.81
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 5.48,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.88
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.132,
+        "region_fraction_100um": 0.596,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2265",
+      "label": "2265 DMH Hmx2 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0552",
+      "male_female_ratio": 1.5,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 5.84,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.916
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 5.43,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.876
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.438,
+        "region_fraction_100um": 0.75,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2266",
+      "label": "2266 DMH Hmx2 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0552",
+      "male_female_ratio": 2.03,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 1.33,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.588
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 5.17,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.861
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.042,
+        "region_fraction_100um": 0.5,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2273",
+      "label": "2273 DMH Hmx2 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0553",
+      "male_female_ratio": 2.45,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.17,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.347
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 3.53,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.821
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.158,
+        "region_fraction_100um": 0.632,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2275",
+      "label": "2275 ARH-PVp Tbx3 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0554",
+      "male_female_ratio": 0.47,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 5.88,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.92
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 1.03,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.69
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.417,
+        "region_fraction_100um": 0.75,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2279",
+      "label": "2279 ARH-PVp Tbx3 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut-GABA",
+      "parent_id": "CS20230722_SUPT_0555",
+      "male_female_ratio": 1.13,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 5.65,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.901
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.48,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.504
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.141,
+        "region_fraction_100um": 0.439,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2272",
+      "label": "2272 DMH Hmx2 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0553",
+      "male_female_ratio": 1.78,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.15,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.321
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.33,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.296
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.273,
+        "region_fraction_100um": 0.758,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2280",
+      "label": "2280 ARH-PVp Tbx3 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0555",
+      "male_female_ratio": 1.0,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Esr1",
+            "val": null,
+            "reliable": null,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "METADATA",
+            "percentiles": []
+          },
+          {
+            "gene": "Nkx2-1",
+            "val": 5.12,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.85
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.45,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.467
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.078,
+        "region_fraction_100um": 0.277,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2283",
+      "label": "2283 ARH-PVp Tbx3 Glut_4",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0557",
+      "male_female_ratio": 1.27,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.11,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.938
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 7.16,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.931
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.483,
+        "region_fraction_100um": 0.808,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2296",
+      "label": "2296 VMH Fezf1 Glut_2",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0564",
+      "male_female_ratio": 1.94,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.21,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.945
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 1.73,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.741
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.471,
+        "region_fraction_100um": 0.758,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2298",
+      "label": "2298 VMH Fezf1 Glut_3",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0565",
+      "male_female_ratio": 1.7,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.0,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.931
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.81,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.65
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.265,
+        "region_fraction_100um": 0.776,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_CLUS_2301",
+      "label": "2301 VMH Nr5a1 Glut_1",
+      "taxonomy_level": "cluster",
+      "taxonomy_rank": 0,
+      "nt_type": "Glut",
+      "parent_id": "CS20230722_SUPT_0566",
+      "male_female_ratio": 0.96,
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 0,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 0,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.1,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.934
+              }
+            ]
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.54,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.54
+              }
+            ]
+          }
+        ],
+        "region_fraction": 0.433,
+        "region_fraction_100um": 0.767,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_vmhvl_esr1_pr_neuron/discovery_candidates_rank1.json
+++ b/research/sexually_dimorphic/refresh_20260608_vmhvl_esr1_pr_neuron/discovery_candidates_rank1.json
@@ -1,0 +1,3059 @@
+{
+  "classical_node_id": "vmhvl_esr1_pr_neuron",
+  "classical_node_name": "VMHvl estrogen-receptor alpha / progesterone receptor neuron",
+  "taxonomy_id": "CCN20230722",
+  "rank": 1,
+  "n_candidates": 50,
+  "candidates": [
+    {
+      "node_id": "CS20230722_SUPT_0557",
+      "label": "0557 ARH-PVp Tbx3 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 7,
+        "rank_in_cohort": 1,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.11,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.969
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 7.16,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.979
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.483,
+        "region_fraction_100um": 0.808,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0563",
+      "label": "0563 VMH Fezf1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_128",
+      "discovery_score": {
+        "score": 7,
+        "rank_in_cohort": 2,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.63,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.99
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 6.48,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.969
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.424,
+        "region_fraction_100um": 0.712,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0439",
+      "label": "0439 DMH Prdm13 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_095",
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 3,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 5.92,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.959
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.36,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.309
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.056,
+        "region_fraction_100um": 0.151,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0569",
+      "label": "0569 VMH Nr5a1 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_129",
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 4,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 4.96,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.866
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 1.52,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.68
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.756,
+        "region_fraction_100um": 0.913,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0568",
+      "label": "0568 VMH Nr5a1 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_129",
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 5,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 3.49,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.732
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 1.83,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.722
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.779,
+        "region_fraction_100um": 0.898,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0565",
+      "label": "0565 VMH Fezf1 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_128",
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 6,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 5.74,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.928
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 3.89,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.897
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.443,
+        "region_fraction_100um": 0.789,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0564",
+      "label": "0564 VMH Fezf1 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_128",
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 7,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 5.34,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.887
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 1.39,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.67
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.581,
+        "region_fraction_100um": 0.795,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0571",
+      "label": "0571 VMH Nr5a1 Glut_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_129",
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 8,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 3.52,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.742
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.3,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.144
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.495,
+        "region_fraction_100um": 0.958,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0570",
+      "label": "0570 VMH Nr5a1 Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_129",
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 9,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 2.87,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.649
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 2.04,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.773
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.487,
+        "region_fraction_100um": 0.815,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0553",
+      "label": "0553 DMH Hmx2 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_125",
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 10,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.16,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.33
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 1.93,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.742
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.221,
+        "region_fraction_100um": 0.712,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0545",
+      "label": "0545 DMH Nkx2-4 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_123",
+      "discovery_score": {
+        "score": 5,
+        "rank_in_cohort": 11,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 4.87,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.856
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.61,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.526
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.34,
+        "region_fraction_100um": 0.598,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0427",
+      "label": "0427 ARH-PVi Six6 Dopa-Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_091",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 12,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.21,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.816,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.392
+              }
+            ],
+            "coverage": 0.667
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.31,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.186
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.168,
+        "region_fraction_100um": 0.552,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0572",
+      "label": "0572 LHA Pmch Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_130",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 13,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 6.35,
+            "reliable": true,
+            "raw_tier": 2,
+            "applied_score": 2.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.979
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.57,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.485
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.01,
+        "region_fraction_100um": 0.026,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0440",
+      "label": "0440 DMH Prdm13 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_095",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 14,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 5.74,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.928
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.34,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.258
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.024,
+        "region_fraction_100um": 0.212,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0429",
+      "label": "0429 TMv-PMv Tbx3 Hist-Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_092",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 15,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 3.29,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.68
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 4.9,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.948
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.09,
+        "region_fraction_100um": 0.142,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0430",
+      "label": "0430 TMv-PMv Tbx3 Hist-Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_092",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 16,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.38,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.433
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 3.75,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.866
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.157,
+        "region_fraction_100um": 0.365,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0495",
+      "label": "0495 ARH-PVp Tbx3 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_108",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 17,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 4.62,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.804
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.71,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.577
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.132,
+        "region_fraction_100um": 0.419,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0493",
+      "label": "0493 ARH-PVp Tbx3 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_108",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 18,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 4.52,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.794
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 2.02,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.763
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.089,
+        "region_fraction_100um": 0.32,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0492",
+      "label": "0492 DMH Hmx2 Gaba_6",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 19,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.39,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.443
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.33,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.237
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.152,
+        "region_fraction_100um": 0.444,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0473",
+      "label": "0473 DMH-LHA Gsx1 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_102",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 20,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.67,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.526
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.37,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.32
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.095,
+        "region_fraction_100um": 0.198,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0472",
+      "label": "0472 DMH-LHA Gsx1 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_102",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 21,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.41,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.464
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.29,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.134
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.112,
+        "region_fraction_100um": 0.366,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0470",
+      "label": "0470 DMH-LHA Gsx1 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_102",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 22,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 2.1,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.598
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.47,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.402
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.091,
+        "region_fraction_100um": 0.365,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0567",
+      "label": "0567 VMH Nr5a1 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_129",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 23,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 3.35,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.711
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 4.64,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.928
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.16,
+        "region_fraction_100um": 0.296,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0566",
+      "label": "0566 VMH Nr5a1 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_129",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 24,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 2.19,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.608
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 1.21,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.66
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.133,
+        "region_fraction_100um": 0.208,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0573",
+      "label": "0573 LHA Pmch Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_130",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 25,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 5.36,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.897
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.5,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.443
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.056,
+        "region_fraction_100um": 0.148,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0558",
+      "label": "0558 ARH-PVp Tbx3 Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 26,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 3.29,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.68
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.4,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.33
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.191,
+        "region_fraction_100um": 0.345,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0556",
+      "label": "0556 ARH-PVp Tbx3 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 27,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 4.69,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.825
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.32,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.216
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.06,
+        "region_fraction_100um": 0.235,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0555",
+      "label": "0555 ARH-PVp Tbx3 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 28,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 5.3,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.876
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.64,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.546
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.111,
+        "region_fraction_100um": 0.372,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0554",
+      "label": "0554 ARH-PVp Tbx3 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_126",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 29,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 5.59,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.907
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.58,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.505
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.165,
+        "region_fraction_100um": 0.321,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0562",
+      "label": "0562 DMH-LHA Vgll2 Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_127",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 30,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.17,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.371
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.58,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.505
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.105,
+        "region_fraction_100um": 0.224,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0544",
+      "label": "0544 DMH Nkx2-4 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_123",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 31,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 5.8,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.948
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.65,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.557
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.065,
+        "region_fraction_100um": 0.127,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0552",
+      "label": "0552 DMH Hmx2 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_125",
+      "discovery_score": {
+        "score": 4,
+        "rank_in_cohort": 32,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 2.79,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.639
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 3.65,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.856
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.103,
+        "region_fraction_100um": 0.278,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0480",
+      "label": "0480 TU-ARH Otp Six6 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_104",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 33,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.68,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.935,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.536
+              }
+            ],
+            "coverage": 0.875
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.52,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.454
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.084,
+        "region_fraction_100um": 0.195,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0478",
+      "label": "0478 TU-ARH Otp Six6 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_104",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 34,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 1.2,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.926,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.567
+              }
+            ],
+            "coverage": 0.857
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.28,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.124
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.086,
+        "region_fraction_100um": 0.223,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0453",
+      "label": "0453 SBPV-PVa Six6 Satb2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_099",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 35,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.24,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.402
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.22,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.894,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.062
+              }
+            ],
+            "coverage": 0.8
+          }
+        ],
+        "region_fraction": 0.06,
+        "region_fraction_100um": 0.184,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0489",
+      "label": "0489 DMH Hmx2 Gaba_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 36,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.41,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.943,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.464
+              }
+            ],
+            "coverage": 0.889
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.46,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.943,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.392
+              }
+            ],
+            "coverage": 0.889
+          }
+        ],
+        "region_fraction": 0.031,
+        "region_fraction_100um": 0.114,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0610",
+      "label": "0610 PH Pitx2 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_138",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 37,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.13,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.866,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.289
+              }
+            ],
+            "coverage": 0.75
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.57,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.485
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.025,
+        "region_fraction_100um": 0.1,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0487",
+      "label": "0487 DMH Hmx2 Gaba_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 38,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.16,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.853,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.33
+              }
+            ],
+            "coverage": 0.727
+          },
+          {
+            "gene": "Tac1",
+            "val": 3.83,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.887
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.111,
+        "region_fraction_100um": 0.232,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0457",
+      "label": "0457 AHN Onecut3 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_100",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 39,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.11,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.775,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.268
+              }
+            ],
+            "coverage": 0.6
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.34,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.258
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.061,
+        "region_fraction_100um": 0.173,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0479",
+      "label": "0479 TU-ARH Otp Six6 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_104",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 40,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.54,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.816,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.515
+              }
+            ],
+            "coverage": 0.667
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.34,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.943,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.258
+              }
+            ],
+            "coverage": 0.889
+          }
+        ],
+        "region_fraction": 0.076,
+        "region_fraction_100um": 0.336,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0490",
+      "label": "0490 DMH Hmx2 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 41,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.48,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.816,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.505
+              }
+            ],
+            "coverage": 0.667
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.77,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.913,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.598
+              }
+            ],
+            "coverage": 0.833
+          }
+        ],
+        "region_fraction": 0.052,
+        "region_fraction_100um": 0.111,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0561",
+      "label": "0561 DMH-LHA Vgll2 Glut_3",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_127",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 42,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.16,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.707,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.33
+              }
+            ],
+            "coverage": 0.5
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.3,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.144
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.05,
+        "region_fraction_100um": 0.178,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0488",
+      "label": "0488 DMH Hmx2 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_107",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 43,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.17,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.667,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.371
+              }
+            ],
+            "coverage": 0.444
+          },
+          {
+            "gene": "Tac1",
+            "val": 1.57,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 0.943,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.691
+              }
+            ],
+            "coverage": 0.889
+          }
+        ],
+        "region_fraction": 0.09,
+        "region_fraction_100um": 0.232,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_1173",
+      "label": "1173 Tanycyte NN_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_322",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 44,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 2.97,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.66
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.27,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.113
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.001,
+        "region_fraction_100um": 0.093,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0494",
+      "label": "0494 ARH-PVp Tbx3 Gaba_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_108",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 45,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 4.13,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.784
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.3,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.144
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.021,
+        "region_fraction_100um": 0.082,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0477",
+      "label": "0477 PVHd-DMH Lhx6 Gaba_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_103",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 46,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 2.45,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.629
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.47,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.402
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.048,
+        "region_fraction_100um": 0.087,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0608",
+      "label": "0608 PH-an Pitx2 Glut_1",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_137",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 47,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 3.95,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.773
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.24,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.072
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.019,
+        "region_fraction_100um": 0.058,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0560",
+      "label": "0560 DMH-LHA Vgll2 Glut_2",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_127",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 48,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 0.12,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.278
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.53,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.474
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.006,
+        "region_fraction_100um": 0.027,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0595",
+      "label": "0595 PH-ant-LHA Otp Bsx Glut_5",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_134",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 49,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 3.44,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.722
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 1.74,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.701
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.007,
+        "region_fraction_100um": 0.05,
+        "region_evidence": "SELF"
+      }
+    },
+    {
+      "node_id": "CS20230722_SUPT_0594",
+      "label": "0594 PH-ant-LHA Otp Bsx Glut_4",
+      "taxonomy_level": "supertype",
+      "taxonomy_rank": 1,
+      "nt_type": null,
+      "parent_id": "CS20230722_SUBC_134",
+      "discovery_score": {
+        "score": 3,
+        "rank_in_cohort": 50,
+        "cohort_size": 50,
+        "next_best_score": 7,
+        "rank": 1,
+        "contexts": [
+          {
+            "id": "cohort",
+            "kind": "SURVIVAL_COHORT",
+            "rank": 1,
+            "n_members": 50,
+            "filters": [
+              "region=MBA:693"
+            ]
+          }
+        ],
+        "expression_detail": [
+          {
+            "gene": "Nkx2-1",
+            "val": 3.29,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.68
+              }
+            ],
+            "coverage": 1.0
+          },
+          {
+            "gene": "Tac1",
+            "val": 0.32,
+            "reliable": true,
+            "raw_tier": 1,
+            "applied_score": 1.0,
+            "source": "EXPRESSION",
+            "percentiles": [
+              {
+                "context_id": "cohort",
+                "pct": 0.216
+              }
+            ],
+            "coverage": 1.0
+          }
+        ],
+        "region_fraction": 0.045,
+        "region_fraction_100um": 0.076,
+        "region_evidence": "SELF"
+      }
+    }
+  ]
+}

--- a/research/sexually_dimorphic/refresh_20260608_vmhvl_esr1_pr_neuron/prior_summary_preserved.md
+++ b/research/sexually_dimorphic/refresh_20260608_vmhvl_esr1_pr_neuron/prior_summary_preserved.md
@@ -1,0 +1,326 @@
+# VMHvl estrogen-receptor alpha / progesterone receptor neuron — WMBv1 Mapping Report
+*draft · 2026-04-25 · Source: `/Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml`*
+
+**⚠ Draft mappings. Evidence is atlas-metadata only unless otherwise noted. All edges require expert review before use.**
+
+---
+
+## Introduction
+
+The VMHvl estrogen-receptor alpha / progesterone receptor neuron is a molecularly
+heterogeneous, predominantly glutamatergic population of the ventrolateral subdivision
+of the ventromedial hypothalamus, defined by neurochemical criteria including ERα
+(Esr1), progesterone receptor (Pgr), Nkx2-1, and Tac1 [1], [2]. Distinct functional
+subpopulations have been described: a Pgr+ subset required for mating in both sexes
+and for male fighting [2]; an ERα+/Nkx2-1+/Tac1+ subset that drives female-specific
+locomotion [1]; and additional ERα-expressing subtypes with separate projection
+targets and sex-related roles. Single-nucleus RNA-seq has identified 17 transcriptomic
+types within this anatomical population, and the classical node is explicitly flagged
+as heterogeneous and a candidate for splitting into multiple sub-nodes in future
+iterations. Mapping this composite classical type to WMBv1 is therefore expected
+to produce a small set of co-primary supertype targets rather than a single best
+match, and the report should be read with that ambiguity in mind.
+
+### Classical type table
+
+| Property | Value | References |
+|---|---|---|
+| Soma location | Ventromedial hypothalamic nucleus [MBA:693] (ventrolateral subdivision, VMHvl) | [1] |
+| Defining markers | Esr1, Nkx2-1, Tac1 (transcript) [1]; Pgr (transcript) [2] | [1], [2] |
+| Neuropeptides | Tac1 | [1] |
+| CL term | — (none assigned; candidate for new term) | |
+
+<details>
+<summary>Details — source evidence for classical type properties</summary>
+
+- **Soma location / Esr1 / Nkx2-1 / Tac1:** primary literature, mouse, VMHvl-targeted Cre and pharmacogenetic dissection · [1]
+
+  > Estrogen-receptor alpha (ERα) neurons in the ventrolateral region of the ventromedial hypothalamus (VMHVL) control an array of sex-specific responses to maximize reproductive success. In females, these VMHVL neurons are believed to coordinate metabolism and reproduction. However, it remains unknown whether specific neuronal populations control distinct components of this physiological repertoire. Here, we identify a subset of ERα VMHVL neurons that promotes hormone-dependent female locomotion. Activating Nkx2-1-expressing VMHVL neurons via pharmacogenetics elicits a female-specific burst of spontaneous movement, which requires ERα and Tac1 signaling. Disrupting the development of Nkx2-1(+) VMHVL neurons results in female-specific obesity, inactivity, and loss of VMHVL neurons coexpressing ERα and Tac1. Unexpectedly, two responses controlled by ERα(+) neurons, fertility and brown adipose tissue thermogenesis, are unaffected. We conclude that a dedicated subset of VMHVL neurons marked by ERα, NKX2-1, and Tac1 regulates estrogen-dependent fluctuations in physical activity and constitutes one of several neuroendocrine modules that drive sex-specific responses.
+  > — Correa et al. 2015, Developmental and Hormonal Regulation · [1] <!-- quote_key: 27794167_af52b501 -->
+
+- **Pgr marker:** review-level summary, mouse VMHvl, sex-typical behaviour context · [2]
+
+  > Another molecularly defined sexually dimorphic VMHvl subpopulation that controls sex-typical behaviors in both sexes is the progesterone receptor (PR)-expressing neurons. This subpopulation is required for the normal display of mating in both sexes and for fighting in males [76].
+  > — Zilkha et al. 2021, Sexually Dimorphic Brain Regions and Structures · [2] <!-- quote_key: 233446934_8cb6b0bc -->
+
+</details>
+
+---
+
+## Results
+
+Two co-primary mapping edges were assessed; both reach 🟡 MODERATE confidence as
+CROSS_CUTTING targets — SUPT_0564 (VMH Fezf1 Glut_2), supported by atlas metadata
+matching VMH location and Pgr/Nkx2-1 expression, and SUPT_0563 (VMH Fezf1 Glut_1),
+added on the basis of an Esr1+ TRAP-seq bulk-correlation contrast (Knoedler 2022
+[3]) that places three SUPT_0563 child clusters in the top four atlas-wide hits
+for the VMH female-receptive vs BNST female-receptive δ.
+
+### Mapping candidates
+
+**Candidate overview.**
+
+| Rank | WMBv1 cluster | Supertype | Cells (10x) | Confidence | Key property alignment | Verdict |
+|---|---|---|---|---|---|---|
+| 1 | 0564 VMH Fezf1 Glut_2 [CS20230722_SUPT_0564] | (self) | 621 | 🟡 MODERATE | VMH location CONSISTENT; Nkx2-1 CONSISTENT; Pgr APPROXIMATE | Best candidate (broader Pgr/Nkx2-1/Tac1 subpop.) |
+| 1 | 0563 VMH Fezf1 Glut_1 [CS20230722_SUPT_0563] | (self) | 153 | 🟡 MODERATE | VMH location CONSISTENT; female-biased child clusters CONSISTENT (Knoedler 2022 δ ranks 1, 2, 4) | Best candidate (female-biased lordosis subpop.) |
+2 edges total. Relationship type: CROSS_CUTTING (both edges; the heterogeneous classical
+node is split across both supertypes).
+
+^MERFISH cell count not separately recorded for SUPT_0563 in this facts file; child
+clusters CLUS_2290, CLUS_2292, CLUS_2293 all have primary anatomy = Ventromedial
+hypothalamic nucleus.
+
+### 0564 VMH Fezf1 Glut_2 [CS20230722_SUPT_0564] · 🟡 MODERATE
+
+**Property alignment — Table 1.**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Ventromedial hypothalamic nucleus [MBA:693] (VMHvl) | MBA:693 (VMH) n=360, dominant location | not assessed | CONSISTENT |
+| NT type | not stated; VMHvl predominantly glutamatergic | Glutamatergic (VMH Fezf1 Glut label) | not assessed | CONSISTENT |
+| Nkx2-1 expression | POSITIVE (defining marker) | precomputed mean = 5.34 | not assessed | CONSISTENT |
+| Pgr expression | POSITIVE (defining marker) | precomputed mean = 4.54 | not assessed | APPROXIMATE |
+| Esr1 expression | POSITIVE (defining marker) | precomputed mean = 2.35 | not assessed | APPROXIMATE |
+| Tac1 expression | POSITIVE (defining marker, neuropeptide) | precomputed mean = 1.39 | not assessed | APPROXIMATE |
+| Sex ratio | female-biased lordosis subpopulation expected (subset only) | not available | not available at supertype level | NOT_ASSESSED |
+
+**Evidence support — Table 2.**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| SUPT_0564 atlas metadata (VMH n=360; Nkx2-1, Pgr, Esr1, Tac1) | Atlas metadata | PARTIAL | MBA:693 n=360; Nkx2-1=5.34, Pgr=4.54, Esr1=2.35, Tac1=1.39 | atlas-internal |
+| Knoedler 2022 TRAP-seq VMH_FR vs BNST_FR (target SUPT_0564) | Bulk transcriptomic correlation | PARTIAL | SUPT_0564 not in top 20 by δ; companion SUPT_0563 takes ranks 1, 2, 4 | [3] |
+
+*(Child-cluster breakdown not assessed — see proposed experiments. Three of the top four atlas-wide hits in the Knoedler 2022 VMH_FR vs BNST_FR contrast belong to the companion supertype SUPT_0563 rather than to SUPT_0564 itself.)*
+
+#### Supporting evidence
+
+- **VMH location is the dominant atlas anatomy for SUPT_0564.** MBA:693 (Ventromedial hypothalamic nucleus) is recorded as the primary location with n=360 cells, directly matching the classical soma annotation [1].
+- **Nkx2-1 is strongly expressed at supertype level** (precomputed mean = 5.34), consistent with the Nkx2-1+ defining role established in [1].
+- **Pgr is moderately expressed** (mean = 4.54), partly supporting the Pgr+ subpopulation reported in [2]; subset expression is consistent with the heterogeneity of the classical type.
+- **Glutamatergic NT identity** matches the VMH Fezf1 Glut label (CONSISTENT alignment).
+- **Independent quantitative cross-check from bulk-correlation [3].** SUPT_0564 itself does not appear in the top 20 by δ in the VMH_FR vs BNST_FR contrast; instead three of the top four hits belong to the companion supertype SUPT_0563. This supports a CROSS_CUTTING split of the classical type across the two supertypes rather than a single SUPT_0564 mapping:
+
+  > Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq pooled VMH female-receptive vs BNST female-receptive. SUPT_0564 itself does not appear in the top 20 by δ — instead, SUPT_0563 takes 3 of the top 4 (CLUS_2293, 2290, 2292). This is independent quantitative support for the open question already raised on this edge: SUPT_0563 should be added as a co-primary CROSS_CUTTING target. SUPT_0564 retains its existing ATLAS_METADATA support but should not be the sole mapping target.
+  > — Knoedler et al. 2022 · [3]
+
+  ![Top 10 clusters by δ for VMH_FR_vs_BNST_FR (CS20230722_SUPT_0564)](figures/vmhvl_esr1_pr_neuron_VMH_FR_vs_BNST_FR_a31e6284.png)
+
+#### Marker evidence provenance
+
+- **Esr1** (mean = 2.35, APPROXIMATE) — moderate atlas expression. Esr1 marks a defining subset, not the full SUPT_0564 supertype; the dilution is expected for a heterogeneous supertype. *(note: Esr1+ neurons span multiple VMH supertypes — the moderate atlas mean is consistent with Esr1 being a subset marker of SUPT_0564, not a defining feature of every cell.)*
+- **Tac1** (mean = 1.39, APPROXIMATE) — low atlas expression; consistent with the small Esr1+/Nkx2-1+/Tac1+ subset described in [1]. Tac1 is also listed as a neuropeptide on the classical node, sourced from the same primary study [1]; the low supertype mean does not refute the existence of a Tac1+ subset but does indicate that Tac1+ cells are a minority within SUPT_0564.
+- **Pgr** (mean = 4.54, APPROXIMATE) — moderate atlas expression. Classical evidence is review-level [2]; primary literature on PR+ VMHvl neurons exists but is not directly cited on the node, which is a weak-evidence flag for this marker.
+- **Nkx2-1** (mean = 5.34, CONSISTENT) — the strongest marker alignment for this edge. Atlas evidence is transcript-based; classical evidence [1] also relies on Nkx2-1 transgenic targeting at protein level, so the data sources are complementary and concordant.
+
+#### Concerns
+
+- **Heterogeneity / ambiguous mapping.** VMHvl contains 17 transcriptomic types (Kim 2019 — referenced in classical node notes; not in `reference_index`). The classical node spans multiple functional subpopulations and a single SUPT_0564 mapping is incomplete; SUPT_0563 should be retained as a co-primary target (see below).
+- **Calb1 is the highest-expressed gene in SUPT_0564 (mean = 8.0), but is not a defining marker** of vmhvl_esr1_pr_neuron. Calb1 is a canonical marker of the distinct SDN-POA calbindin neuron — high Calb1 in SUPT_0564 warrants primary literature verification to confirm that SUPT_0564 represents the ERα/PR VMHvl population rather than a Calb1+ subtype.
+- **Esr1 / Tac1 atlas means are below the threshold** for these to be DEFINING atlas markers of SUPT_0564, even though they are defining features of the classical type. This is consistent with subset expression but limits the strength of supertype-level support.
+- **No direct child-cluster assessment was performed for SUPT_0564** in the current edge YAML — the Knoedler 2022 δ ranking covers all atlas clusters but no SUPT_0564 child cluster is in the top 20.
+
+#### What would upgrade confidence
+
+- Cluster-level Esr1, Pgr, Nkx2-1, Tac1 co-expression analysis across SUPT_0564 child clusters; expected output: refined `property_comparisons` and possibly a child-cluster MODERATE/HIGH edge to a specific Pgr+ cluster.
+- Targeted literature search for primary studies on VMHvl PR+ neurons (the Pgr citation [2] is review-level); expected output: replace [2] with a primary citation supporting Pgr as a defining marker.
+- MapMyCells annotation transfer of an external VMHvl PR-Cre or ERα-Cre scRNA-seq dataset against WMBv1 at F1 ≥ 0.50 (SUPT_0564) or F1 ≥ 0.80 (cluster-level); expected output: `AnnotationTransferEvidence` distinguishing the SUPT_0563 vs SUPT_0564 split.
+
+### 0563 VMH Fezf1 Glut_1 [CS20230722_SUPT_0563] · 🟡 MODERATE
+
+**Property alignment — Table 1.**
+
+| Property | Classical | Supertype | Best cluster | Alignment |
+|---|---|---|---|---|
+| Soma location | Ventromedial hypothalamic nucleus [MBA:693] (VMHvl) | MBA:693 (VMH) primary location across child clusters | CLUS_2290, CLUS_2292, CLUS_2293 — all primary anat = VMH | CONSISTENT |
+| NT type | not stated; VMHvl predominantly glutamatergic | Glutamatergic (VMH Fezf1 Glut label) | Glutamatergic | CONSISTENT |
+| Sex ratio | female-biased lordosis subpopulation expected | not available at supertype level | MFR=0.08 (CLUS_2290), MFR=0.12 (CLUS_2292) — both strongly female-biased | CONSISTENT |
+
+**Evidence support — Table 2.**
+
+| Evidence | Type | Supports | Headline | Source |
+|---|---|---|---|---|
+| Knoedler 2022 TRAP-seq VMH_FR vs BNST_FR (target SUPT_0563) | Bulk transcriptomic correlation | SUPPORT | best child CLUS_2293 rank 1/5322, δ=0.0180; CLUS_2290 rank 2 (MFR=0.08); CLUS_2292 rank 4 (MFR=0.12); 3 of top 20 are SUPT_0563 children | [3] |
+
+*(3 of the top-20 child-cluster hits in the Knoedler 2022 VMH_FR vs BNST_FR contrast — CLUS_2290, CLUS_2292, CLUS_2293 — belong to SUPT_0563; CLUS_2290 and CLUS_2292 also carry the strongest female bias in the contrast (MFR=0.08, 0.12). Best match: CLUS_2293 (rank 1 of 5322).)*
+
+#### Supporting evidence
+
+- **Atlas-wide top-rank hit on a VMHvl-relevant bulk-correlation contrast [3].** SUPT_0563 child clusters take three of the top four positions by δ = ρ(VMH_FR) − ρ(BNST_FR), with CLUS_2293 ranked 1/5322 (δ=0.0180):
+
+  > Knoedler 2022 (PMID:35143761) Esr1+ TRAP-seq pooled VMH female-receptive vs BNST female-receptive. SUPT_0563 takes three of the top four child-cluster positions by δ = ρ(VMH_FR) − ρ(BNST_FR): CLUS_2293 (rank 1, δ=0.0180), CLUS_2290 (rank 2, δ=0.0159, MFR=0.08), CLUS_2292 (rank 4, δ=0.0145, MFR=0.12). The female-biased CLUS_2290 and CLUS_2292 directly correspond to the lordosis-circuit subpopulation flagged in vmhvl_esr1_pr_neuron's classical definition. SUPT_0563 was missed by the rank-1 DB query (no DEFINING_SCOPED markers in atlas metadata for this supertype) and is added here as a co-primary CROSS_CUTTING target alongside SUPT_0564 based on the bulk-correlation evidence.
+  > — Knoedler et al. 2022 · [3]
+
+  ![Top 10 clusters by δ for VMH_FR_vs_BNST_FR (CS20230722_SUPT_0563)](figures/vmhvl_esr1_pr_neuron_VMH_FR_vs_BNST_FR_3701016a.png)
+
+- **VMH soma location** is the primary anatomical annotation across all three top SUPT_0563 child clusters (CLUS_2290, CLUS_2292, CLUS_2293; all primary anat = Ventromedial hypothalamic nucleus), CONSISTENT with the MBA:693 classical soma location [1].
+- **Glutamatergic NT type** is concordant (VMH Fezf1 Glut label, CONSISTENT).
+- **Sex ratio in the top child clusters is strongly female-biased** — CLUS_2290 MFR=0.08 and CLUS_2292 MFR=0.12 — directly matching the female-biased lordosis subpopulation flagged in the classical node's definition [1]. (Sex ratio is NULL at supertype level; the signal lives entirely in the female-biased child clusters that the bulk correlation also surfaces.)
+
+#### Marker evidence provenance
+
+- **No defining-marker atlas annotations** are recorded for SUPT_0563 in the current edge YAML — the supertype was missed by the rank-1 DB query because it carries no DEFINING_SCOPED markers in atlas metadata. Per-marker precomputed expression values for Esr1/Pgr/Nkx2-1/Tac1 at SUPT_0563 child clusters are not in `property_comparisons` and so cannot be assessed here. This is the primary gap in the SUPT_0563 evidence base; the bulk-correlation evidence anchors the mapping but cannot replace per-marker confirmation at cluster level.
+- **Sex ratio is the strongest cluster-level marker** for SUPT_0563 — CLUS_2290 (MFR=0.08) and CLUS_2292 (MFR=0.12) are both strongly female-biased, consistent with the lordosis-circuit subpopulation [1].
+
+#### Concerns
+
+- **Co-primary / ambiguous mapping with SUPT_0564.** The classical type is heterogeneous; SUPT_0563 captures the female-biased lordosis subpopulation, SUPT_0564 captures the broader Pgr+/Nkx2-1+/Tac1+ population. Both edges should be retained until the classical node is split or finer-grained data resolves the boundary.
+- **Marker-level atlas confirmation is missing.** Esr1, Pgr, Nkx2-1, Tac1 precomputed values for SUPT_0563 child clusters were not assessed in the current edge YAML; the mapping rests on bulk-correlation rank + sex bias + soma anatomy without independent single-cell marker support.
+- **Classical sex ratio at supertype level is NULL.** The sex-bias signal is concentrated in two of several SUPT_0563 child clusters (CLUS_2290, CLUS_2292) — consistent with a subset-of-supertype interpretation, but caveat that not all SUPT_0563 cells are female-biased.
+
+#### What would upgrade confidence
+
+- Cluster-level Esr1, Pgr, Nkx2-1, Tac1 co-expression in CLUS_2290, CLUS_2292, CLUS_2293 vs the female-biased clusters of SUPT_0564 — distinguishes the two SUPT mappings; expected output: refined `property_comparisons` and per-cluster MODERATE/HIGH edges.
+- MapMyCells annotation transfer of published VMHvl ERα-Cre or PR-Cre scRNA-seq data to WMBv1 at F1 ≥ 0.50 (supertype) / F1 ≥ 0.80 (cluster); expected output: `AnnotationTransferEvidence` quantifying the SUPT_0563 vs SUPT_0564 split.
+
+---
+
+### Methods
+
+<details>
+<summary>Data sources, analyses, and reproducibility receipts</summary>
+
+**Classical type definition.** vmhvl_esr1_pr_neuron is defined on a CLASSICAL_NEUROCHEMICAL
+basis: defining markers Esr1, Nkx2-1, Tac1 (transcript) [1] and Pgr (transcript) [2];
+neuropeptide Tac1 [1]; soma location Ventromedial hypothalamic nucleus [MBA:693] (ventrolateral
+subdivision) [1]. NT type is not directly stated on the classical node but VMHvl neurons
+are predominantly glutamatergic. The classical node is explicitly heterogeneous — 17
+transcriptomic types reported by snRNA-seq within the same anatomical population — and is
+flagged as a candidate for splitting into multiple sub-nodes in future iterations. No CL
+term is currently assigned.
+
+**Atlas mapping query.** Candidate atlas clusters were retrieved from the WMBv1
+taxonomy (CCN20230722) at ranks 0 (cluster) and 1 (supertype) using metadata-based
+scoring (region match, NT type, defining markers, sex bias when applicable). Full
+scoring rules: `workflows/map-cell-type.md`.
+
+**Property alignment.** Each defining property of the classical type was compared to
+the corresponding atlas-side value via the `property_comparisons` schema, with
+alignments graded CONSISTENT / APPROXIMATE / DISCORDANT / NOT_ASSESSED. Atlas-side
+numerical values came from precomputed expression on the cluster (cluster.yaml in
+the taxonomy reference store) and from MERFISH spatial registration for soma
+location.
+
+**Bulk transcriptomic correlation.**
+
+| Field | Value |
+|---|---|
+| Source publication | Knoedler et al. 2022 · PMID:35143761 · [3] |
+| GEO accession | GSE183092 |
+| Technique | TRAP-seq |
+| n pools | 12 |
+| Atlas | CCN20230722 (SHA-256: b21ca985) |
+| Statistic | spearman_rho |
+| Parameters | pseudobulk_transform=log1p(sum/n_cells); pool_transform=log1p(replicate_mean(DESeq2_normalised_counts)); gene_id_space=ensembl_mouse_via_symbol_lookup (conf/gene_mapping_CCN20230722.tsv); gene_intersection=intersection_across_4_regions∩atlas_col_names; n_replicates_per_pool=3. |
+| Script | [correlate.py](https://github.com/Cellular-Semantics/evidencell/blob/4e67d6b/kb/correlation_runs/corr_run_20260428_knoedler_esr1_wmbv1/correlate.py) |
+| Code version | 4e67d6b |
+| Caveats | Cross-sex within-region δ contrasts (Male vs FR or Male vs FNR) are artefactual: across all three regions tested (POA, VMH, BNST) the top hits are hindbrain Calcb cholinergic motor neurons — a global male-vs-female expression bias that swamps region-specific signals. Methodological rule: paired-bulk δ requires the two pools to differ in cell population (region/marker/state) holding sex constant; cross-sex δ within a single population is not a valid use of this method. TRAP-seq vs scRNA-seq pseudobulk: polysome-bound mRNA shifts absolute ρ values lower than for FACS-bulk inputs (Stephens-style), but Spearman rank-based statistics handle the magnitude offset; δ rankings are comparable across the two run types. |
+
+**Atlas data sources.**
+- WMBv1 · taxonomy_id CCN20230722 · pseudobulk source `conf/mapmycells/CCN20230722/precomputed_stats.h5` · SHA-256 `b21ca985652fb25f9608f99005139a40757133a76fbe845ae5b175c5c26a447b`.
+
+**Anti-hallucination.** All citations, atlas accessions, ontology CURIEs, and verbatim
+literature quotes in this report are validated against the evidencell knowledge base
+at write time. Authored-prose evidence narratives are validated against their source
+`evidence_items[*].explanation` fields. The pre-write hook rejects any unresolvable
+identifier or unattributed blockquote. Specific mapping limitations and caveats are
+documented per-candidate in the Discussion section.
+
+**Evidence base.**
+
+| Edge ID | Evidence types | Supports | Source |
+|---|---|---|---|
+| edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564 | ATLAS_METADATA; BULK_CORRELATION | PARTIAL; PARTIAL | atlas-internal; [3] |
+| edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563 | BULK_CORRELATION | SUPPORT | [3] |
+
+*Generated by evidencell `860919b` at 2026-04-30T09:04:16+00:00 from [/Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml](/Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/draft/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml).*
+
+</details>
+
+---
+
+## Discussion
+
+**Primary mapping:** vmhvl_esr1_pr_neuron is mapped as two co-primary CROSS_CUTTING
+edges, both at 🟡 MODERATE confidence: 0564 VMH Fezf1 Glut_2 [CS20230722_SUPT_0564]
+(supported by ATLAS_METADATA — VMH location n=360, Nkx2-1 = 5.34, Pgr = 4.54) and
+0563 VMH Fezf1 Glut_1 [CS20230722_SUPT_0563] (supported by BulkCorrelationEvidence
+from Knoedler 2022 [3] — three child clusters in the top four atlas-wide hits, two
+of which carry strong female bias). Key caveats: AMBIGUOUS_MAPPING (the heterogeneous
+classical type splits across the two supertypes); MARKER_NOT_SPECIFIC (Calb1 is the
+top-expressed gene in SUPT_0564 but is not a defining marker, requiring primary
+literature verification).
+
+No Cell Ontology term currently assigned. This classical node is a candidate for
+contribution of one or more new CL terms — the population is heterogeneous with
+17 reported transcriptomic types and may need to be split into multiple sub-nodes
+before a single CL term can be assigned cleanly.
+
+### Proposed experiments and follow-ups
+
+#### 1. Cluster-level co-expression of Esr1, Pgr, Nkx2-1, Tac1 across SUPT_0563 and SUPT_0564 child clusters
+
+**What:** Pull precomputed expression for Esr1, Pgr, Nkx2-1, Tac1 across all child
+clusters of SUPT_0563 (CLUS_2290, 2291, 2292, 2293) and SUPT_0564, with particular
+attention to the Knoedler-2022 top hits (CLUS_2290, 2292, 2293) and to the female-biased
+clusters by MFR.
+
+**Target:** Distinguish a Pgr+/Nkx2-1+/Tac1+ subset from a female-biased Esr1+ subset
+across the two supertypes; identify which child clusters anchor each functional split.
+
+**Expected output:** Refined `property_comparisons` for both edges; potentially
+new MODERATE/HIGH cluster-level edges (e.g. to CLUS_2290, 2292, or 2293).
+
+**Resolves:** Open questions 1 and 2 (SUPT_0563 vs SUPT_0564 split; CLUS_2290 vs
+CLUS_2292 distinct subtypes vs replicates); the Calb1 caveat on SUPT_0564.
+
+#### 2. MapMyCells annotation transfer of external VMHvl ERα/PR scRNA-seq
+
+**What:** Run MapMyCells against WMBv1 using a published VMHvl ERα-Cre or PR-Cre
+sorted scRNA-seq dataset (e.g. Kim 2019 or comparable VMHvl-targeted snRNA-seq).
+
+**Target:** F1 ≥ 0.50 at supertype; F1 ≥ 0.80 at cluster level; expect F1 to split
+between SUPT_0563 (female-biased) and SUPT_0564 (broader Pgr+/Nkx2-1+).
+
+**Expected output:** `AnnotationTransferEvidence` entries on both edges,
+quantifying the proportion of cells assigned to each supertype.
+
+**Resolves:** Open question 1 (SUPT_0563 vs SUPT_0564 clean split or further
+heterogeneity); the missing per-marker confirmation on SUPT_0563.
+
+#### 3. Targeted literature search for primary VMHvl PR+ marker evidence
+
+**What:** Cite-traverse from [2] (review-level Pgr citation) to primary studies
+on Pgr expression and function in VMHvl neurons.
+
+**Target:** Replace the review-level [2] with a primary citation; resolve whether
+Pgr+ VMHvl neurons preferentially correspond to SUPT_0563 or SUPT_0564.
+
+**Expected output:** Updated `defining_markers[*].refs` on the classical node;
+potentially a new LITERATURE evidence item on whichever edge gains primary support.
+
+**Resolves:** The marker-evidence-provenance flag on Pgr (currently sourced only
+from a review).
+
+### Open questions
+
+1. **(SUPT_0563 edge)** Is SUPT_0563 vs SUPT_0564 a clean female-vs-broader split,
+   or do both supertypes contain heterogeneous sub-populations that cross-cut the
+   classical definition?
+2. **(SUPT_0563 edge)** Are CLUS_2290 and CLUS_2292 distinct functional subtypes
+   within SUPT_0563, or replicates of the same lordosis subpopulation?
+3. **(SUPT_0564 edge)** Does Calb1 (highest-expressed gene in SUPT_0564, mean = 8.0)
+   co-localise with Esr1/Pgr in VMHvl neurons, or does it mark a distinct
+   subpopulation within SUPT_0564 — potentially the SDN-POA calbindin neuron
+   contaminant?
+
+---
+
+## References
+
+| # | Citation | PMID | Used for |
+|---|---|---|---|
+| [1] | Correa et al. 2015 | [PMID:25543145](https://pubmed.ncbi.nlm.nih.gov/25543145/) | Soma location (VMHvl); Esr1, Nkx2-1, Tac1 markers; Tac1 neuropeptide |
+| [2] | Zilkha et al. 2021 | [PMID:33910083](https://pubmed.ncbi.nlm.nih.gov/33910083/) | Pgr marker (review-level) |
+| [3] | Knoedler et al. 2022 | [PMID:35143761](https://pubmed.ncbi.nlm.nih.gov/35143761/) | Esr1+ TRAP-seq pooled VMH female-receptive vs BNST female-receptive bulk-correlation contrast against WMBv1 |

--- a/research/sexually_dimorphic/refresh_20260608_vmhvl_esr1_pr_neuron/refresh_summary.json
+++ b/research/sexually_dimorphic/refresh_20260608_vmhvl_esr1_pr_neuron/refresh_summary.json
@@ -1,0 +1,135 @@
+{
+  "graph": "kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml",
+  "node_id": "vmhvl_esr1_pr_neuron",
+  "taxonomy_id": "CCN20230722",
+  "ranks": {
+    "rank0": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_CLUS_2290",
+          "CS20230722_CLUS_2292",
+          "CS20230722_CLUS_1959",
+          "CS20230722_CLUS_2295",
+          "CS20230722_CLUS_2297"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml vmhvl_esr1_pr_neuron CCN20230722 0 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_vmhvl_esr1_pr_neuron/discovery_candidates_rank0.json",
+          "  emit-stage-b: wrote 5 edge(s) + 5 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 5,
+        "edges_skipped_taxtype_not_in_topk": 2,
+        "skipped_details": [
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564",
+            "taxonomy_type": "CS20230722_SUPT_0564"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563",
+            "taxonomy_type": "CS20230722_SUPT_0563"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2290",
+            "taxonomy_type": "CS20230722_CLUS_2290"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2292",
+            "taxonomy_type": "CS20230722_CLUS_2292"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_1959",
+            "taxonomy_type": "CS20230722_CLUS_1959"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2295",
+            "taxonomy_type": "CS20230722_CLUS_2295"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2297",
+            "taxonomy_type": "CS20230722_CLUS_2297"
+          }
+        ]
+      }
+    },
+    "rank1": {
+      "stage_a": {
+        "n_candidates": 50,
+        "top5": [
+          "CS20230722_SUPT_0557",
+          "CS20230722_SUPT_0563",
+          "CS20230722_SUPT_0439",
+          "CS20230722_SUPT_0569",
+          "CS20230722_SUPT_0568"
+        ]
+      },
+      "emit_b": {
+        "last_lines": [
+          "uv run python -m evidencell.stage_b_emit /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml vmhvl_esr1_pr_neuron CCN20230722 1 5 --discovery-json /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/research/sexually_dimorphic/refresh_20260608_vmhvl_esr1_pr_neuron/discovery_candidates_rank1.json",
+          "  emit-stage-b: wrote 5 edge(s) + 4 stub node(s) to /Users/do12/Documents/GitHub/BICAN_agentic_framework_planning/evidencell/kb/graphs/sexually_dimorphic/20260425_sexually_dimorphic_report_ingest.yaml"
+        ]
+      },
+      "refresh_pc": {
+        "edges_refreshed": 7,
+        "edges_skipped_taxtype_not_in_topk": 5,
+        "skipped_details": [
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2290",
+            "taxonomy_type": "CS20230722_CLUS_2290"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2292",
+            "taxonomy_type": "CS20230722_CLUS_2292"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_1959",
+            "taxonomy_type": "CS20230722_CLUS_1959"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2295",
+            "taxonomy_type": "CS20230722_CLUS_2295"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_CLUS_2297",
+            "taxonomy_type": "CS20230722_CLUS_2297"
+          }
+        ],
+        "refreshed_details": [
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0564",
+            "taxonomy_type": "CS20230722_SUPT_0564"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_cs20230722_supt_0563",
+            "taxonomy_type": "CS20230722_SUPT_0563"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0557",
+            "taxonomy_type": "CS20230722_SUPT_0557"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0563",
+            "taxonomy_type": "CS20230722_SUPT_0563"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0439",
+            "taxonomy_type": "CS20230722_SUPT_0439"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0569",
+            "taxonomy_type": "CS20230722_SUPT_0569"
+          },
+          {
+            "edge_id": "edge_vmhvl_esr1_pr_neuron_to_CS20230722_SUPT_0568",
+            "taxonomy_type": "CS20230722_SUPT_0568"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Stage A + Stage B emit + refresh-property-comparisons at ranks 0 and 1 for all 9 curated classical nodes in `sexually_dimorphic`.
- Reports regenerated end-to-end via `workflows/gen-report.md` (synth + validation subagents + Step 4b verdict-block check + rationale-writeback).
- 104 verdict blocks written back to the graph YAML across 9 nodes.

## Stale-location audit

See [`research/sexually_dimorphic/refresh_20260608_stale_audit.md`](https://github.com/Cellular-Semantics/evidencell/blob/refresh_reports_20260608_sexually_dimorphic/research/sexually_dimorphic/refresh_20260608_stale_audit.md). Four edges fell outside current Stage A top-50 at the rank matching their target's level:

| Node | Stale edge | Rank |
|---|---|---|
| `avpv_kiss1_neuron` | `CS20230722_CLUS_1915` | 0 (canonical case from session 2026-06-07/08) |
| `mpoa_esr1_neuron` | `CS20230722_SUPT_0486` | 1 |
| `bnst_crf_neuron` | `CS20230722_SUPT_0358` | 1 |
| `arc_aromatase_neuron` | `CS20230722_SUPT_0486` | 1 |

All four are legacy curator picks whose `taxonomy_type` fell outside current proximity-aware scoring's top-50. Edges retained with caveats noting stale property_comparisons; reported in each affected node's `unresolved_questions` per #111.

## Driver

`research/_drivers/refresh_region.py` — reusable Stage A/B + refresh chain per region with rank-aware stale-audit filtering (skips false-positive rank-mismatch entries). Used here for sexually_dimorphic; will be reused for hippocampus next.

## Known follow-ups (out of scope for this PR)

- #111: score-specific-cluster mode for the four stale edges above.
- #112: taxonomy_id typo `CCN202307220` blocking 4 other regions (dg / cerebellum / BG / immature_neurons).

## Test plan

- [ ] Reviewer spot-checks the 4 stale-audit entries and decides whether to keep or remove each legacy edge.
- [ ] Reviewer spot-checks 1–2 report Markdown files for biological accuracy.
- [ ] Pre-edit hook + rationale-writeback structured checks passed for all 9 nodes (verified in this branch's commits).

Co-author: Claude Opus 4.7 (1M context)